### PR TITLE
Add .NET Framework reference assemblies

### DIFF
--- a/DataCore.Adapter.sln
+++ b/DataCore.Adapter.sln
@@ -75,6 +75,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{D6BE3C37
 		build\Dependencies.props = build\Dependencies.props
 		build\Get-Version.ps1 = build\Get-Version.ps1
 		build\increment-version.ps1 = build\increment-version.ps1
+		build\NetFX.targets = build\NetFX.targets
 		build\Set-TeamCityParameters.ps1 = build\Set-TeamCityParameters.ps1
 		build\tools.ps1 = build\tools.ps1
 		build\version.json = build\version.json

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -35,6 +35,9 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- .NET Framework targeting (required to allow compilation against .NET Framework in non-Windows environments). -->
+  <Import Project=".\build\NetFX.targets" />
+  
   <!-- Extension point to allow Continuous Integration systems to inject their own configuration. -->
   <Import Project="CI.targets" Condition="Exists('CI.targets')" />
 

--- a/build/NetFX.targets
+++ b/build/NetFX.targets
@@ -1,0 +1,11 @@
+<Project>
+
+  <!-- .NET Framework targeting (required to allow compilation against .NET Framework in non-Windows environments) -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Add reference to `Microsoft.NETFramework.ReferenceAssemblies` package for `net461` and `net48` targets, to allow compilation in non-Windows environments