### PR TITLE
V2 working

### DIFF
--- a/DataCore.Adapter.sln
+++ b/DataCore.Adapter.sln
@@ -87,6 +87,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.Proxy", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.Tests.WebHost", "test\DataCore.Adapter.Tests.WebHost\DataCore.Adapter.Tests.WebHost.csproj", "{D50F25F4-A0B1-4897-99B2-9E091B3516E5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataCore.Adapter.DependencyInjection", "src\DataCore.Adapter.DependencyInjection\DataCore.Adapter.DependencyInjection.csproj", "{5CD15B99-02B0-4BBD-9033-5DF46520F77D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -189,6 +191,10 @@ Global
 		{D50F25F4-A0B1-4897-99B2-9E091B3516E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D50F25F4-A0B1-4897-99B2-9E091B3516E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D50F25F4-A0B1-4897-99B2-9E091B3516E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CD15B99-02B0-4BBD-9033-5DF46520F77D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CD15B99-02B0-4BBD-9033-5DF46520F77D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CD15B99-02B0-4BBD-9033-5DF46520F77D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CD15B99-02B0-4BBD-9033-5DF46520F77D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -222,6 +228,7 @@ Global
 		{A28BD1F2-AFC4-4AF9-8C20-F943BAB260C5} = {1BF8C809-6F14-4C52-B172-D43A96295884}
 		{3B99AA8E-5B75-4188-BC84-5BFBA5265A00} = {041CEC9C-1271-4A4E-BEF6-6279A8B0FC97}
 		{D50F25F4-A0B1-4897-99B2-9E091B3516E5} = {1BF8C809-6F14-4C52-B172-D43A96295884}
+		{5CD15B99-02B0-4BBD-9033-5DF46520F77D} = {B158078F-D217-46FE-A9B8-7BD1B99922BA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {323415F4-D394-4EAA-B259-7C6834BFD819}

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -18,8 +18,9 @@
     <MicrosoftAspNetCoreSignalRVersion>1.1.0</MicrosoftAspNetCoreSignalRVersion>
     <MicrosoftAspNetWebApiClientVersion>5.2.7</MicrosoftAspNetWebApiClientVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.1.1</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksVersion>3.1.8</MicrosoftExtensionsDiagnosticsHealthChecksVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>3.1.8</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>3.1.9</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDiagnosticsHealthChecksVersion>3.1.9</MicrosoftExtensionsDiagnosticsHealthChecksVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>3.1.9</MicrosoftExtensionsLoggingAbstractionsVersion>
   </PropertyGroup>
   
   <!-- gRPC Packages -->
@@ -45,7 +46,7 @@
   <PropertyGroup>
     <CastleCoreVersion>4.4.1</CastleCoreVersion>
     <CsvHelperVersion>15.0.5</CsvHelperVersion>
-    <IntelligentPlantBackgroundTasksVersion>3.0.0</IntelligentPlantBackgroundTasksVersion>
+    <IntelligentPlantBackgroundTasksVersion>4.0.0</IntelligentPlantBackgroundTasksVersion>
     <JaahasHttpRequestTransformerVersion>1.0.1</JaahasHttpRequestTransformerVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
     <NSwagAspNetCoreVersion>13.7.0</NSwagAspNetCoreVersion>

--- a/examples/DataCore.Adapter.AspNetCoreExample/Properties/launchSettings.json
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "DataCore.Adapter.AspNetCoreExample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/data-core/v1.0/host-info",
+      "launchUrl": "api/app-store-connect/v1.0/host-info",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
@@ -90,6 +90,43 @@ namespace DataCore.Adapter.AspNetCoreExample {
                 options.DocumentName = "v1.0";
                 options.Title = "App Store Connect Adapters";
                 options.Description = "HTTP API for querying an App Store Connect adapters host.";
+                options.AddOperationFilter(context => {
+                    // Don't include the legacy routes.
+                    return !context.OperationDescription.Path.StartsWith("/api/data-core/");
+                });
+                options.OperationProcessors.Add(new NSwag.Generation.Processors.OperationProcessor(context => { 
+                    string RemoveWhiteSpace(string s) {
+                        return s.Replace("\n", "").Trim();
+                    }
+
+                    if (context.OperationDescription.Operation.Summary != null) {
+                        context.OperationDescription.Operation.Summary = RemoveWhiteSpace(context.OperationDescription.Operation.Summary);
+                    }
+
+                    if (context.OperationDescription.Operation.Description != null) {
+                        context.OperationDescription.Operation.Description = RemoveWhiteSpace(context.OperationDescription.Operation.Description);
+                    }
+
+                    foreach (var parameter in context.OperationDescription.Operation.Parameters) {
+                        if (parameter.Description == null) {
+                            continue;
+                        }
+                        parameter.Description = RemoveWhiteSpace(parameter.Description);
+                    }
+
+                    if (context.OperationDescription.Operation.RequestBody?.Description != null) {
+                        context.OperationDescription.Operation.RequestBody.Description = RemoveWhiteSpace(context.OperationDescription.Operation.RequestBody.Description);
+                    }
+
+                    foreach (var response in context.OperationDescription.Operation.Responses.Values) {
+                        if (response.Description == null) {
+                            continue;
+                        }
+                        response.Description = RemoveWhiteSpace(response.Description);
+                    }
+
+                    return true;
+                }));
             });
         }
 

--- a/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
@@ -521,17 +521,7 @@ namespace DataCore.Adapter {
             }
 
             var type = adapter.GetType();
-            var adapterAttribute = type.GetCustomAttribute<AdapterMetadataAttribute>();
-            var vendorAttribute = type.GetCustomAttribute<VendorInfoAttribute>() ?? type.Assembly.GetCustomAttribute<VendorInfoAttribute>();
-
-            var uri = adapterAttribute?.Uri ?? new Uri(string.Concat("asc:adapter-type/", type.FullName, "/"));
-            return new AdapterTypeDescriptor(
-                uri, 
-                adapterAttribute?.GetName(), 
-                adapterAttribute?.GetDescription(), 
-                type.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? type.Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? type.Assembly.GetName().Version?.ToString(),
-                vendorAttribute?.CreateVendorInfo()
-            );
+            return type.CreateAdapterTypeDescriptor()!;
         }
 
 

--- a/src/DataCore.Adapter.AspNetCore.Common/Configuration/CommonAdapterConfigurationExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/Configuration/CommonAdapterConfigurationExtensions.cs
@@ -6,9 +6,7 @@ using DataCore.Adapter;
 using DataCore.Adapter.AspNetCore;
 using DataCore.Adapter.AspNetCore.Authorization;
 using DataCore.Adapter.Common;
-using DataCore.Adapter.Extensions;
-
-using IntelligentPlant.BackgroundTasks;
+using DataCore.Adapter.DependencyInjection;
 
 using Microsoft.Extensions.Hosting;
 
@@ -154,142 +152,7 @@ namespace Microsoft.Extensions.DependencyInjection {
         }
 
 
