### PR TITLE
Subscription topic wildcards

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 1,
-  "Minor": 0,
-  "Patch": 2,
-  "PreRelease": ""
+  "Minor": 1,
+  "Patch": 0,
+  "PreRelease": "alpha"
 }

--- a/src/DataCore.Adapter/Events/EventMessagePushWithTopics.cs
+++ b/src/DataCore.Adapter/Events/EventMessagePushWithTopics.cs
@@ -528,8 +528,10 @@ namespace DataCore.Adapter.Events {
         /// <para>
         ///   This method is used to determine if an event message will be pushed to a subscriber. 
         ///   The default behaviour is to return <see langword="true"/> if <paramref name="subscriptionTopic"/> 
-        ///   and <paramref name="eventMessageTopic"/> topic are equal using a case-insensitive 
-        ///   match.
+        ///   and <paramref name="eventMessageTopic"/> are equal using a case-insensitive match. 
+        ///   If an <see cref="EventMessagePushWithTopicsOptions.IsTopicMatch"/> delegate is 
+        ///   provided in the feature options, this delegate will be invoked if the default 
+        ///   check returns <see langword="false"/>.
         /// </para>
         /// 
         /// <para>
@@ -539,7 +541,15 @@ namespace DataCore.Adapter.Events {
         /// 
         /// </remarks>
         protected virtual bool IsTopicMatch(string subscriptionTopic, string? eventMessageTopic) {
-            return string.Equals(subscriptionTopic, eventMessageTopic, StringComparison.Ordinal);
+            if (string.Equals(subscriptionTopic, eventMessageTopic, StringComparison.Ordinal)) {
+                return true;
+            }
+
+            if (_options.IsTopicMatch != null) {
+                return _options.IsTopicMatch(subscriptionTopic, eventMessageTopic);
+            }
+
+            return false;
         }
 
 
@@ -735,6 +745,16 @@ namespace DataCore.Adapter.Events {
         /// to zero.
         /// </summary>
         public Action<IEnumerable<string>>? OnTopicSubscriptionsRemoved { get; set; }
+
+        /// <summary>
+        /// A delegate that is invoked to determine if the topic for a subscription matches the 
+        /// topic for a received event message.
+        /// </summary>
+        /// <remarks>
+        ///   The first parameter passed to the delegate is the subscription topic, and the second 
+        ///   parameter is the topic for the received event message.
+        /// </remarks>
+        public Func<string, string?, bool>? IsTopicMatch { get; set; }
 
     }
 

--- a/src/DataCore.Adapter/PatternMatchingExtensions.cs
+++ b/src/DataCore.Adapter/PatternMatchingExtensions.cs
@@ -97,9 +97,15 @@ namespace DataCore.Adapter {
             // * = 0+ characters (i.e. ".*" in regex-speak)
             // ? = 1 character (i.e. "." in regex-speak)
 
+#if NETSTANDARD
+            pattern = Regex.Escape(pattern)
+                .Replace(@"\*", ".*")
+                .Replace(@"\?", ".");
+#else
             pattern = Regex.Escape(pattern)
                 .Replace(@"\*", ".*", StringComparison.Ordinal)
                 .Replace(@"\?", ".", StringComparison.Ordinal);
+#endif
 
             return s.Like(new Regex(pattern, RegexOptions.IgnoreCase));
         }

--- a/src/DataCore.Adapter/PatternMatchingExtensions.cs
+++ b/src/DataCore.Adapter/PatternMatchingExtensions.cs
@@ -97,7 +97,9 @@ namespace DataCore.Adapter {
             // * = 0+ characters (i.e. ".*" in regex-speak)
             // ? = 1 character (i.e. "." in regex-speak)
 
-            pattern = Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".");
+            pattern = Regex.Escape(pattern)
+                .Replace(@"\*", ".*", StringComparison.Ordinal)
+                .Replace(@"\?", ".", StringComparison.Ordinal);
 
             return s.Like(new Regex(pattern, RegexOptions.IgnoreCase));
         }

--- a/test/DataCore.Adapter.Tests/SubscriptionTests.cs
+++ b/test/DataCore.Adapter.Tests/SubscriptionTests.cs
@@ -238,6 +238,63 @@ namespace DataCore.Adapter.Tests {
 
 
         [TestMethod]
+        public async Task SnapshotWildcardSubscriptionShouldEmitValues() {
+            var now = DateTime.UtcNow;
+
+            var options = new SnapshotTagValuePushOptions() {
+                AdapterId = TestContext.TestName,
+                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray()),
+                IsTopicMatch = (subscribed, received) => {
+                    // If we subscribe to "tag_root", we should receive messages with a topic of 
+                    // e.g. "tag_root/sub_tag".
+                    return received.Id.StartsWith(subscribed.Id + "/");
+                }
+            };
+
+            using (var feature = new SnapshotTagValuePush(options, null, null)) {
+                var subscription = await feature.Subscribe(
+                    ExampleCallContext.ForPrincipal(null),
+                    new CreateSnapshotTagValueSubscriptionRequest() {
+                        Tags = new[] { TestContext.TestName }
+                    },
+                    CancellationToken
+                );
+
+                // We should receive this value due to our IsTopicMatch delegate
+                var val1 = TagValueBuilder.Create().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
+                var tagId1 = TestContext.TestName + "/SubTag";
+                await feature.ValueReceived(TagValueQueryResult.Create(tagId1, tagId1, val1));
+
+                // We should not receive this value
+                var val2 = TagValueBuilder.Create().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
+                var tagId2 = "Should_Not_Match";
+                await feature.ValueReceived(TagValueQueryResult.Create(tagId2, tagId2, val2));
+
+                // We should receive this value because it is an exact match for the tag we subscribed to.
+                var val3 = TagValueBuilder.Create().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
+                var tagId3 = TestContext.TestName;
+                await feature.ValueReceived(TagValueQueryResult.Create(tagId3, tagId3, val3));
+
+                CancelAfter(TimeSpan.FromSeconds(1));
+
+                var emitted = await subscription.ReadAsync(CancellationToken);
+                Assert.IsNotNull(emitted);
+                Assert.AreEqual(tagId1, emitted.TagId);
+                Assert.AreEqual(tagId1, emitted.TagName);
+                Assert.AreEqual(val1.UtcSampleTime, emitted.Value.UtcSampleTime);
+                Assert.AreEqual(val1.UtcSampleTime.Ticks, emitted.Value.GetValueOrDefault<long>());
+
+                emitted = await subscription.ReadAsync(CancellationToken);
+                Assert.IsNotNull(emitted);
+                Assert.AreEqual(tagId3, emitted.TagId);
+                Assert.AreEqual(tagId3, emitted.TagName);
+                Assert.AreEqual(val3.UtcSampleTime, emitted.Value.UtcSampleTime);
+                Assert.AreEqual(val3.UtcSampleTime.Ticks, emitted.Value.GetValueOrDefault<long>());
+            }
+        }
+
+
+        [TestMethod]
         public async Task EventSubscriptionShouldEmitValues() {
             var now = DateTime.UtcNow;
 
@@ -450,6 +507,84 @@ namespace DataCore.Adapter.Tests {
                     }
                 }
                 catch (OperationCanceledException) { }
+            }
+        }
+
+
+        [TestMethod]
+        public async Task EventTopicWildcardSubscriptionShouldReceiveMessages() {
+            var now = DateTime.UtcNow;
+            var topicRoot = Guid.NewGuid().ToString();
+
+            var options = new EventMessagePushWithTopicsOptions() {
+                AdapterId = TestContext.TestName,
+                IsTopicMatch = (subscribed, received) => {
+                    // If we subscribe to "topic_root", we should receive messages with a topic of 
+                    // e.g. "topic_root/sub_topic".
+                    return received != null && received.StartsWith(subscribed);
+                }
+            };
+
+            using (var feature = new EventMessagePushWithTopics(options, null, null)) {
+                var subscription = await feature.Subscribe(
+                    ExampleCallContext.ForPrincipal(null),
+                    new CreateEventMessageTopicSubscriptionRequest() {
+                        Topics = new[] { topicRoot }
+                    },
+                    CancellationToken
+                );
+
+                // We should receive this message due to the IsTopicMatch delegate.
+                var msg1 = EventMessageBuilder
+                    .Create()
+                    .WithTopic(topicRoot + "/" + Guid.NewGuid().ToString())
+                    .WithUtcEventTime(now)
+                    .WithMessage(TestContext.TestName + "_1")
+                    .Build();
+
+                // We should not receive this message.
+                var msg2 = EventMessageBuilder
+                    .Create()
+                    .WithTopic(null)
+                    .WithUtcEventTime(now)
+                    .WithMessage(TestContext.TestName + "_2")
+                    .Build();
+
+                // We should receive this message since the topic exactly matches our subscription.
+                var msg3 = EventMessageBuilder
+                    .Create()
+                    .WithTopic(topicRoot)
+                    .WithUtcEventTime(now)
+                    .WithMessage(TestContext.TestName + "_3")
+                    .Build();
+
+                await feature.ValueReceived(msg1);
+                await feature.ValueReceived(msg2);
+                await feature.ValueReceived(msg3);
+
+                var messagesReceived = 0;
+
+                CancelAfter(TimeSpan.FromSeconds(1));
+
+                var emitted = await subscription.ReadAsync(CancellationToken);
+                Assert.IsNotNull(emitted);
+                Assert.AreEqual(msg1.Message, emitted.Message);
+                ++messagesReceived;
+
+                emitted = await subscription.ReadAsync(CancellationToken);
+                Assert.IsNotNull(emitted);
+                Assert.AreEqual(msg3.Message, emitted.Message);
+                ++messagesReceived;
+
+                try {
+                    emitted = await subscription.ReadAsync(CancellationToken);
+                    // Exception should be thrown before we get to here!
+                    ++messagesReceived;
+                }
+                catch (OperationCanceledException) { }
+                catch (ChannelClosedException) { }
+
+                Assert.AreEqual(2, messagesReceived);
             }
         }
 


### PR DESCRIPTION
Add hooks to allow snapshot tag value subscriptions implemented via the `SnapshotTagValuePush` class to support wildcards in subscription topics (e.g. to allow an MQTT adapter push a value received on a `some_root/some/child/topic` channel to a subscriber who subscribed to `some_root/#`).