### PR TITLE
Adapter type metadata

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AdapterAttribute.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterAttribute.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace DataCore.Adapter {
+
+    /// <summary>
+    /// <see cref="AdapterAttribute"/> is used to annotate concrete implementations of <see cref="IAdapter"/> 
+    /// to provide metadata about an adapter.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class AdapterAttribute : Attribute {
+
+        /// <summary>
+        /// The localised display name.
+        /// </summary>
+        private readonly LocalizableString _name = new LocalizableString(nameof(Name));
+
+        /// <summary>
+        /// The localised description.
+        /// </summary>
+        private readonly LocalizableString _description = new LocalizableString(nameof(Description));
+
+        /// <summary>
+        /// The resource type used to retrieved localised values for the display name and 
+        /// description.
+        /// </summary>
+        private Type? _resourceType;
+
+        /// <summary>
+        /// The feature URI. Well-known URIs are defined in <see cref="WellKnownFeatures"/>.
+        /// </summary>
+        public Uri Uri { get; }
+
+        /// <summary>
+        /// The type that contains the resources for the <see cref="Name"/> and <see cref="Description"/> properties.
+        /// </summary>
+        public Type? ResourceType {
+            get => _resourceType;
+            set {
+                if (_resourceType != value) {
+                    _resourceType = value;
+
+                    _name.ResourceType = value;
+                    _description.ResourceType = value;
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// The display name for the feature.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721:Property names should not match get methods", Justification = "Following convention used by DisplayAttribute")]
+        public string? Name {
+            get => _name.Value;
+            set => _name.Value = value;
+        }
+
+        /// <summary>
+        /// The description for the feature.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721:Property names should not match get methods", Justification = "Following convention used by DisplayAttribute")]
+        public string? Description {
+            get => _description.Value;
+            set => _description.Value = value;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="AdapterFeatureAttribute"/>.
+        /// </summary>
+        /// <param name="uriString">
+        ///   The absolute feature URI. Well-known URIs are defined in <see cref="WellKnownFeatures"/>. 
+        ///   Note that the URI assigned to the <see cref="Uri"/> property will always have a trailing 
+        ///   forwards slash (/) appended if required.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="uriString"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="uriString"/> is not a valid URI.
+        /// </exception>
+        public AdapterAttribute(string uriString) {
+            if (uriString == null) {
+                throw new ArgumentNullException(nameof(uriString));
+            }
+
+            if (!UriExtensions.TryCreateUriWithTrailingSlash(uriString, out var uri)) {
+                throw new ArgumentException(SharedResources.Error_InvalidUri, nameof(uriString));
+            }
+
+            Uri = uri!;
+        }
+
+
+        /// <summary>
+        /// Gets the display name for the adapter type. This can be either a literal string 
+        /// specified by the <see cref="Name"/> property, or a localised string found when 
+        /// <see cref="ResourceType"/> is specified and <see cref="Name"/> represents a resource 
+        /// key within the resource type.
+        /// </summary>
+        /// <returns>
+        ///   The display name for the adapter type.
+        /// </returns>
+        public string? GetName() => _name.GetLocalizableValue();
+
+
+        /// <summary>
+        /// Gets the description for the adapter type. This can be either a literal string 
+        /// specified by the <see cref="Description"/> property, or a localised string found when 
+        /// <see cref="ResourceType"/> is specified and <see cref="Description"/> represents a 
+        /// resource key within the resource type.
+        /// </summary>
+        /// <returns>
+        ///   The description for the adapter type.
+        /// </returns>
+        public string? GetDescription() => _description.GetLocalizableValue();
+
+    }
+}

--- a/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
@@ -510,6 +510,32 @@ namespace DataCore.Adapter {
 
 
         /// <summary>
+        /// Creates an <see cref="AdapterTypeDescriptor"/> for the <see cref="IAdapter"/>.
+        /// </summary>
+        /// <returns>
+        ///   The <see cref="AdapterTypeDescriptor"/> for the adapter.
+        /// </returns>
+        public static AdapterTypeDescriptor CreateTypeDescriptor(this IAdapter adapter) {
+            if (adapter == null) {
+                throw new ArgumentNullException(nameof(adapter));
+            }
+
+            var type = adapter.GetType();
+            var adapterAttribute = type.GetCustomAttribute<AdapterMetadataAttribute>();
+            var vendorAttribute = type.GetCustomAttribute<VendorInfoAttribute>() ?? type.Assembly.GetCustomAttribute<VendorInfoAttribute>();
+
+            var uri = adapterAttribute?.Uri ?? new Uri(string.Concat("asc:adapter-type/", type.FullName, "/"));
+            return new AdapterTypeDescriptor(
+                uri, 
+                adapterAttribute?.GetName(), 
+                adapterAttribute?.GetDescription(), 
+                type.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? type.Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? type.Assembly.GetName().Version?.ToString(),
+                vendorAttribute?.CreateVendorInfo()
+            );
+        }
+
+
+        /// <summary>
         /// Creates an <see cref="AdapterDescriptorExtended"/> for the <see cref="IAdapter"/>.
         /// </summary>
         /// <param name="adapter">
@@ -544,7 +570,8 @@ namespace DataCore.Adapter {
                 adapter.Descriptor.Description,
                 standardFeatures.Where(x => x != null).Select(x => x.ToString()).OrderBy(x => x).ToArray(),
                 extensionFeatures.Where(x => x != null).Select(x => x.ToString()).OrderBy(x => x).ToArray(),
-                adapter.Properties
+                adapter.Properties,
+                adapter.TypeDescriptor
             );
         }
 

--- a/src/DataCore.Adapter.Abstractions/AdapterMetadataAttribute.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterMetadataAttribute.cs
@@ -4,11 +4,11 @@ using System.ComponentModel.DataAnnotations;
 namespace DataCore.Adapter {
 
     /// <summary>
-    /// <see cref="AdapterAttribute"/> is used to annotate concrete implementations of <see cref="IAdapter"/> 
-    /// to provide metadata about an adapter.
+    /// <see cref="AdapterMetadataAttribute"/> is used to annotate concrete implementations of <see cref="IAdapter"/> 
+    /// to provide metadata about an adapter type.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    public class AdapterAttribute : Attribute {
+    public class AdapterMetadataAttribute : Attribute {
 
         /// <summary>
         /// The localised display name.
@@ -80,7 +80,7 @@ namespace DataCore.Adapter {
         /// <exception cref="ArgumentException">
         ///   <paramref name="uriString"/> is not a valid URI.
         /// </exception>
-        public AdapterAttribute(string uriString) {
+        public AdapterMetadataAttribute(string uriString) {
             if (uriString == null) {
                 throw new ArgumentNullException(nameof(uriString));
             }

--- a/src/DataCore.Adapter.Abstractions/IAdapter.cs
+++ b/src/DataCore.Adapter.Abstractions/IAdapter.cs
@@ -17,6 +17,11 @@ namespace DataCore.Adapter {
         AdapterDescriptor Descriptor { get; }
 
         /// <summary>
+        /// Gets the adapter type descriptor.
+        /// </summary>
+        AdapterTypeDescriptor TypeDescriptor { get; }
+
+        /// <summary>
         /// Gets the feature collection for the adapter.
         /// </summary>
         IAdapterFeaturesCollection Features { get; }

--- a/src/DataCore.Adapter.Abstractions/VendorInfoAttribute.cs
+++ b/src/DataCore.Adapter.Abstractions/VendorInfoAttribute.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+using DataCore.Adapter.Common;
+
+namespace DataCore.Adapter {
+
+    /// <summary>
+    /// <see cref="VendorInfoAttribute"/> is used to provide metadata about an adapter vendor.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = true)]
+    public class VendorInfoAttribute : Attribute {
+
+        /// <summary>
+        /// The vendor name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The vendor's URL.
+        /// </summary>
+        public Uri? Url { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="VendorInfoAttribute"/> object.
+        /// </summary>
+        /// <param name="name">
+        ///   The vendor name.
+        /// </param>
+        /// <param name="urlString">
+        ///   The vendor URL.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="name"/> is <see langword="null"/>.
+        /// </exception>
+        public VendorInfoAttribute(string name, string? urlString) {
+            if (name == null) {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Name = name;
+            Url = urlString != null && Uri.TryCreate(urlString, UriKind.Absolute, out var url) && (Uri.UriSchemeHttps.Equals(url.Scheme, StringComparison.OrdinalIgnoreCase) || Uri.UriSchemeHttp.Equals(url.Scheme, StringComparison.OrdinalIgnoreCase))
+                ? url
+                : null;
+        }
+
+
+        /// <summary>
+        /// Creates a <see cref="VendorInfo"/> object using the configured settings.
+        /// </summary>
+        /// <returns>
+        ///   A new <see cref="VendorInfo"/> object.
+        /// </returns>
+        public VendorInfo CreateVendorInfo() {
+            return VendorInfo.Create(Name, Url?.ToString());
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/DataCore.Adapter.AspNetCore.SignalR.Proxy.csproj
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/DataCore.Adapter.AspNetCore.SignalR.Proxy.csproj
@@ -24,9 +24,13 @@
 
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\VendorInfo.cs" Link="VendorInfo.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Resources.Designer.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Resources.Designer.cs
@@ -22,7 +22,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
+    public class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("DataCore.Adapter.AspNetCore.SignalR.Proxy.Resources", typeof(Resources).Assembly);
@@ -51,7 +51,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -61,9 +61,27 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Proxy that communicates with a remote adapter via ASP.NET Core SignalR..
+        /// </summary>
+        public static string AdapterMetadata_Description {
+            get {
+                return ResourceManager.GetString("AdapterMetadata_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SignalR Proxy.
+        /// </summary>
+        public static string AdapterMetadata_DisplayName {
+            get {
+                return ResourceManager.GetString("AdapterMetadata_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Adapter ID is required..
         /// </summary>
-        internal static string Error_AdapterIdIsRequired {
+        public static string Error_AdapterIdIsRequired {
             get {
                 return ResourceManager.GetString("Error_AdapterIdIsRequired", resourceCulture);
             }
@@ -72,7 +90,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Connection factory is required..
         /// </summary>
-        internal static string Error_ConnectionFactoryIsRequired {
+        public static string Error_ConnectionFactoryIsRequired {
             get {
                 return ResourceManager.GetString("Error_ConnectionFactoryIsRequired", resourceCulture);
             }
@@ -81,7 +99,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to SignalR Connection.
         /// </summary>
-        internal static string HealthCheck_DisplayName_Connection {
+        public static string HealthCheck_DisplayName_Connection {
             get {
                 return ResourceManager.GetString("HealthCheck_DisplayName_Connection", resourceCulture);
             }
@@ -90,7 +108,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Remote Adapter Health.
         /// </summary>
-        internal static string HealthCheck_DisplayName_RemoteAdapter {
+        public static string HealthCheck_DisplayName_RemoteAdapter {
             get {
                 return ResourceManager.GetString("HealthCheck_DisplayName_RemoteAdapter", resourceCulture);
             }
@@ -99,7 +117,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to SignalR hub connection status is {0}..
         /// </summary>
-        internal static string HealthCheck_ExtensionHubConnectionStatusDescription {
+        public static string HealthCheck_ExtensionHubConnectionStatusDescription {
             get {
                 return ResourceManager.GetString("HealthCheck_ExtensionHubConnectionStatusDescription", resourceCulture);
             }
@@ -108,7 +126,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to SignalR hub connection status is {0}. See inner results for remote adapter health..
         /// </summary>
-        internal static string HealthCheck_HubConnectionStatusDescription {
+        public static string HealthCheck_HubConnectionStatusDescription {
             get {
                 return ResourceManager.GetString("HealthCheck_HubConnectionStatusDescription", resourceCulture);
             }
@@ -117,7 +135,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to SignalR hub connection status is {0}..
         /// </summary>
-        internal static string HealthCheck_HubConnectionStatusDescriptionNoInnerResults {
+        public static string HealthCheck_HubConnectionStatusDescriptionNoInnerResults {
             get {
                 return ResourceManager.GetString("HealthCheck_HubConnectionStatusDescriptionNoInnerResults", resourceCulture);
             }
@@ -126,7 +144,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to The remote adapter does not implement health checks..
         /// </summary>
-        internal static string HealthCheck_RemoteAdapterHealthNotSupported {
+        public static string HealthCheck_RemoteAdapterHealthNotSupported {
             get {
                 return ResourceManager.GetString("HealthCheck_RemoteAdapterHealthNotSupported", resourceCulture);
             }
@@ -135,7 +153,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
-        internal static string HealthCheck_UnknownConnectionState {
+        public static string HealthCheck_UnknownConnectionState {
             get {
                 return ResourceManager.GetString("HealthCheck_UnknownConnectionState", resourceCulture);
             }
@@ -144,7 +162,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to SignalR Connection ({0}).
         /// </summary>
-        internal static string HeathCheck_DisplayName_ExtensionConnection {
+        public static string HeathCheck_DisplayName_ExtensionConnection {
             get {
                 return ResourceManager.GetString("HeathCheck_DisplayName_ExtensionConnection", resourceCulture);
             }
@@ -153,7 +171,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Error while running events subscription..
         /// </summary>
-        internal static string Log_EventsSubscriptionError {
+        public static string Log_EventsSubscriptionError {
             get {
                 return ResourceManager.GetString("Log_EventsSubscriptionError", resourceCulture);
             }
@@ -162,7 +180,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Error while registering an extension feature implementation: {0}.
         /// </summary>
-        internal static string Log_ExtensionFeatureRegistrationError {
+        public static string Log_ExtensionFeatureRegistrationError {
             get {
                 return ResourceManager.GetString("Log_ExtensionFeatureRegistrationError", resourceCulture);
             }
@@ -171,7 +189,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to No implementation available for extension feature: {0}.
         /// </summary>
-        internal static string Log_NoExtensionImplementationAvailable {
+        public static string Log_NoExtensionImplementationAvailable {
             get {
                 return ResourceManager.GetString("Log_NoExtensionImplementationAvailable", resourceCulture);
             }
@@ -180,7 +198,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Error while running snapshot tag value subscription..
         /// </summary>
-        internal static string Log_SnapshotTagValueSubscriptionError {
+        public static string Log_SnapshotTagValueSubscriptionError {
             get {
                 return ResourceManager.GetString("Log_SnapshotTagValueSubscriptionError", resourceCulture);
             }
@@ -189,7 +207,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to An error occurred while disposing subscriptions..
         /// </summary>
-        internal static string Log_SubscriptionDisposeError {
+        public static string Log_SubscriptionDisposeError {
             get {
                 return ResourceManager.GetString("Log_SubscriptionDisposeError", resourceCulture);
             }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Resources.resx
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AdapterMetadata_Description" xml:space="preserve">
+    <value>Proxy that communicates with a remote adapter via ASP.NET Core SignalR.</value>
+  </data>
+  <data name="AdapterMetadata_DisplayName" xml:space="preserve">
+    <value>SignalR Proxy</value>
+  </data>
   <data name="Error_AdapterIdIsRequired" xml:space="preserve">
     <value>Adapter ID is required.</value>
   </data>

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
@@ -16,8 +16,14 @@ using Microsoft.Extensions.Logging;
 namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
 
     /// <summary>
-    /// Adapter proxy that communicates with a remote adapter via SignalR.
+    /// Adapter proxy that communicates with a remote adapter via ASP.NET Core SignalR.
     /// </summary>
+    [AdapterMetadata(
+        "https://www.intelligentplant.com/app-store-connect/adapters/proxies/signalr",
+        ResourceType = typeof(Resources),
+        Name = nameof(Resources.AdapterMetadata_DisplayName),
+        Description = nameof(Resources.AdapterMetadata_Description)
+    )]
     public class SignalRAdapterProxy : AdapterBase<SignalRAdapterProxyOptions>, IAdapterProxy {
 
         /// <summary>

--- a/src/DataCore.Adapter.Core/Common/AdapterDescriptorExtended.cs
+++ b/src/DataCore.Adapter.Core/Common/AdapterDescriptorExtended.cs
@@ -11,6 +11,11 @@ namespace DataCore.Adapter.Common {
     public class AdapterDescriptorExtended : AdapterDescriptor {
 
         /// <summary>
+        /// The adapter type descriptor.
+        /// </summary>
+        public AdapterTypeDescriptor? TypeDescriptor { get; }
+
+        /// <summary>
         /// The names of the implemented standard adapter features.
         /// </summary>
         public IEnumerable<string> Features { get; }
@@ -49,6 +54,9 @@ namespace DataCore.Adapter.Common {
         /// <param name="properties">
         ///   Additional adapter properties.
         /// </param>
+        /// <param name="typeDescriptor">
+        ///   The adapter type descriptor.
+        /// </param>
         /// <exception cref="ArgumentException">
         ///   <paramref name="id"/> is <see langword="null"/> or white space.
         /// </exception>
@@ -61,11 +69,14 @@ namespace DataCore.Adapter.Common {
             string? description, 
             IEnumerable<string>? features, 
             IEnumerable<string>? extensions, 
-            IEnumerable<AdapterProperty>? properties
+            IEnumerable<AdapterProperty>? properties,
+            AdapterTypeDescriptor? typeDescriptor
         ) : base(id, name, description) {
+            
             Features = features?.ToArray() ?? Array.Empty<string>();
             Extensions = extensions?.ToArray() ?? Array.Empty<string>();
             Properties = properties?.ToArray() ?? Array.Empty<AdapterProperty>();
+            TypeDescriptor = typeDescriptor;
         }
 
 
@@ -92,14 +103,17 @@ namespace DataCore.Adapter.Common {
         /// <param name="properties">
         ///   Additional adapter properties.
         /// </param>
+        /// <param name="typeDescriptor">
+        ///   The adapter type descriptor.
+        /// </param>
         /// <exception cref="ArgumentException">
         ///   <paramref name="id"/> is <see langword="null"/> or white space.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="name"/> is <see langword="null"/> or white space.
         /// </exception>
-        public static AdapterDescriptorExtended Create(string id, string name, string? description, IEnumerable<string>? features, IEnumerable<string>? extensions, IEnumerable<AdapterProperty>? properties) {
-            return new AdapterDescriptorExtended(id, name, description, features, extensions, properties);
+        public static AdapterDescriptorExtended Create(string id, string name, string? description, IEnumerable<string>? features, IEnumerable<string>? extensions, IEnumerable<AdapterProperty>? properties, AdapterTypeDescriptor? typeDescriptor) {
+            return new AdapterDescriptorExtended(id, name, description, features, extensions, properties, typeDescriptor);
         }
 
     }

--- a/src/DataCore.Adapter.Core/Common/AdapterTypeDescriptor.cs
+++ b/src/DataCore.Adapter.Core/Common/AdapterTypeDescriptor.cs
@@ -1,0 +1,73 @@
+﻿using System;
+
+namespace DataCore.Adapter.Common {
+
+    /// <summary>
+    /// Describes an adapter type.
+    /// </summary>
+    public class AdapterTypeDescriptor {
+
+        /// <summary>
+        /// The URI for the adapter type.
+        /// </summary>
+        public Uri Uri { get; }
+
+        /// <summary>
+        /// The display name for the adapter type.
+        /// </summary>
+        public string? Name { get; }
+
+        /// <summary>
+        /// The description for the adapter type.
+        /// </summary>
+        public string? Description { get; }
+
+        /// <summary>
+        /// The adapter type version number, expressed as a Semantic Versioning v2 version.
+        /// </summary>
+        public string? Version { get; }
+
+        /// <summary>
+        /// The vendor information for the adapter type.
+        /// </summary>
+        public VendorInfo? Vendor { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="AdapterTypeDescriptor"/> object.
+        /// </summary>
+        /// <param name="uri">
+        ///   The URI for the adapter type.
+        /// </param>
+        /// <param name="name">
+        ///   The adapter type display name.
+        /// </param>
+        /// <param name="description">
+        ///   The adapter type description.
+        /// </param>
+        /// <param name="version">
+        ///   The adapter type version. This will be parsed and converted to a Semantic Versioning 
+        ///   v2 version (https://semver.org/spec/v2.0.0.html).
+        /// </param>
+        /// <param name="vendor">
+        ///   The adapter type vendor information.
+        /// </param>
+        public AdapterTypeDescriptor(Uri uri, string? name, string? description, string? version, VendorInfo? vendor) {
+            Uri = uri ?? throw new ArgumentNullException(nameof(uri));
+            Name = name;
+            Description = description;
+            if (version == null) {
+                Version = null;
+            }
+            else {
+                Version = NuGet.Versioning.SemanticVersion.TryParse(version, out var semVer)
+                    ? semVer.ToFullString()
+                    : System.Version.TryParse(version, out var v)
+                        ? new NuGet.Versioning.SemanticVersion(v.Major, v.Minor, v.Build, string.Empty, v.Revision.ToString(System.Globalization.CultureInfo.CurrentCulture)).ToFullString()
+                        : null;
+            }
+            Vendor = vendor;
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.Csv/CsvAdapter.cs
+++ b/src/DataCore.Adapter.Csv/CsvAdapter.cs
@@ -9,10 +9,13 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using CsvHelper;
+
 using DataCore.Adapter.Common;
 using DataCore.Adapter.RealTimeData;
 using IntelligentPlant.BackgroundTasks;
 using Microsoft.Extensions.Logging;
+
+
 
 namespace DataCore.Adapter.Csv {
 
@@ -20,6 +23,12 @@ namespace DataCore.Adapter.Csv {
     /// App Store Connect adapter that uses a looping CSV file as its source data.
     /// </summary>
     /// <seealso cref="CsvAdapterOptions"/>
+    [AdapterMetadata(
+        "https://www.intelligentplant.com/app-store-connect/adapters/csv",
+        ResourceType = typeof(Resources),
+        Name = nameof(Resources.AdapterMetadata_DisplayName),
+        Description = nameof(Resources.AdapterMetadata_Description)
+    )]
     public class CsvAdapter : AdapterBase<CsvAdapterOptions>, ITagSearch, IReadSnapshotTagValues, IReadRawTagValues {
 
         /// <summary>

--- a/src/DataCore.Adapter.Csv/DataCore.Adapter.Csv.csproj
+++ b/src/DataCore.Adapter.Csv/DataCore.Adapter.Csv.csproj
@@ -26,9 +26,13 @@
 
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\VendorInfo.cs" Link="VendorInfo.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Csv/Resources.Designer.cs
+++ b/src/DataCore.Adapter.Csv/Resources.Designer.cs
@@ -22,7 +22,7 @@ namespace DataCore.Adapter.Csv {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
+    public class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace DataCore.Adapter.Csv {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("DataCore.Adapter.Csv.Resources", typeof(Resources).Assembly);
@@ -51,7 +51,7 @@ namespace DataCore.Adapter.Csv {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -61,9 +61,27 @@ namespace DataCore.Adapter.Csv {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Adapter that uses a looping CSV file as its source data..
+        /// </summary>
+        public static string AdapterMetadata_Description {
+            get {
+                return ResourceManager.GetString("AdapterMetadata_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CSV.
+        /// </summary>
+        public static string AdapterMetadata_DisplayName {
+            get {
+                return ResourceManager.GetString("AdapterMetadata_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No CSV file was specified. Check that the {0} or {1} property is defined correctly in the adapter options..
         /// </summary>
-        internal static string Error_NoCsvFileDefined {
+        public static string Error_NoCsvFileDefined {
             get {
                 return ResourceManager.GetString("Error_NoCsvFileDefined", resourceCulture);
             }
@@ -72,7 +90,7 @@ namespace DataCore.Adapter.Csv {
         /// <summary>
         ///   Looks up a localized string similar to A snapshot polling error occurred..
         /// </summary>
-        internal static string Log_SnapshotPollingError {
+        public static string Log_SnapshotPollingError {
             get {
                 return ResourceManager.GetString("Log_SnapshotPollingError", resourceCulture);
             }

--- a/src/DataCore.Adapter.Csv/Resources.resx
+++ b/src/DataCore.Adapter.Csv/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AdapterMetadata_Description" xml:space="preserve">
+    <value>Adapter that uses a looping CSV file as its source data.</value>
+  </data>
+  <data name="AdapterMetadata_DisplayName" xml:space="preserve">
+    <value>CSV</value>
+  </data>
   <data name="Error_NoCsvFileDefined" xml:space="preserve">
     <value>No CSV file was specified. Check that the {0} or {1} property is defined correctly in the adapter options.</value>
     <comment>{0} - CsvFile property name

--- a/src/DataCore.Adapter.Grpc.Proxy/DataCore.Adapter.Grpc.Proxy.csproj
+++ b/src/DataCore.Adapter.Grpc.Proxy/DataCore.Adapter.Grpc.Proxy.csproj
@@ -24,9 +24,13 @@
 
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\VendorInfo.cs" Link="VendorInfo.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.cs
@@ -21,6 +21,12 @@ namespace DataCore.Adapter.Grpc.Proxy {
     /// <summary>
     /// Adapter proxy that communicates with a remote adapter via gRPC.
     /// </summary>
+    [AdapterMetadata(
+        "https://www.intelligentplant.com/app-store-connect/adapters/proxies/grpc",
+        ResourceType = typeof(Resources),
+        Name = nameof(Resources.AdapterMetadata_DisplayName),
+        Description = nameof(Resources.AdapterMetadata_Description)
+    )]
     public class GrpcAdapterProxy : AdapterBase<GrpcAdapterProxyOptions>, IAdapterProxy {
 
         /// <summary>

--- a/src/DataCore.Adapter.Grpc.Proxy/Resources.Designer.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Resources.Designer.cs
@@ -22,7 +22,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
+    public class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("DataCore.Adapter.Grpc.Proxy.Resources", typeof(Resources).Assembly);
@@ -51,7 +51,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -61,9 +61,27 @@ namespace DataCore.Adapter.Grpc.Proxy {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Proxy that communicates with a remote adapter via gRPC..
+        /// </summary>
+        public static string AdapterMetadata_Description {
+            get {
+                return ResourceManager.GetString("AdapterMetadata_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to gRPC Proxy.
+        /// </summary>
+        public static string AdapterMetadata_DisplayName {
+            get {
+                return ResourceManager.GetString("AdapterMetadata_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Adapter ID is required..
         /// </summary>
-        internal static string Error_AdapterIdIsRequired {
+        public static string Error_AdapterIdIsRequired {
             get {
                 return ResourceManager.GetString("Error_AdapterIdIsRequired", resourceCulture);
             }
@@ -72,7 +90,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to gRPC channel state is {0}. See inner results for remote adapter health..
         /// </summary>
-        internal static string HealthCheck_ChannelStateDescription {
+        public static string HealthCheck_ChannelStateDescription {
             get {
                 return ResourceManager.GetString("HealthCheck_ChannelStateDescription", resourceCulture);
             }
@@ -81,7 +99,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to gRPC channel state is {0}..
         /// </summary>
-        internal static string HealthCheck_ChannelStateDescriptionNoInnerResults {
+        public static string HealthCheck_ChannelStateDescriptionNoInnerResults {
             get {
                 return ResourceManager.GetString("HealthCheck_ChannelStateDescriptionNoInnerResults", resourceCulture);
             }
@@ -90,7 +108,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to gRPC Connection.
         /// </summary>
-        internal static string HealthCheck_DisplayName_Connection {
+        public static string HealthCheck_DisplayName_Connection {
             get {
                 return ResourceManager.GetString("HealthCheck_DisplayName_Connection", resourceCulture);
             }
@@ -99,7 +117,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Remote Adapter Health.
         /// </summary>
-        internal static string HealthCheck_DisplayName_RemoteAdapter {
+        public static string HealthCheck_DisplayName_RemoteAdapter {
             get {
                 return ResourceManager.GetString("HealthCheck_DisplayName_RemoteAdapter", resourceCulture);
             }
@@ -108,7 +126,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to See inner results for remote adapter health..
         /// </summary>
-        internal static string HealthCheck_GrpcNetClientDescription {
+        public static string HealthCheck_GrpcNetClientDescription {
             get {
                 return ResourceManager.GetString("HealthCheck_GrpcNetClientDescription", resourceCulture);
             }
@@ -117,7 +135,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to The remote adapter does not implement health checks..
         /// </summary>
-        internal static string HealthCheck_RemoteAdapterHealthNotSupported {
+        public static string HealthCheck_RemoteAdapterHealthNotSupported {
             get {
                 return ResourceManager.GetString("HealthCheck_RemoteAdapterHealthNotSupported", resourceCulture);
             }
@@ -126,7 +144,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Error while shutting down gRPC channel..
         /// </summary>
-        internal static string Log_ChannelShutdownError {
+        public static string Log_ChannelShutdownError {
             get {
                 return ResourceManager.GetString("Log_ChannelShutdownError", resourceCulture);
             }
@@ -135,7 +153,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Error while calling the heartbeat endpoint..
         /// </summary>
-        internal static string Log_ErrorDuringHeartbeatInvocation {
+        public static string Log_ErrorDuringHeartbeatInvocation {
             get {
                 return ResourceManager.GetString("Log_ErrorDuringHeartbeatInvocation", resourceCulture);
             }
@@ -144,7 +162,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Error while registering an extension feature implementation: {0}.
         /// </summary>
-        internal static string Log_ExtensionFeatureRegistrationError {
+        public static string Log_ExtensionFeatureRegistrationError {
             get {
                 return ResourceManager.GetString("Log_ExtensionFeatureRegistrationError", resourceCulture);
             }
@@ -153,7 +171,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to No implementation available for extension feature: {0}.
         /// </summary>
-        internal static string Log_NoExtensionImplementationAvailable {
+        public static string Log_NoExtensionImplementationAvailable {
             get {
                 return ResourceManager.GetString("Log_NoExtensionImplementationAvailable", resourceCulture);
             }
@@ -162,7 +180,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to An error occurred while disposing subscriptions..
         /// </summary>
-        internal static string Log_SubscriptionDisposeError {
+        public static string Log_SubscriptionDisposeError {
             get {
                 return ResourceManager.GetString("Log_SubscriptionDisposeError", resourceCulture);
             }

--- a/src/DataCore.Adapter.Grpc.Proxy/Resources.resx
+++ b/src/DataCore.Adapter.Grpc.Proxy/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AdapterMetadata_Description" xml:space="preserve">
+    <value>Proxy that communicates with a remote adapter via gRPC.</value>
+  </data>
+  <data name="AdapterMetadata_DisplayName" xml:space="preserve">
+    <value>gRPC Proxy</value>
+  </data>
   <data name="Error_AdapterIdIsRequired" xml:space="preserve">
     <value>Adapter ID is required.</value>
   </data>

--- a/src/DataCore.Adapter.Http.Proxy/DataCore.Adapter.Http.Proxy.csproj
+++ b/src/DataCore.Adapter.Http.Proxy/DataCore.Adapter.Http.Proxy.csproj
@@ -32,9 +32,13 @@
 
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\VendorInfo.cs" Link="VendorInfo.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
+++ b/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace DataCore.Adapter.Http.Proxy {
 
     /// <summary>
-    /// Adapter proxy that communicates with a remote adapter via SignalR.
+    /// Adapter proxy that communicates with a remote adapter via HTTP.
     /// </summary>
     /// <remarks>
     ///   In order to apply per-call authorization to adapter calls, use the 
@@ -26,6 +26,12 @@ namespace DataCore.Adapter.Http.Proxy {
     ///   <see cref="IAdapterCallContext.User"/> property from the adapter call to the delegating 
     ///   handler prior to sending each HTTP request.
     /// </remarks>
+    [AdapterMetadata(
+        "https://www.intelligentplant.com/app-store-connect/adapters/proxies/http",
+        ResourceType = typeof(Resources),
+        Name = nameof(Resources.AdapterMetadata_DisplayName),
+        Description = nameof(Resources.AdapterMetadata_Description)
+    )]
     public class HttpAdapterProxy : AdapterBase<HttpAdapterProxyOptions>, IAdapterProxy {
 
         /// <summary>

--- a/src/DataCore.Adapter.Http.Proxy/Resources.Designer.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Resources.Designer.cs
@@ -22,7 +22,7 @@ namespace DataCore.Adapter.Http.Proxy {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
+    public class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace DataCore.Adapter.Http.Proxy {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("DataCore.Adapter.Http.Proxy.Resources", typeof(Resources).Assembly);
@@ -51,7 +51,7 @@ namespace DataCore.Adapter.Http.Proxy {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -61,9 +61,27 @@ namespace DataCore.Adapter.Http.Proxy {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Proxy that communicates with a remote adapter via HTTP..
+        /// </summary>
+        public static string AdapterMetadata_Description {
+            get {
+                return ResourceManager.GetString("AdapterMetadata_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HTTP Proxy.
+        /// </summary>
+        public static string AdapterMetadata_DisplayName {
+            get {
+                return ResourceManager.GetString("AdapterMetadata_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Adapter ID is required..
         /// </summary>
-        internal static string Error_AdapterIdIsRequired {
+        public static string Error_AdapterIdIsRequired {
             get {
                 return ResourceManager.GetString("Error_AdapterIdIsRequired", resourceCulture);
             }
@@ -72,7 +90,7 @@ namespace DataCore.Adapter.Http.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to HTTP Connection.
         /// </summary>
-        internal static string HealthCheck_DisplayName_Connection {
+        public static string HealthCheck_DisplayName_Connection {
             get {
                 return ResourceManager.GetString("HealthCheck_DisplayName_Connection", resourceCulture);
             }
@@ -81,7 +99,7 @@ namespace DataCore.Adapter.Http.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Remote Adapter Health.
         /// </summary>
-        internal static string HealthCheck_DisplayName_RemoteAdapter {
+        public static string HealthCheck_DisplayName_RemoteAdapter {
             get {
                 return ResourceManager.GetString("HealthCheck_DisplayName_RemoteAdapter", resourceCulture);
             }
@@ -90,7 +108,7 @@ namespace DataCore.Adapter.Http.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to The remote adapter does not implement health checks..
         /// </summary>
-        internal static string HealthCheck_RemoteAdapterHealthNotSupported {
+        public static string HealthCheck_RemoteAdapterHealthNotSupported {
             get {
                 return ResourceManager.GetString("HealthCheck_RemoteAdapterHealthNotSupported", resourceCulture);
             }
@@ -99,7 +117,7 @@ namespace DataCore.Adapter.Http.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to See inner results for remote adapter health..
         /// </summary>
-        internal static string HealthChecks_RemoteHeathDescription {
+        public static string HealthChecks_RemoteHeathDescription {
             get {
                 return ResourceManager.GetString("HealthChecks_RemoteHeathDescription", resourceCulture);
             }
@@ -108,7 +126,7 @@ namespace DataCore.Adapter.Http.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to Error while registering an extension feature implementation: {FeatureName}.
         /// </summary>
-        internal static string Log_ExtensionFeatureRegistrationError {
+        public static string Log_ExtensionFeatureRegistrationError {
             get {
                 return ResourceManager.GetString("Log_ExtensionFeatureRegistrationError", resourceCulture);
             }
@@ -117,7 +135,7 @@ namespace DataCore.Adapter.Http.Proxy {
         /// <summary>
         ///   Looks up a localized string similar to No implementation available for extension feature: {FeatureName}.
         /// </summary>
-        internal static string Log_NoExtensionImplementationAvailable {
+        public static string Log_NoExtensionImplementationAvailable {
             get {
                 return ResourceManager.GetString("Log_NoExtensionImplementationAvailable", resourceCulture);
             }

--- a/src/DataCore.Adapter.Http.Proxy/Resources.resx
+++ b/src/DataCore.Adapter.Http.Proxy/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AdapterMetadata_Description" xml:space="preserve">
+    <value>Proxy that communicates with a remote adapter via HTTP.</value>
+  </data>
+  <data name="AdapterMetadata_DisplayName" xml:space="preserve">
+    <value>HTTP Proxy</value>
+  </data>
   <data name="Error_AdapterIdIsRequired" xml:space="preserve">
     <value>Adapter ID is required.</value>
   </data>

--- a/src/DataCore.Adapter.Json/AdapterDescriptorExtendedConverter.cs
+++ b/src/DataCore.Adapter.Json/AdapterDescriptorExtendedConverter.cs
@@ -21,6 +21,7 @@ namespace DataCore.Adapter.Json {
             string[] features = null!;
             string[] extensions = null!;
             AdapterProperty[] properties = null!;
+            AdapterTypeDescriptor typeDescriptor = null!;
 
             while (reader.Read() && reader.TokenType != JsonTokenType.EndObject) {
                 if (reader.TokenType != JsonTokenType.PropertyName) {
@@ -50,12 +51,15 @@ namespace DataCore.Adapter.Json {
                 else if (string.Equals(propertyName, nameof(AdapterDescriptorExtended.Properties), StringComparison.OrdinalIgnoreCase)) {
                     properties = JsonSerializer.Deserialize<AdapterProperty[]>(ref reader, options);
                 }
+                else if (string.Equals(propertyName, nameof(AdapterDescriptorExtended.TypeDescriptor), StringComparison.OrdinalIgnoreCase)) {
+                    typeDescriptor = JsonSerializer.Deserialize<AdapterTypeDescriptor>(ref reader, options);
+                }
                 else {
                     reader.Skip();
                 }
             }
 
-            return AdapterDescriptorExtended.Create(id, name, description, features, extensions, properties);
+            return AdapterDescriptorExtended.Create(id, name, description, features, extensions, properties, typeDescriptor);
         }
 
 
@@ -74,6 +78,7 @@ namespace DataCore.Adapter.Json {
             WritePropertyValue(writer, nameof(AdapterDescriptorExtended.Features), value.Features, options);
             WritePropertyValue(writer, nameof(AdapterDescriptorExtended.Extensions), value.Extensions, options);
             WritePropertyValue(writer, nameof(AdapterDescriptorExtended.Properties), value.Properties, options);
+            WritePropertyValue(writer, nameof(AdapterDescriptorExtended.TypeDescriptor), value.TypeDescriptor, options);
 
             writer.WriteEndObject();
         }

--- a/src/DataCore.Adapter.Json/AdapterTypeDescriptorConverter.cs
+++ b/src/DataCore.Adapter.Json/AdapterTypeDescriptorConverter.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Text.Json;
+
+using DataCore.Adapter.Common;
+
+namespace DataCore.Adapter.Json {
+
+    /// <summary>
+    /// JSON converter for <see cref="AdapterTypeDescriptor"/>.
+    /// </summary>
+    public class AdapterTypeDescriptorConverter : AdapterJsonConverter<AdapterTypeDescriptor> {
+
+        /// <inheritdoc/>
+        public override AdapterTypeDescriptor Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+            if (reader.TokenType != JsonTokenType.StartObject) {
+                ThrowInvalidJsonError();
+            }
+
+            Uri uri = null!;
+            string? name = null!;
+            string? description = null!;
+            string? version = null!;
+            VendorInfo? vendor = null!;
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject) {
+                if (reader.TokenType != JsonTokenType.PropertyName) {
+                    continue;
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read()) {
+                    ThrowInvalidJsonError();
+                }
+
+                if (string.Equals(propertyName, nameof(AdapterTypeDescriptor.Uri), StringComparison.OrdinalIgnoreCase)) {
+                    uri = JsonSerializer.Deserialize<Uri>(ref reader, options);
+                }
+                else if (string.Equals(propertyName, nameof(AdapterTypeDescriptor.Name), StringComparison.OrdinalIgnoreCase)) {
+                    name = JsonSerializer.Deserialize<string>(ref reader, options);
+                }
+                else if (string.Equals(propertyName, nameof(AdapterTypeDescriptor.Description), StringComparison.OrdinalIgnoreCase)) {
+                    description = JsonSerializer.Deserialize<string>(ref reader, options);
+                }
+                else if (string.Equals(propertyName, nameof(AdapterTypeDescriptor.Version), StringComparison.OrdinalIgnoreCase)) {
+                    version = JsonSerializer.Deserialize<string>(ref reader, options);
+                }
+                else if (string.Equals(propertyName, nameof(AdapterTypeDescriptor.Vendor), StringComparison.OrdinalIgnoreCase)) {
+                    vendor = JsonSerializer.Deserialize<VendorInfo>(ref reader, options);
+                }
+                else {
+                    reader.Skip();
+                }
+            }
+
+            return new AdapterTypeDescriptor(uri, name, description, version, vendor);
+        }
+
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, AdapterTypeDescriptor value, JsonSerializerOptions options) {
+            if (value == null) {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStartObject();
+
+            WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Uri), value.Uri, options);
+            WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Name), value.Name, options);
+            WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Description), value.Description, options);
+            WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Version), value.Version, options);
+            WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Vendor), value.Vendor, options);
+
+            writer.WriteEndObject();
+        }
+
+    }
+}

--- a/src/DataCore.Adapter/AdapterBase.cs
+++ b/src/DataCore.Adapter/AdapterBase.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using DataCore.Adapter.Common;
@@ -117,7 +118,6 @@ namespace DataCore.Adapter {
         /// </summary>
         private ConcurrentDictionary<string, AdapterProperty> _properties = new ConcurrentDictionary<string, AdapterProperty>();
 
-
         /// <inheritdoc/>
         public AdapterDescriptor Descriptor {
             get {
@@ -127,6 +127,9 @@ namespace DataCore.Adapter {
                 }
             }
         }
+
+        /// <inheritdoc/>
+        public AdapterTypeDescriptor TypeDescriptor { get; }
 
         /// <inheritdoc/>
         public IAdapterFeaturesCollection Features {
@@ -215,6 +218,7 @@ namespace DataCore.Adapter {
 
             StopToken = _stopTokenSource.Token;
             _descriptor = new AdapterDescriptor(id, name, description);
+            TypeDescriptor = this.CreateTypeDescriptor();
             BackgroundTaskService = new BackgroundTaskServiceWrapper(this, backgroundTaskService ?? IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default);
             Logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
             _loggerScope = Logger.BeginScope(_descriptor.Id);

--- a/src/Protos/datacore/adapter/Types.proto
+++ b/src/Protos/datacore/adapter/Types.proto
@@ -79,16 +79,26 @@ message VendorInfo {
 
 // Adapter models
 
+message AdapterTypeDescriptor {
+    string uri = 1;
+    string name = 2;
+    string description = 3;
+    string version = 4;
+    VendorInfo vendor_info = 5;
+}
+
 message AdapterDescriptor {
     string id = 1;
     string name = 2;
     string description = 3;
 }
+
 message ExtendedAdapterDescriptor {
     AdapterDescriptor adapterDescriptor = 1;
     repeated string features = 2;
     repeated string extensions = 3;
     repeated AdapterProperty properties = 4;
+    AdapterTypeDescriptor type_descriptor = 5;
 }
 
 enum HealthStatus {

--- a/src/Shared/VendorInfo.cs
+++ b/src/Shared/VendorInfo.cs
@@ -1,0 +1,1 @@
+[assembly: DataCore.Adapter.VendorInfo("Intelligent Plant", "https://www.intelligentplant.com")]

--- a/swagger.json
+++ b/swagger.json
@@ -1951,6 +1951,15 @@
             "description": "An extended descriptor for an adapter, that includes information about the features that the \nadapter has implemented.",
             "additionalProperties": false,
             "properties": {
+              "typeDescriptor": {
+                "description": "The adapter type descriptor.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AdapterTypeDescriptor"
+                  }
+                ]
+              },
               "features": {
                 "type": "array",
                 "description": "The names of the implemented standard adapter features.",
@@ -1975,6 +1984,59 @@
             }
           }
         ]
+      },
+      "AdapterTypeDescriptor": {
+        "type": "object",
+        "description": "Describes an adapter type.",
+        "additionalProperties": false,
+        "properties": {
+          "uri": {
+            "type": "string",
+            "description": "The URI for the adapter type.",
+            "format": "uri"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name for the adapter type.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "The description for the adapter type.",
+            "nullable": true
+          },
+          "version": {
+            "type": "string",
+            "description": "The adapter type version number, expressed as a Semantic Versioning v2 version.",
+            "nullable": true
+          },
+          "vendor": {
+            "description": "The vendor information for the adapter type.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/VendorInfo"
+              }
+            ]
+          }
+        }
+      },
+      "VendorInfo": {
+        "type": "object",
+        "description": "Describes the vendor for the hosting application.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The vendor name.",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "description": "The vendor URL.",
+            "nullable": true
+          }
+        }
       },
       "AdapterProperty": {
         "type": "object",
@@ -2680,23 +2742,6 @@
             "items": {
               "$ref": "#/components/schemas/AdapterProperty"
             }
-          }
-        }
-      },
-      "VendorInfo": {
-        "type": "object",
-        "description": "Describes the vendor for the hosting application.",
-        "additionalProperties": false,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The vendor name.",
-            "nullable": true
-          },
-          "url": {
-            "type": "string",
-            "description": "The vendor URL.",
-            "nullable": true
           }
         }
       },

--- a/test/DataCore.Adapter.Tests.WebHost/WebHostStartup.cs
+++ b/test/DataCore.Adapter.Tests.WebHost/WebHostStartup.cs
@@ -49,7 +49,7 @@ namespace DataCore.Adapter.Tests {
                     svc.AddSingleton<Events.InMemoryEventMessageStoreOptions>();
                 })
                 .AddAdapter(sp => {
-                    var adapter = ActivatorUtilities.CreateInstance<Csv.CsvAdapter>(sp, "sensor-csv", new Csv.CsvAdapterOptions() {
+                    var adapter = ActivatorUtilities.CreateInstance<Csv.CsvAdapter>(sp, WebHostConfiguration.AdapterId, new Csv.CsvAdapterOptions() {
                         Name = "Sensor CSV",
                         Description = "CSV adapter with dummy sensor data",
                         IsDataLoopingAllowed = true,

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -19,6 +19,8 @@ namespace DataCore.Adapter.Tests {
 
         public AdapterDescriptor Descriptor { get; }
 
+        public AdapterTypeDescriptor TypeDescriptor { get; }
+
         public IAdapterFeaturesCollection Features { get; }
 
         public IEnumerable<AdapterProperty> Properties { get; } = Array.Empty<AdapterProperty>();
@@ -34,6 +36,7 @@ namespace DataCore.Adapter.Tests {
 
         public ExampleAdapter() {
             Descriptor = AdapterDescriptor.Create("unit-tests", "Unit Tests Adapter", "Adapter for use in unit tests");
+            TypeDescriptor = this.CreateTypeDescriptor();
             var features = new AdapterFeaturesCollection(this);
             _snapshotSubscriptionManager = new SnapshotSubscriptionManager(this);
             _eventSubscriptionManager = new EventSubscriptionManager();

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -221,7 +221,14 @@ namespace DataCore.Adapter.Tests {
                 },
                 new [] {
                     new AdapterProperty("Property1", new Variant(100, VariantType.Int32))
-                }
+                },
+                new AdapterTypeDescriptor(
+                    new Uri("asc:unit-tests/json-tests/" + TestContext.TestName), 
+                    TestContext.TestName, 
+                    TestContext.TestName, 
+                    "1.0.0",
+                    new VendorInfo("", "")
+                )
             );
 
             var json = JsonSerializer.Serialize(expected, options);
@@ -253,6 +260,14 @@ namespace DataCore.Adapter.Tests {
                 Assert.AreEqual(expectedValue.Name, actualValue.Name);
                 Assert.AreEqual(expectedValue.Value, actualValue.Value);
             }
+
+            Assert.IsNotNull(actual.TypeDescriptor);
+            Assert.AreEqual(expected.TypeDescriptor.Uri, actual.TypeDescriptor.Uri);
+            Assert.AreEqual(expected.TypeDescriptor.Name, actual.TypeDescriptor.Name);
+            Assert.AreEqual(expected.TypeDescriptor.Description, actual.TypeDescriptor.Description);
+            Assert.IsNotNull(expected.TypeDescriptor.Vendor);
+            Assert.AreEqual(expected.TypeDescriptor.Vendor.Name, actual.TypeDescriptor.Vendor.Name);
+            Assert.AreEqual(expected.TypeDescriptor.Vendor.Url, actual.TypeDescriptor.Vendor.Url);
         }
 
 

--- a/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
@@ -117,6 +117,7 @@ namespace DataCore.Adapter.Tests {
             return RunAdapterTest((proxy, context) => {
                 Assert.IsNotNull(proxy.RemoteHostInfo);
                 Assert.IsNotNull(proxy.RemoteDescriptor);
+                Assert.IsNotNull(proxy.RemoteDescriptor.TypeDescriptor);
 
                 return Task.CompletedTask;
             });


### PR DESCRIPTION
- `AdapterMetadataAttribute` and `VendorInfoAttribute` allow metadata about an adapter type and vendor to be specified via attributes.
- `AdapterTypeDescriptor` describes information about a driver type.
- `IAdapter` and `AdapterDescriptorExtended` now have a `TypeDescriptor` property of type `AdapterTypeDescriptor`, which allows the adapter to be queried for information about its driver at runtime.
- `AdapterExtensions.CreateTypeDescriptor` can automatically create an `AdapterTypeDescriptor` for an adapter based on the attributes described above.

Example `AdapterDescriptorExtended` serialized to JSON:

```json
{
  "id": "sensor-csv",
  "name": "Sensor CSV",
  "description": "CSV adapter with dummy sensor data",
  "features": [
    "asc:features/diagnostics/health-check/",
    "asc:features/events/push/",
    "asc:features/events/push/topics/",
    "asc:features/events/read/cursor/",
    "asc:features/events/read/time/",
    "asc:features/events/write/",
    "asc:features/real-time-data/tags/info/",
    "asc:features/real-time-data/tags/search/",
    "asc:features/real-time-data/values/push/",
    "asc:features/real-time-data/values/read/at-times/",
    "asc:features/real-time-data/values/read/plot/",
    "asc:features/real-time-data/values/read/processed/",
    "asc:features/real-time-data/values/read/raw/",
    "asc:features/real-time-data/values/read/snapshot/"
  ],
  "extensions": [],
  "properties": [],
  "typeDescriptor": {
    "uri": "https://www.intelligentplant.com/app-store-connect/adapters/csv/",
    "name": "CSV",
    "description": "Adapter that uses a looping CSV file as its source data.",
    "version": "1.0.0",
    "vendor": {
      "name": "Intelligent Plant",
      "url": "https://www.intelligentplant.com/"
    }
  }
}
```