-        /// <summary>
-        /// Adds the <see cref="IAdapterAccessor"/> service that is used to resolve adapters at 
-        /// runtime.
-        /// </summary>
-        /// <typeparam name="T">
-        ///   The <see cref="IAdapterAccessor"/> implementation type.
-        /// </typeparam>
-        /// <param name="builder">
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </param>
-        /// <returns>
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="builder"/> is <see langword="null"/>.
-        /// </exception>
-        public static IAdapterConfigurationBuilder AddAdapterAccessor<T>(
-            this IAdapterConfigurationBuilder builder
-        ) where T : class, IAdapterAccessor {
-            if (builder == null) {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            return builder.AddAdapterAccessor(typeof(T));
-        }
-
-
-        /// <summary>
-        /// Adds the <see cref="IAdapterAccessor"/> service that is used to resolve adapters at 
-        /// runtime.
-        /// </summary>
-        /// <typeparam name="T">
-        ///   The <see cref="IAdapterAccessor"/> implementation type.
-        /// </typeparam>
-        /// <param name="builder">
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </param>
-        /// <param name="implementationFactory">
-        ///   The factory that creates the service.
-        /// </param>
-        /// <returns>
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="builder"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="implementationFactory"/> is <see langword="null"/>.
-        /// </exception>
-        public static IAdapterConfigurationBuilder AddAdapterAccessor<T>(
-            this IAdapterConfigurationBuilder builder,
-            Func<IServiceProvider, T> implementationFactory
-        ) where T : class, IAdapterAccessor {
-            if (builder == null) {
-                throw new ArgumentNullException(nameof(builder));
-            }
-            if (implementationFactory == null) {
-                throw new ArgumentNullException(nameof(implementationFactory));
-            }
-
-            builder.Services.AddSingleton<IAdapterAccessor, T>(implementationFactory);
-            return builder;
-        }
-
-
-        /// <summary>
-        /// Adds the <see cref="IAdapterAccessor"/> service that is used to resolve adapters at 
-        /// runtime.
-        /// </summary>
-        /// <param name="builder">
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </param>
-        /// <param name="implementationType">
-        ///   The <see cref="IAdapterAccessor"/> implementation type.
-        /// </param>
-        /// <returns>
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </returns>
-        private static IAdapterConfigurationBuilder AddAdapterAccessor(
-            this IAdapterConfigurationBuilder builder,
-            Type implementationType
-        ) {
-            builder.Services.AddSingleton(typeof(IAdapterAccessor), implementationType);
-            return builder;
-        }
-
-
-        /// <summary>
-        /// Adds the default background task service.
-        /// </summary>
-        /// <param name="builder">
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </param>
-        /// <returns>
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </returns>
-        private static IAdapterConfigurationBuilder AddBackgroundTaskService(
-            this IAdapterConfigurationBuilder builder
-        ) {
-            builder.Services.AddBackgroundTaskService();
-            return builder;
-        }
-
-
-        /// <summary>
-        /// Configures the <see cref="IBackgroundTaskService"/> used by App Store Connect adapters.
-        /// </summary>
-        /// <param name="builder">
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </param>
-        /// <param name="configure">
-        ///   The configuration delegate.
-        /// </param>
-        /// <returns>
-        ///   The <see cref="IAdapterConfigurationBuilder"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="builder"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="configure"/> is <see langword="null"/>.
-        /// </exception>
-        public static IAdapterConfigurationBuilder AddBackgroundTaskService(
-            this IAdapterConfigurationBuilder builder,
-            Action<BackgroundTaskServiceOptions> configure
-        ) {
-            if (builder == null) {
-                throw new ArgumentNullException(nameof(builder));
-            }
-            if (configure == null) {
-                throw new ArgumentNullException(nameof(configure));
-            }
-
-            builder.Services.AddBackgroundTaskService(configure);
-            return builder;
-        }
+        
 
 
         /// <summary>
@@ -487,57 +350,12 @@ namespace Microsoft.Extensions.DependencyInjection {
         ///   The <see cref="IAdapterConfigurationBuilder"/>.
         /// </returns>
         private static IAdapterConfigurationBuilder AddDefaultServices(this IAdapterConfigurationBuilder builder) {
-            builder.AddBackgroundTaskService(options => options.AllowWorkItemRegistrationWhileStopped = true);
+            builder.Services.AddAspNetCoreBackgroundTaskService(options => options.AllowWorkItemRegistrationWhileStopped = true);
             builder.Services.AddSingleton(HostInfo.Unspecified);
             builder.AddAdapterAccessor<AspNetCoreAdapterAccessor>();
             builder.Services.AddSingleton(typeof(IAdapterAuthorizationService), sp => new DefaultAdapterAuthorizationService(false, sp.GetService<AspNetCore.Authorization.IAuthorizationService>()));
             builder.AddAutomaticInitialization();
             return builder;
-        }
-
-
-        /// <summary>
-        /// Adds services required to run App Store Connect adapters.
-        /// </summary>
-        /// <param name="services">
-        ///   The service collection.
-        /// </param>
-        /// <param name="configure">
-        ///   An <see cref="Action{T}"/> used to configure the adapter service options.
-        /// </param>
-        /// <returns>
-        ///   The service collection.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="services"/> is <see langword="null"/>.
-        /// </exception>
-        [Obsolete("Use " + nameof(AddDataCoreAdapterServices) + "(" + nameof(IServiceCollection) + ") instead", false)]
-        public static IServiceCollection AddDataCoreAdapterServices(this IServiceCollection services, Action<AdapterServicesOptionsBuilder> configure) {
-            if (services == null) {
-                throw new ArgumentNullException(nameof(services));
-            }
-
-            var options = new AdapterServicesOptionsBuilder();
-            configure?.Invoke(options);
-
-            var builder = services.AddDataCoreAdapterServices();
-
-            if (options.AdapterAccessorType != null) {
-                builder.AddAdapterAccessor(options.AdapterAccessorType);
-            }
-
-            if (options.BackgroundTaskServiceOptions != null) {
-                builder.AddBackgroundTaskService(options.BackgroundTaskServiceOptions);
-            }
-
-            if (options.UseAuthorization && options.FeatureAuthorizationHandlerType != null) {
-                builder.AddAdapterFeatureAuthorization(options.FeatureAuthorizationHandlerType);
-            }
-
-            builder.AddAutomaticInitialization();
-            builder.AddHostInfo(options.HostInfo);
-
-            return services;
         }
 
     }

--- a/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
@@ -23,6 +23,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\DataCore.Adapter\DataCore.Adapter.csproj" />
+    <ProjectReference Include="..\DataCore.Adapter.DependencyInjection\DataCore.Adapter.DependencyInjection.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
@@ -690,12 +690,12 @@ namespace DataCore.Adapter {
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            if (string.IsNullOrWhiteSpace(descriptor.Uri)) {
+            if (string.IsNullOrWhiteSpace(descriptor.Id)) {
                 return null;
             }
 
             return new AdapterTypeDescriptor(
-                new Uri(descriptor.Uri, UriKind.Absolute),
+                new Uri(descriptor.Id, UriKind.Absolute),
                 descriptor.Name,
                 descriptor.Description,
                 descriptor.Version,
@@ -719,7 +719,7 @@ namespace DataCore.Adapter {
             }
 
             return new Grpc.AdapterTypeDescriptor() { 
-                Uri = descriptor.Uri.ToString(),
+                Id = descriptor.Id.ToString(),
                 Name = descriptor.Name ?? string.Empty,
                 Description = descriptor.Description ?? string.Empty,
                 Version = descriptor.Version ?? string.Empty,

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
@@ -14,8 +14,10 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// API controller for requesting information about the hosted adapters.
     /// </summary>
     [ApiController]
-    [Area("data-core")]
+    [Area("app-store-connect")]
     [Route("api/[area]/v1.0/adapters")]
+    // Legacy route for compatibility with v1 of the toolkit
+    [Route("api/data-core/v1.0/adapters")] 
     public class AdaptersController : ControllerBase {
 
         /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AssetModelBrowserController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AssetModelBrowserController.cs
@@ -12,8 +12,10 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// API controller for browsing an adapter's asset model hierarchy.
     /// </summary>
     [ApiController]
-    [Area("data-core")]
+    [Area("app-store-connect")]
     [Route("api/[area]/v1.0/asset-model")]
+    // Legacy route for compatibility with v1 of the toolkit
+    [Route("api/data-core/v1.0/asset-model")] 
     public class AssetModelBrowserController : ControllerBase {
 
         /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/EventsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/EventsController.cs
@@ -13,8 +13,10 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// API controller for querying event messages on adapters.
     /// </summary>
     [ApiController]
-    [Area("data-core")]
+    [Area("app-store-connect")]
     [Route("api/[area]/v1.0/events")]
+    // Legacy route for compatibility with v1 of the toolkit
+    [Route("api/data-core/v1.0/events")] 
     public class EventsController : ControllerBase {
 
         /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
@@ -17,8 +17,10 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// Controller for invoking extension adapter features.
     /// </summary>
     [ApiController]
-    [Area("data-core")]
+    [Area("app-store-connect")]
     [Route("api/[area]/v1.0/extensions")]
+    // Legacy route for compatibility with v1 of the toolkit
+    [Route("api/data-core/v1.0/extensions")] 
     public class ExtensionFeaturesController : ControllerBase {
 
         /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/HostInfoController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/HostInfoController.cs
@@ -12,8 +12,10 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// API controller for requesting information about the hosting application.
     /// </summary>
     [ApiController]
-    [Area("data-core")]
+    [Area("app-store-connect")]
     [Route("api/[area]/v1.0/host-info")]
+    // Legacy route for compatibility with v1 of the toolkit
+    [Route("api/data-core/v1.0/host-info")] 
     public class HostInfoController: ControllerBase {
 
         /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagAnnotationsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagAnnotationsController.cs
@@ -12,8 +12,10 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// API controller for requesting annotations on tag values.
     /// </summary>
     [ApiController]
-    [Area("data-core")]
+    [Area("app-store-connect")]
     [Route("api/[area]/v1.0/tag-annotations")]
+    // Legacy route for compatibility with v1 of the toolkit
+    [Route("api/data-core/v1.0/tag-annotations")] 
     public class TagAnnotationsController: ControllerBase {
 
         /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
@@ -13,8 +13,10 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// API controller for performing tag searches.
     /// </summary>
     [ApiController]
-    [Area("data-core")]
+    [Area("app-store-connect")]
     [Route("api/[area]/v1.0/tags")]
+    // Legacy route for compatibility with v1 of the toolkit
+    [Route("api/data-core/v1.0/tags")] 
     public class TagSearchController : ControllerBase {
 
         /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagValuesController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagValuesController.cs
@@ -14,8 +14,10 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// API controller for requesting tag data.
     /// </summary>
     [ApiController]
-    [Area("data-core")]
+    [Area("app-store-connect")]
     [Route("api/[area]/v1.0/tag-values")]
+    // Legacy route for compatibility with v1 of the toolkit
+    [Route("api/data-core/v1.0/tag-values")] 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Validation is performed by MVC framework")]
     public class TagValuesController: ControllerBase {
 
@@ -52,6 +54,31 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         public TagValuesController(IAdapterAccessor adapterAccessor, IBackgroundTaskService backgroundTaskService) {
             _adapterAccessor = adapterAccessor ?? throw new ArgumentNullException(nameof(adapterAccessor));
             _backgroundTaskService = backgroundTaskService ?? throw new ArgumentNullException(nameof(backgroundTaskService));
+        }
+
+
+        /// <summary>
+        /// Requests snapshot (current) tag values.
+        /// </summary>
+        /// <param name="adapterId">
+        ///   The ID of the adapter to query.
+        /// </param>
+        /// <param name="tag">
+        ///   The tag IDs or names to poll.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   Successful responses contain the snapshot values for the requested tags.
+        /// </returns>
+        [HttpGet]
+        [Route("{adapterId}/snapshot")]
+        [ProducesResponseType(typeof(IEnumerable<TagValueQueryResult>), 200)]
+        public Task<IActionResult> ReadSnapshotValues(string adapterId, [FromQuery] string[] tag = null!, CancellationToken cancellationToken = default) {
+            return ReadSnapshotValues(adapterId, new ReadSnapshotTagValuesRequest() { 
+                Tags = tag ?? Array.Empty<string>()
+            }, cancellationToken);
         }
 
 

--- a/src/DataCore.Adapter.Core/Common/AdapterTypeDescriptor.cs
+++ b/src/DataCore.Adapter.Core/Common/AdapterTypeDescriptor.cs
@@ -10,7 +10,7 @@ namespace DataCore.Adapter.Common {
         /// <summary>
         /// The URI for the adapter type.
         /// </summary>
-        public Uri Uri { get; }
+        public Uri Id { get; }
 
         /// <summary>
         /// The display name for the adapter type.
@@ -36,7 +36,7 @@ namespace DataCore.Adapter.Common {
         /// <summary>
         /// Creates a new <see cref="AdapterTypeDescriptor"/> object.
         /// </summary>
-        /// <param name="uri">
+        /// <param name="id">
         ///   The URI for the adapter type.
         /// </param>
         /// <param name="name">
@@ -52,8 +52,8 @@ namespace DataCore.Adapter.Common {
         /// <param name="vendor">
         ///   The adapter type vendor information.
         /// </param>
-        public AdapterTypeDescriptor(Uri uri, string? name, string? description, string? version, VendorInfo? vendor) {
-            Uri = uri ?? throw new ArgumentNullException(nameof(uri));
+        public AdapterTypeDescriptor(Uri id, string? name, string? description, string? version, VendorInfo? vendor) {
+            Id = id ?? throw new ArgumentNullException(nameof(id));
             Name = name;
             Description = description;
             if (version == null) {

--- a/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationBuilderExtensions.cs
+++ b/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationBuilderExtensions.cs
@@ -1,0 +1,191 @@
+﻿using System;
+
+using DataCore.Adapter;
+using DataCore.Adapter.DependencyInjection;
+
+using IntelligentPlant.BackgroundTasks;
+
+namespace Microsoft.Extensions.DependencyInjection {
+
+    /// <summary>
+    /// Extensions for <see cref="IAdapterConfigurationBuilder"/>.
+    /// </summary>
+    public static class AdapterConfigurationBuilderExtensions {
+
+        /// <summary>
+        /// Adds the <see cref="IAdapterAccessor"/> service that is used to resolve adapters at 
+        /// runtime.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The <see cref="IAdapterAccessor"/> implementation type.
+        /// </typeparam>
+        /// <param name="builder">
+        ///   The <see cref="IAdapterConfigurationBuilder"/>.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IAdapterConfigurationBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static IAdapterConfigurationBuilder AddAdapterAccessor<T>(
+            this IAdapterConfigurationBuilder builder
+        ) where T : class, IAdapterAccessor {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.AddAdapterAccessor(typeof(T));
+        }
+
+
+        /// <summary>
+        /// Adds the <see cref="IAdapterAccessor"/> service that is used to resolve adapters at 
+        /// runtime.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The <see cref="IAdapterAccessor"/> implementation type.
+        /// </typeparam>
+        /// <param name="builder">
+        ///   The <see cref="IAdapterConfigurationBuilder"/>.
+        /// </param>
+        /// <param name="implementationFactory">
+        ///   The factory that creates the service.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IAdapterConfigurationBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="implementationFactory"/> is <see langword="null"/>.
+        /// </exception>
+        public static IAdapterConfigurationBuilder AddAdapterAccessor<T>(
+            this IAdapterConfigurationBuilder builder,
+            Func<IServiceProvider, T> implementationFactory
+        ) where T : class, IAdapterAccessor {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (implementationFactory == null) {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
+
+            builder.Services.AddSingleton<IAdapterAccessor, T>(implementationFactory);
+            return builder;
+        }
+
+
+        /// <summary>
+        /// Adds the <see cref="IAdapterAccessor"/> service that is used to resolve adapters at 
+        /// runtime.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="IAdapterConfigurationBuilder"/>.
+        /// </param>
+        /// <param name="implementationType">
+        ///   The <see cref="IAdapterAccessor"/> implementation type.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IAdapterConfigurationBuilder"/>.
+        /// </returns>
+        private static IAdapterConfigurationBuilder AddAdapterAccessor(
+            this IAdapterConfigurationBuilder builder,
+            Type implementationType
+        ) {
+            builder.Services.AddSingleton(typeof(IAdapterAccessor), implementationType);
+            return builder;
+        }
+
+
+        /// <summary>
+        /// Adds <see cref="BackgroundTaskService.Default"/> as the registered <see cref="IBackgroundTaskService"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///   The configuration builder.
+        /// </param>
+        /// <returns>
+        ///   The configuration builder.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static IAdapterConfigurationBuilder AddDefaultBackgroundTaskService(this IAdapterConfigurationBuilder builder) {
+            return builder.AddBackgroundTaskService(BackgroundTaskService.Default);
+        }
+
+
+        /// <summary>
+        /// Adds the specified implementation as the registered <see cref="IBackgroundTaskService"/>. 
+        /// Note that the implementation must be externally initialised before it will be able to 
+        /// process queued work items.
+        /// </summary>
+        /// <param name="builder">
+        ///   The configuration builder.
+        /// </param>
+        /// <param name="implementationInstance">
+        ///   The <see cref="IBackgroundTaskService"/> implementation instance to use.
+        /// </param>
+        /// <returns>
+        ///   The configuration builder.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="implementationInstance"/> is <see langword="null"/>.
+        /// </exception>
+        public static IAdapterConfigurationBuilder AddBackgroundTaskService(this IAdapterConfigurationBuilder builder, IBackgroundTaskService implementationInstance) {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (implementationInstance == null) {
+                throw new ArgumentNullException(nameof(implementationInstance));
+            }
+
+            builder.Services.AddSingleton(implementationInstance);
+
+            return builder;
+        }
+
+
+        /// <summary>
+        /// Adds an <see cref="IBackgroundTaskService"/> registration and supporting services to 
+        /// the service collection. Note that the <see cref="IBackgroundTaskService"/> must be 
+        /// externally initialised before it will be able to process queued work items.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The background service implementation type.
+        /// </typeparam>
+        /// <param name="builder">
+        ///   The configuration builder.
+        /// </param>
+        /// <param name="configure">
+        ///   A delegate that can be used to configure the <see cref="BackgroundTaskServiceOptions"/> 
+        ///   for the service.
+        /// </param>
+        /// <returns>
+        ///   The configuration builder.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static IAdapterConfigurationBuilder AddBackgroundTaskService<T>(
+            this IAdapterConfigurationBuilder builder,
+            Action<BackgroundTaskServiceOptions>? configure = null
+        ) where T : class, IBackgroundTaskService {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            var options = new BackgroundTaskServiceOptions();
+            configure?.Invoke(options);
+            builder.Services.AddSingleton(options);
+            builder.Services.AddSingleton<IBackgroundTaskService, T>();
+
+            return builder;
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.DependencyInjection/DataCore.Adapter.DependencyInjection.csproj
+++ b/src/DataCore.Adapter.DependencyInjection/DataCore.Adapter.DependencyInjection.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageId>$(PackagePrefix).Adapter.DependencyInjection</PackageId>
+    <Description>App Store Connect types for use with Microsoft.Extensions.DependencyInjection.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="$(IntelligentPlantBackgroundTasksVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DataCore.Adapter.Abstractions\DataCore.Adapter.Abstractions.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/src/DataCore.Adapter.DependencyInjection/DefaultAdapterConfigurationBuilder.cs
+++ b/src/DataCore.Adapter.DependencyInjection/DefaultAdapterConfigurationBuilder.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 
-namespace Microsoft.Extensions.DependencyInjection {
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DataCore.Adapter.DependencyInjection {
 
     /// <summary>
     /// Default <see cref="IAdapterConfigurationBuilder"/> implementation.

--- a/src/DataCore.Adapter.DependencyInjection/IAdapterConfigurationBuilder.cs
+++ b/src/DataCore.Adapter.DependencyInjection/IAdapterConfigurationBuilder.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿
+using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Extensions.DependencyInjection {
+namespace DataCore.Adapter.DependencyInjection {
 
     /// <summary>
     /// An interface for configuring App Store Connect adapter services.

--- a/src/DataCore.Adapter.Http.Client/AdapterHttpClient.cs
+++ b/src/DataCore.Adapter.Http.Client/AdapterHttpClient.cs
@@ -19,6 +19,11 @@ namespace DataCore.Adapter.Http.Client {
         public HttpClient HttpClient { get; }
 
         /// <summary>
+        /// The App Store Connect adapters toolkit version to use.
+        /// </summary>
+        public CompatibilityVersion CompatibilityVersion { get; set; } = CompatibilityVersion.Latest;
+
+        /// <summary>
         /// The client for querying the remote host about available adapters.
         /// </summary>
         public AdaptersClient Adapters { get; }

--- a/src/DataCore.Adapter.Http.Client/Clients/AdaptersClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/AdaptersClient.cs
@@ -17,7 +17,9 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private const string UrlPrefix = "api/data-core/v1.0/adapters";
+        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0 
+            ? "api/data-core/v1.0/adapters" 
+            : "api/app-store-connect/v1.0/adapters";
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/AssetModelBrowserClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/AssetModelBrowserClient.cs
@@ -16,7 +16,9 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private const string UrlPrefix = "api/data-core/v1.0/asset-model";
+        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
+            ? "api/data-core/v1.0/asset-model"
+            : "api/app-store-connect/v1.0/asset-model";
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/EventsClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/EventsClient.cs
@@ -16,7 +16,9 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private const string UrlPrefix = "api/data-core/v1.0/events";
+        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
+            ? "api/data-core/v1.0/events"
+            : "api/app-store-connect/v1.0/events";
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/ExtensionFeaturesClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/ExtensionFeaturesClient.cs
@@ -17,7 +17,9 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private const string UrlPrefix = "api/data-core/v1.0/extensions";
+        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
+            ? "api/data-core/v1.0/extensions"
+            : "api/app-store-connect/v1.0/extensions";
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/HostInfoClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/HostInfoClient.cs
@@ -15,7 +15,9 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private const string UrlPrefix = "api/data-core/v1.0/host-info";
+        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
+            ? "api/data-core/v1.0/host-info"
+            : "api/app-store-connect/v1.0/host-info";
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/TagSearchClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagSearchClient.cs
@@ -17,7 +17,9 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private const string UrlPrefix = "api/data-core/v1.0/tags";
+        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
+            ? "api/data-core/v1.0/tags"
+            : "api/app-store-connect/v1.0/tags";
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/TagValueAnnotationsClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagValueAnnotationsClient.cs
@@ -16,7 +16,9 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private const string UrlPrefix = "api/data-core/v1.0/tag-annotations";
+        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
+            ? "api/data-core/v1.0/tag-annotations"
+            : "api/app-store-connect/v1.0/tag-annotations";
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/TagValuesClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagValuesClient.cs
@@ -16,7 +16,9 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private const string UrlPrefix = "api/data-core/v1.0/tag-values";
+        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
+            ? "api/data-core/v1.0/tag-values"
+            : "api/app-store-connect/v1.0/tag-values";
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/CompatibilityVersion.cs
+++ b/src/DataCore.Adapter.Http.Client/CompatibilityVersion.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DataCore.Adapter.Http.Client {
+
+    /// <summary>
+    /// Describes the App Store Connect adapter toolkit version that the client should use.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Following convension used by ASP.NET Core MVC")]
+    public enum CompatibilityVersion {
+        /// <summary>
+        /// v1.0
+        /// </summary>
+        Version_1_0 = 1,
+        /// <summary>
+        /// v2.0
+        /// </summary>
+        Version_2_0 = 2,
+        /// <summary>
+        /// The current version.
+        /// </summary>
+        Latest = int.MaxValue
+    }
+}

--- a/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
+++ b/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
@@ -139,6 +139,7 @@ namespace DataCore.Adapter.Http.Proxy {
             logger
         ) {
             _client = client ?? throw new ArgumentNullException(nameof(client));
+            _client.CompatibilityVersion = options?.CompatibilityVersion ?? CompatibilityVersion.Latest;
             _remoteAdapterId = Options?.RemoteId ?? throw new ArgumentException(Resources.Error_AdapterIdIsRequired, nameof(options));
             _extensionFeatureFactory = Options?.ExtensionFeatureFactory;
             _snapshotRefreshInterval = Options?.TagValuePushInterval ?? TimeSpan.FromMinutes(1);

--- a/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxyOptions.cs
+++ b/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxyOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 
+using DataCore.Adapter.Http.Client;
 using DataCore.Adapter.Proxy;
 
 namespace DataCore.Adapter.Http.Proxy {
@@ -14,6 +15,11 @@ namespace DataCore.Adapter.Http.Proxy {
         /// </summary>
         [Required]
         public string RemoteId { get; set; } = default!;
+
+        /// <summary>
+        /// The App Store Connect adapter toolkit version to use when querying the remote adapter.
+        /// </summary>
+        public CompatibilityVersion CompatibilityVersion { get; set; } = CompatibilityVersion.Latest;
 
         /// <summary>
         /// The interval to use between re-polling the health status of the remote adapter. 

--- a/src/DataCore.Adapter.Json/AdapterTypeDescriptorConverter.cs
+++ b/src/DataCore.Adapter.Json/AdapterTypeDescriptorConverter.cs
@@ -16,7 +16,7 @@ namespace DataCore.Adapter.Json {
                 ThrowInvalidJsonError();
             }
 
-            Uri uri = null!;
+            Uri id = null!;
             string? name = null!;
             string? description = null!;
             string? version = null!;
@@ -32,8 +32,8 @@ namespace DataCore.Adapter.Json {
                     ThrowInvalidJsonError();
                 }
 
-                if (string.Equals(propertyName, nameof(AdapterTypeDescriptor.Uri), StringComparison.OrdinalIgnoreCase)) {
-                    uri = JsonSerializer.Deserialize<Uri>(ref reader, options);
+                if (string.Equals(propertyName, nameof(AdapterTypeDescriptor.Id), StringComparison.OrdinalIgnoreCase)) {
+                    id = JsonSerializer.Deserialize<Uri>(ref reader, options);
                 }
                 else if (string.Equals(propertyName, nameof(AdapterTypeDescriptor.Name), StringComparison.OrdinalIgnoreCase)) {
                     name = JsonSerializer.Deserialize<string>(ref reader, options);
@@ -52,7 +52,7 @@ namespace DataCore.Adapter.Json {
                 }
             }
 
-            return new AdapterTypeDescriptor(uri, name, description, version, vendor);
+            return new AdapterTypeDescriptor(id, name, description, version, vendor);
         }
 
 
@@ -65,7 +65,7 @@ namespace DataCore.Adapter.Json {
 
             writer.WriteStartObject();
 
-            WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Uri), value.Uri, options);
+            WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Id), value.Id.ToString(), options);
             WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Name), value.Name, options);
             WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Description), value.Description, options);
             WritePropertyValue(writer, nameof(AdapterTypeDescriptor.Version), value.Version, options);

--- a/src/Protos/datacore/adapter/Types.proto
+++ b/src/Protos/datacore/adapter/Types.proto
@@ -80,7 +80,7 @@ message VendorInfo {
 // Adapter models
 
 message AdapterTypeDescriptor {
-    string uri = 1;
+    string id = 1;
     string name = 2;
     string description = 3;
     string version = 4;

--- a/swagger.json
+++ b/swagger.json
@@ -12,7 +12,7 @@
     }
   ],
   "paths": {
-    "/api/data-core/v1.0/adapters": {
+    "/api/app-store-connect/v1.0/adapters": {
       "get": {
         "tags": [
           "Adapters"
@@ -23,7 +23,7 @@
           {
             "name": "id",
             "in": "query",
-            "description": "The adapter ID filter.\n            ",
+            "description": "The adapter ID filter.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -33,7 +33,7 @@
           {
             "name": "name",
             "in": "query",
-            "description": "The adapter name filter.\n            ",
+            "description": "The adapter name filter.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -43,7 +43,7 @@
           {
             "name": "description",
             "in": "query",
-            "description": "The adapter description filter.\n            ",
+            "description": "The adapter description filter.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -55,7 +55,7 @@
             "in": "query",
             "style": "form",
             "explode": true,
-            "description": "The adapter feature filter. Unlike the ID, name and description filters, the feature \nfilter must exactly match the standard or extension feature name.\n            ",
+            "description": "The adapter feature filter. Unlike the ID, name and description filters, the feature filter must exactly match the standard or extension feature name.",
             "schema": {
               "type": "array",
               "nullable": true,
@@ -68,7 +68,7 @@
           {
             "name": "pageSize",
             "in": "query",
-            "description": "The page size for the query.\n            ",
+            "description": "The page size for the query.",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -79,7 +79,7 @@
           {
             "name": "page",
             "in": "query",
-            "description": "The page number for the query.\n            ",
+            "description": "The page number for the query.",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -90,7 +90,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of AdapterDescriptor \nobjects.\n            ",
+            "description": "Successful responses contain a collection of AdapterDescriptor objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -112,7 +112,7 @@
         "operationId": "Adapters_FindAdapters",
         "requestBody": {
           "x-name": "request",
-          "description": "The search filter.\n            ",
+          "description": "The search filter.",
           "content": {
             "application/json": {
               "schema": {
@@ -125,7 +125,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of AdapterDescriptor \nobjects.\n            ",
+            "description": "Successful responses contain a collection of AdapterDescriptor objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -140,7 +140,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/adapters/{adapterId}": {
+    "/api/app-store-connect/v1.0/adapters/{adapterId}": {
       "get": {
         "tags": [
           "Adapters"
@@ -152,7 +152,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -162,7 +162,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain the AdapterDescriptorExtended for the \nrequested adapter.\n            ",
+            "description": "Successful responses contain the AdapterDescriptorExtended for the requested adapter.",
             "content": {
               "application/json": {
                 "schema": {
@@ -174,7 +174,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/adapters/{adapterId}/health-status": {
+    "/api/app-store-connect/v1.0/adapters/{adapterId}/health-status": {
       "get": {
         "tags": [
           "Adapters"
@@ -186,7 +186,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -196,7 +196,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain the HealthCheckResult for the requested \nadapter.\n            ",
+            "description": "Successful responses contain the HealthCheckResult for the requested adapter.",
             "content": {
               "application/json": {
                 "schema": {
@@ -208,19 +208,19 @@
         }
       }
     },
-    "/api/data-core/v1.0/asset-model/{adapterId}/browse": {
+    "/api/app-store-connect/v1.0/asset-model/{adapterId}/browse": {
       "get": {
         "tags": [
           "AssetModelBrowser"
         ],
-        "summary": "Browses the asset model hierarchy. Up to MaxNodesPerQuery will be \nreturned.",
+        "summary": "Browses the asset model hierarchy. Up to MaxNodesPerQuery will be returned.",
         "operationId": "AssetModelBrowser_BrowseNodes",
         "parameters": [
           {
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID to query.\n            ",
+            "description": "The adapter ID to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -230,7 +230,7 @@
           {
             "name": "start",
             "in": "query",
-            "description": "The optional starting node ID. If no value is specified, browsing will start at the \ntop-level nodes in the hierarchy.\n            ",
+            "description": "The optional starting node ID. If no value is specified, browsing will start at the top-level nodes in the hierarchy.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -240,7 +240,7 @@
           {
             "name": "page",
             "in": "query",
-            "description": "The results page to retrieve.\n            ",
+            "description": "The results page to retrieve.",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -251,7 +251,7 @@
           {
             "name": "pageSize",
             "in": "query",
-            "description": "The page size for the query.\n            ",
+            "description": "The page size for the query.",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -262,7 +262,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain the matching AssetModelNode objects.\n            ",
+            "description": "Successful responses contain the matching AssetModelNode objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -280,14 +280,14 @@
         "tags": [
           "AssetModelBrowser"
         ],
-        "summary": "Browses the asset model hierarchy. Up to MaxNodesPerQuery will be \nreturned.",
+        "summary": "Browses the asset model hierarchy. Up to MaxNodesPerQuery will be returned.",
         "operationId": "AssetModelBrowser_BrowseNodesPost",
         "parameters": [
           {
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID to query.\n            ",
+            "description": "The adapter ID to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -297,7 +297,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The browse request.\n            ",
+          "description": "The browse request.",
           "content": {
             "application/json": {
               "schema": {
@@ -310,7 +310,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain the matching AssetModelNode objects.\n            ",
+            "description": "Successful responses contain the matching AssetModelNode objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -325,7 +325,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/asset-model/{adapterId}/get-by-id": {
+    "/api/app-store-connect/v1.0/asset-model/{adapterId}/get-by-id": {
       "post": {
         "tags": [
           "AssetModelBrowser"
@@ -337,7 +337,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID to query.\n            ",
+            "description": "The adapter ID to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -347,7 +347,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The request object describing the nodes to retrieve.\n            ",
+          "description": "The request object describing the nodes to retrieve.",
           "content": {
             "application/json": {
               "schema": {
@@ -360,7 +360,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain the matching AssetModelNode objects.\n            ",
+            "description": "Successful responses contain the matching AssetModelNode objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -375,19 +375,19 @@
         }
       }
     },
-    "/api/data-core/v1.0/asset-model/{adapterId}/find": {
+    "/api/app-store-connect/v1.0/asset-model/{adapterId}/find": {
       "post": {
         "tags": [
           "AssetModelBrowser"
         ],
-        "summary": "Finds nodes matching the specified search filter. Up to MaxNodesPerQuery \nwill be returned.",
+        "summary": "Finds nodes matching the specified search filter. Up to MaxNodesPerQuery will be returned.",
         "operationId": "AssetModelBrowser_FindNodes",
         "parameters": [
           {
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID to query.\n            ",
+            "description": "The adapter ID to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -397,7 +397,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The request object describing the nodes to retrieve.\n            ",
+          "description": "The request object describing the nodes to retrieve.",
           "content": {
             "application/json": {
               "schema": {
@@ -410,7 +410,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain the matching AssetModelNode objects.\n            ",
+            "description": "Successful responses contain the matching AssetModelNode objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -425,7 +425,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/events/{adapterId}/by-time-range": {
+    "/api/app-store-connect/v1.0/events/{adapterId}/by-time-range": {
       "post": {
         "tags": [
           "Events"
@@ -437,7 +437,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -447,7 +447,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The search filter.\n            ",
+          "description": "The search filter.",
           "content": {
             "application/json": {
               "schema": {
@@ -460,7 +460,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of EventMessage objects.\n            ",
+            "description": "Successful responses contain a collection of EventMessage objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -475,7 +475,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/events/{adapterId}/by-cursor": {
+    "/api/app-store-connect/v1.0/events/{adapterId}/by-cursor": {
       "post": {
         "tags": [
           "Events"
@@ -487,7 +487,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -497,7 +497,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The search filter.\n            ",
+          "description": "The search filter.",
           "content": {
             "application/json": {
               "schema": {
@@ -510,7 +510,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of EventMessageWithCursorPosition \nobjects.\n            ",
+            "description": "Successful responses contain a collection of EventMessageWithCursorPosition objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -525,20 +525,20 @@
         }
       }
     },
-    "/api/data-core/v1.0/events/{adapterId}/write": {
+    "/api/app-store-connect/v1.0/events/{adapterId}/write": {
       "post": {
         "tags": [
           "Events"
         ],
-        "summary": "Writes event messages to an adapter. Up to MaxEventMessagesPerWriteRequest \nmessages can be written in a single request.",
-        "description": "Up to MaxEventMessagesPerWriteRequest values can be written to the \nadapter in a single request. Subsequent values will be ignored. No corresponding \nWriteEventMessageResult object will be returned for these items.\n            ",
+        "summary": "Writes event messages to an adapter. Up to MaxEventMessagesPerWriteRequest messages can be written in a single request.",
+        "description": "Up to MaxEventMessagesPerWriteRequest values can be written to the adapter in a single request. Subsequent values will be ignored. No corresponding WriteEventMessageResult object will be returned for these items.",
         "operationId": "Events_WriteEventMessages",
         "parameters": [
           {
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID to write to.\n            ",
+            "description": "The adapter ID to write to.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -548,7 +548,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The event messages to write.\n            ",
+          "description": "The event messages to write.",
           "content": {
             "application/json": {
               "schema": {
@@ -561,7 +561,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of WriteEventMessageResult \nobjects (one per sample written).\n            ",
+            "description": "Successful responses contain a collection of WriteEventMessageResult objects (one per sample written).",
             "content": {
               "application/json": {
                 "schema": {
@@ -576,7 +576,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/extensions/{adapterId}": {
+    "/api/app-store-connect/v1.0/extensions/{adapterId}": {
       "get": {
         "tags": [
           "ExtensionFeatures"
@@ -588,7 +588,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter to query.\n            ",
+            "description": "The adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -598,7 +598,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of adapter extension feature URIs.\n            ",
+            "description": "Successful responses contain a collection of adapter extension feature URIs.",
             "content": {
               "application/octet-stream": {
                 "schema": {
@@ -611,7 +611,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/extensions/{adapterId}/descriptor": {
+    "/api/app-store-connect/v1.0/extensions/{adapterId}/descriptor": {
       "get": {
         "tags": [
           "ExtensionFeatures"
@@ -623,7 +623,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter to query.\n            ",
+            "description": "The adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -633,7 +633,7 @@
           {
             "name": "id",
             "in": "query",
-            "description": "The extension feature URI.\n            ",
+            "description": "The extension feature URI.",
             "schema": {
               "type": "string",
               "format": "uri",
@@ -644,7 +644,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain a FeatureDescriptor object.\n            ",
+            "description": "Successful responses contain a FeatureDescriptor object.",
             "content": {
               "application/octet-stream": {
                 "schema": {
@@ -657,7 +657,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/extensions/{adapterId}/operations": {
+    "/api/app-store-connect/v1.0/extensions/{adapterId}/operations": {
       "get": {
         "tags": [
           "ExtensionFeatures"
@@ -669,7 +669,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter to query.\n            ",
+            "description": "The adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -679,7 +679,7 @@
           {
             "name": "id",
             "in": "query",
-            "description": "The extension feature URI.\n            ",
+            "description": "The extension feature URI.",
             "schema": {
               "type": "string",
               "format": "uri",
@@ -690,7 +690,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of ExtensionFeatureOperationDescriptor \nobjects.\n            ",
+            "description": "Successful responses contain a collection of ExtensionFeatureOperationDescriptor objects.",
             "content": {
               "application/octet-stream": {
                 "schema": {
@@ -703,7 +703,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/extensions/{adapterId}/operations/invoke": {
+    "/api/app-store-connect/v1.0/extensions/{adapterId}/operations/invoke": {
       "post": {
         "tags": [
           "ExtensionFeatures"
@@ -715,7 +715,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter to query.\n            ",
+            "description": "The adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -725,7 +725,7 @@
           {
             "name": "id",
             "in": "query",
-            "description": "The URI of the operation to invoke.\n            ",
+            "description": "The URI of the operation to invoke.",
             "schema": {
               "type": "string",
               "format": "uri",
@@ -750,7 +750,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a string describing the result of the operation. \nCallers are responsible for correctly parsing or inferring meaning from this result.\n            ",
+            "description": "Successful responses contain a string describing the result of the operation. Callers are responsible for correctly parsing or inferring meaning from this result.",
             "content": {
               "application/octet-stream": {
                 "schema": {
@@ -763,7 +763,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/host-info": {
+    "/api/app-store-connect/v1.0/host-info": {
       "get": {
         "tags": [
           "HostInfo"
@@ -772,7 +772,7 @@
         "operationId": "HostInfo_GetHostInfo",
         "responses": {
           "200": {
-            "description": "Successful responses contain a HostInfo object describing the hosting \napplication.\n            ",
+            "description": "Successful responses contain a HostInfo object describing the hosting application.",
             "content": {
               "application/json": {
                 "schema": {
@@ -784,7 +784,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/host-info/adapter-features": {
+    "/api/app-store-connect/v1.0/host-info/adapter-features": {
       "get": {
         "tags": [
           "HostInfo"
@@ -793,7 +793,7 @@
         "operationId": "HostInfo_GetStandardFeatureDescriptors",
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of FeatureDescriptor object \ndescribing the standard adapter features.\n            ",
+            "description": "Successful responses contain a collection of FeatureDescriptor object describing the standard adapter features.",
             "content": {
               "application/json": {
                 "schema": {
@@ -808,7 +808,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-annotations/{adapterId}": {
+    "/api/app-store-connect/v1.0/tag-annotations/{adapterId}": {
       "post": {
         "tags": [
           "TagAnnotations"
@@ -820,7 +820,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -830,7 +830,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The query.\n            ",
+          "description": "The query.",
           "content": {
             "application/json": {
               "schema": {
@@ -843,7 +843,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of TagValueAnnotationQueryResult objects.\n            ",
+            "description": "Successful responses contain a collection of TagValueAnnotationQueryResult objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -858,7 +858,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-annotations/{adapterId}/{tagId}/{annotationId}": {
+    "/api/app-store-connect/v1.0/tag-annotations/{adapterId}/{tagId}/{annotationId}": {
       "get": {
         "tags": [
           "TagAnnotations"
@@ -870,7 +870,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -881,7 +881,7 @@
             "name": "tagId",
             "in": "path",
             "required": true,
-            "description": "The tag ID for the annotation.\n            ",
+            "description": "The tag ID for the annotation.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -892,7 +892,7 @@
             "name": "annotationId",
             "in": "path",
             "required": true,
-            "description": "The ID for the annotation.\n            ",
+            "description": "The ID for the annotation.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -902,7 +902,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain the matching TagValueAnnotationExtended object.\n            ",
+            "description": "Successful responses contain the matching TagValueAnnotationExtended object.",
             "content": {
               "application/json": {
                 "schema": {
@@ -924,7 +924,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -935,7 +935,7 @@
             "name": "tagId",
             "in": "path",
             "required": true,
-            "description": "The tag ID.\n            ",
+            "description": "The tag ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -946,7 +946,7 @@
             "name": "annotationId",
             "in": "path",
             "required": true,
-            "description": "The annotation ID.\n            ",
+            "description": "The annotation ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -956,7 +956,7 @@
         ],
         "requestBody": {
           "x-name": "annotation",
-          "description": "The annotation.\n            ",
+          "description": "The annotation.",
           "content": {
             "application/json": {
               "schema": {
@@ -969,7 +969,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a WriteTagValueAnnotationResult \ndescribing the operation.\n            ",
+            "description": "Successful responses contain a WriteTagValueAnnotationResult describing the operation.",
             "content": {
               "application/json": {
                 "schema": {
@@ -991,7 +991,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1002,7 +1002,7 @@
             "name": "tagId",
             "in": "path",
             "required": true,
-            "description": "The tag ID.\n            ",
+            "description": "The tag ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1013,7 +1013,7 @@
             "name": "annotationId",
             "in": "path",
             "required": true,
-            "description": "The annotation ID.\n            ",
+            "description": "The annotation ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1023,7 +1023,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain a WriteTagValueAnnotationResult \ndescribing the operation.\n            ",
+            "description": "Successful responses contain a WriteTagValueAnnotationResult describing the operation.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1035,7 +1035,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-annotations/{adapterId}/{tagId}/create": {
+    "/api/app-store-connect/v1.0/tag-annotations/{adapterId}/{tagId}/create": {
       "post": {
         "tags": [
           "TagAnnotations"
@@ -1047,7 +1047,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1058,7 +1058,7 @@
             "name": "tagId",
             "in": "path",
             "required": true,
-            "description": "The tag ID.\n            ",
+            "description": "The tag ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1068,7 +1068,7 @@
         ],
         "requestBody": {
           "x-name": "annotation",
-          "description": "The annotation.\n            ",
+          "description": "The annotation.",
           "content": {
             "application/json": {
               "schema": {
@@ -1081,7 +1081,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a WriteTagValueAnnotationResult \ndescribing the operation.\n            ",
+            "description": "Successful responses contain a WriteTagValueAnnotationResult describing the operation.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1093,7 +1093,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/tags/{adapterId}/properties": {
+    "/api/app-store-connect/v1.0/tags/{adapterId}/properties": {
       "post": {
         "tags": [
           "TagSearch"
@@ -1105,7 +1105,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1115,7 +1115,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The search filter.\n            ",
+          "description": "The search filter.",
           "content": {
             "application/json": {
               "schema": {
@@ -1128,7 +1128,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of AdapterProperty objects.\n            ",
+            "description": "Successful responses contain a collection of AdapterProperty objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1153,7 +1153,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1163,7 +1163,7 @@
           {
             "name": "pageSize",
             "in": "query",
-            "description": "The page size.\n            ",
+            "description": "The page size.",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -1174,7 +1174,7 @@
           {
             "name": "page",
             "in": "query",
-            "description": "The results page to return.\n            ",
+            "description": "The results page to return.",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -1185,7 +1185,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of AdapterProperty objects.\n            ",
+            "description": "Successful responses contain a collection of AdapterProperty objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1200,7 +1200,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/tags/{adapterId}/find": {
+    "/api/app-store-connect/v1.0/tags/{adapterId}/find": {
       "post": {
         "tags": [
           "TagSearch"
@@ -1212,7 +1212,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1222,7 +1222,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The search filter.\n            ",
+          "description": "The search filter.",
           "content": {
             "application/json": {
               "schema": {
@@ -1235,7 +1235,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of TagDefinition objects.\n            ",
+            "description": "Successful responses contain a collection of TagDefinition objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1260,7 +1260,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string"
             },
@@ -1269,7 +1269,7 @@
           {
             "name": "name",
             "in": "query",
-            "description": "The tag name filter.\n            ",
+            "description": "The tag name filter.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1279,7 +1279,7 @@
           {
             "name": "description",
             "in": "query",
-            "description": "The tag description filter.\n            ",
+            "description": "The tag description filter.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1289,7 +1289,7 @@
           {
             "name": "units",
             "in": "query",
-            "description": "The tag units filter.\n            ",
+            "description": "The tag units filter.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1299,7 +1299,7 @@
           {
             "name": "pageSize",
             "in": "query",
-            "description": "The page size.\n            ",
+            "description": "The page size.",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -1310,7 +1310,7 @@
           {
             "name": "page",
             "in": "query",
-            "description": "The results page to return.\n            ",
+            "description": "The results page to return.",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -1321,7 +1321,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of TagDefinition objects.\n            ",
+            "description": "Successful responses contain a collection of TagDefinition objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1336,7 +1336,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/tags/{adapterId}/get-by-id": {
+    "/api/app-store-connect/v1.0/tags/{adapterId}/get-by-id": {
       "post": {
         "tags": [
           "TagSearch"
@@ -1348,7 +1348,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1358,7 +1358,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The request.\n            ",
+          "description": "The request.",
           "content": {
             "application/json": {
               "schema": {
@@ -1371,7 +1371,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of matching TagDefinition \nobjects.\n            ",
+            "description": "Successful responses contain a collection of matching TagDefinition objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1396,7 +1396,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The adapter ID.\n            ",
+            "description": "The adapter ID.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1408,7 +1408,7 @@
             "in": "query",
             "style": "form",
             "explode": true,
-            "description": "The IDs of the tags to retrieve.\n            ",
+            "description": "The IDs of the tags to retrieve.",
             "schema": {
               "type": "array",
               "nullable": true,
@@ -1421,7 +1421,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of matching TagDefinition \nobjects.\n            ",
+            "description": "Successful responses contain a collection of matching TagDefinition objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1436,7 +1436,57 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-values/{adapterId}/snapshot": {
+    "/api/app-store-connect/v1.0/tag-values/{adapterId}/snapshot": {
+      "get": {
+        "tags": [
+          "TagValues"
+        ],
+        "summary": "Requests snapshot (current) tag values.",
+        "operationId": "TagValues_ReadSnapshotValuesAll",
+        "parameters": [
+          {
+            "name": "adapterId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the adapter to query.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "style": "form",
+            "explode": true,
+            "description": "The tag IDs or names to poll.",
+            "schema": {
+              "type": "array",
+              "nullable": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful responses contain the snapshot values for the requested tags.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TagValueQueryResult"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "tags": [
           "TagValues"
@@ -1448,7 +1498,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The ID of the adapter to query.\n            ",
+            "description": "The ID of the adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1458,7 +1508,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The snapshot data request.\n            ",
+          "description": "The snapshot data request.",
           "content": {
             "application/json": {
               "schema": {
@@ -1471,7 +1521,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain the snapshot values for the requested tags.\n            ",
+            "description": "Successful responses contain the snapshot values for the requested tags.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1486,7 +1536,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-values/{adapterId}/raw": {
+    "/api/app-store-connect/v1.0/tag-values/{adapterId}/raw": {
       "post": {
         "tags": [
           "TagValues"
@@ -1498,7 +1548,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The ID of the adapter to query.\n            ",
+            "description": "The ID of the adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1508,7 +1558,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The raw data request.\n            ",
+          "description": "The raw data request.",
           "content": {
             "application/json": {
               "schema": {
@@ -1521,7 +1571,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain the raw values for the requested tags.\n            ",
+            "description": "Successful responses contain the raw values for the requested tags.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1536,20 +1586,20 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-values/{adapterId}/plot": {
+    "/api/app-store-connect/v1.0/tag-values/{adapterId}/plot": {
       "post": {
         "tags": [
           "TagValues"
         ],
         "summary": "Requests plot (vizualization-friendly) tag values.",
-        "description": "Plot data is intended to provide visualization-friendly data sets for display in e.g. \ncharts.\n            ",
+        "description": "Plot data is intended to provide visualization-friendly data sets for display in e.g. charts.",
         "operationId": "TagValues_ReadPlotValues",
         "parameters": [
           {
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The ID of the adapter to query.\n            ",
+            "description": "The ID of the adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1559,7 +1609,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The plot data request.\n            ",
+          "description": "The plot data request.",
           "content": {
             "application/json": {
               "schema": {
@@ -1572,7 +1622,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain the plot values for the requested tags.\n            ",
+            "description": "Successful responses contain the plot values for the requested tags.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1587,7 +1637,7 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-values/{adapterId}/values-at-times": {
+    "/api/app-store-connect/v1.0/tag-values/{adapterId}/values-at-times": {
       "post": {
         "tags": [
           "TagValues"
@@ -1599,7 +1649,7 @@
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The ID of the adapter to query.\n            ",
+            "description": "The ID of the adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1609,7 +1659,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The values-at-times data request.\n            ",
+          "description": "The values-at-times data request.",
           "content": {
             "application/json": {
               "schema": {
@@ -1622,7 +1672,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain the values for the requested tags at the requested times.\n            ",
+            "description": "Successful responses contain the values for the requested tags at the requested times.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1637,20 +1687,20 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-values/{adapterId}/processed": {
+    "/api/app-store-connect/v1.0/tag-values/{adapterId}/processed": {
       "post": {
         "tags": [
           "TagValues"
         ],
         "summary": "Requests processed (aggregated) tag values.",
-        "description": "Processed data queries are used to request aggregated values for tags. The functions \nsupported vary by data source. The DefaultDataFunctions class defines\nconstants for commonly-supported aggregate functions.\n            ",
+        "description": "Processed data queries are used to request aggregated values for tags. The functions supported vary by data source. The DefaultDataFunctions class definesconstants for commonly-supported aggregate functions.",
         "operationId": "TagValues_ReadProcessedValues",
         "parameters": [
           {
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The ID of the adapter to query.\n            ",
+            "description": "The ID of the adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1660,7 +1710,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The processed data request.\n            ",
+          "description": "The processed data request.",
           "content": {
             "application/json": {
               "schema": {
@@ -1673,7 +1723,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain the aggregated values for the requested tags and data \nfunctions.\n            ",
+            "description": "Successful responses contain the aggregated values for the requested tags and data functions.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1688,20 +1738,20 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-values/{adapterId}/supported-aggregations": {
+    "/api/app-store-connect/v1.0/tag-values/{adapterId}/supported-aggregations": {
       "get": {
         "tags": [
           "TagValues"
         ],
         "summary": "Requests the aggregate functions that can be specified when requesting processed data.",
-        "description": "Processed data queries are used to request aggregated values for tags. The functions \nsupported vary by data source. The DefaultDataFunctions class defines\nconstants for commonly-supported aggregate functions.\n            ",
+        "description": "Processed data queries are used to request aggregated values for tags. The functions supported vary by data source. The DefaultDataFunctions class definesconstants for commonly-supported aggregate functions.",
         "operationId": "TagValues_GetSupportedDataFunctions",
         "parameters": [
           {
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The ID of the adapter to query.\n            ",
+            "description": "The ID of the adapter to query.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1711,7 +1761,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful responses contain descriptors for the aggregated function names that can \nbe specified.\n            ",
+            "description": "Successful responses contain descriptors for the aggregated function names that can be specified.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1726,20 +1776,20 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-values/{adapterId}/write/snapshot": {
+    "/api/app-store-connect/v1.0/tag-values/{adapterId}/write/snapshot": {
       "post": {
         "tags": [
           "TagValues"
         ],
-        "summary": "Writes values to an adapter's snapshot. Up to MaxSamplesPerWriteRequest \nvalues can be written in a single request.",
-        "description": "Up to MaxSamplesPerWriteRequest values can be written to the adapter \nin a single request. Subsequent values will be ignored. No corresponding \nWriteTagValueResult object will be returned for these items.\n            ",
+        "summary": "Writes values to an adapter's snapshot. Up to MaxSamplesPerWriteRequest values can be written in a single request.",
+        "description": "Up to MaxSamplesPerWriteRequest values can be written to the adapter in a single request. Subsequent values will be ignored. No corresponding WriteTagValueResult object will be returned for these items.",
         "operationId": "TagValues_WriteSnapshotValues",
         "parameters": [
           {
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The ID of the adapter to write to.\n            ",
+            "description": "The ID of the adapter to write to.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1749,7 +1799,7 @@
         ],
         "requestBody": {
           "x-name": "request",
-          "description": "The values to write.\n            ",
+          "description": "The values to write.",
           "content": {
             "application/json": {
               "schema": {
@@ -1762,7 +1812,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of WriteTagValueResult \nobjects (one per sample written).\n            ",
+            "description": "Successful responses contain a collection of WriteTagValueResult objects (one per sample written).",
             "content": {
               "application/json": {
                 "schema": {
@@ -1777,20 +1827,20 @@
         }
       }
     },
-    "/api/data-core/v1.0/tag-values/{adapterId}/write/history": {
+    "/api/app-store-connect/v1.0/tag-values/{adapterId}/write/history": {
       "post": {
         "tags": [
           "TagValues"
         ],
-        "summary": "Writes values to an adapter's historical archive. Up to MaxSamplesPerWriteRequest\nvalues can be written in a single request.",
-        "description": "Up to MaxSamplesPerWriteRequest values can be written to the adapter \nin a single request. Subsequent values will be ignored. No corresponding \nWriteTagValueResult object will be returned for these items.\n            ",
+        "summary": "Writes values to an adapter's historical archive. Up to MaxSamplesPerWriteRequestvalues can be written in a single request.",
+        "description": "Up to MaxSamplesPerWriteRequest values can be written to the adapter in a single request. Subsequent values will be ignored. No corresponding WriteTagValueResult object will be returned for these items.",
         "operationId": "TagValues_WriteHistoricalValues",
         "parameters": [
           {
             "name": "adapterId",
             "in": "path",
             "required": true,
-            "description": "The ID of the adapter to write to.\n            ",
+            "description": "The ID of the adapter to write to.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -1800,7 +1850,7 @@
         ],
         "requestBody": {
           "x-name": "values",
-          "description": "The values to write.\n            ",
+          "description": "The values to write.",
           "content": {
             "application/json": {
               "schema": {
@@ -1813,7 +1863,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful responses contain a collection of WriteTagValueResult \nobjects (one per sample written).\n            ",
+            "description": "Successful responses contain a collection of WriteTagValueResult objects (one per sample written).",
             "content": {
               "application/json": {
                 "schema": {
@@ -1990,7 +2040,7 @@
         "description": "Describes an adapter type.",
         "additionalProperties": false,
         "properties": {
-          "uri": {
+          "id": {
             "type": "string",
             "description": "The URI for the adapter type.",
             "format": "uri"

--- a/test/DataCore.Adapter.Tests/AssemblyInitializer.cs
+++ b/test/DataCore.Adapter.Tests/AssemblyInitializer.cs
@@ -43,7 +43,7 @@ namespace DataCore.Adapter.Tests {
             if (RunExternalWebHost) {
                 var services = new ServiceCollection();
                 WebHostConfiguration.ConfigureDefaultServices(services);
-                services.AddBackgroundTaskService();
+                services.AddAspNetCoreBackgroundTaskService();
 
 #if NET48
                 // Can't use Grpc.Net with .NET Framework, so need to allow gRPC proxies to be created using a Grpc.Core channel.

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -262,7 +262,7 @@ namespace DataCore.Adapter.Tests {
             }
 
             Assert.IsNotNull(actual.TypeDescriptor);
-            Assert.AreEqual(expected.TypeDescriptor.Uri, actual.TypeDescriptor.Uri);
+            Assert.AreEqual(expected.TypeDescriptor.Id, actual.TypeDescriptor.Id);
             Assert.AreEqual(expected.TypeDescriptor.Name, actual.TypeDescriptor.Name);
             Assert.AreEqual(expected.TypeDescriptor.Description, actual.TypeDescriptor.Description);
             Assert.IsNotNull(expected.TypeDescriptor.Vendor);


### PR DESCRIPTION
- `Uri` property on `AdapterTypeDescriptor` renamed to `Id`.
- Migrate some dependency injection functionality to new `DataCore.Adapter.DependencyInjection` project.
- Default API URL prefix going forwards is now `/api/app-store-connect/` instead of `/api/data-core/`.
  - All existing URLs are available under both prefixes.
