### PR TITLE
Unit test helpers

### DIFF
--- a/DataCore.Adapter.sln
+++ b/DataCore.Adapter.sln
@@ -87,7 +87,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.Proxy", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.Tests.WebHost", "test\DataCore.Adapter.Tests.WebHost\DataCore.Adapter.Tests.WebHost.csproj", "{D50F25F4-A0B1-4897-99B2-9E091B3516E5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataCore.Adapter.DependencyInjection", "src\DataCore.Adapter.DependencyInjection\DataCore.Adapter.DependencyInjection.csproj", "{5CD15B99-02B0-4BBD-9033-5DF46520F77D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.DependencyInjection", "src\DataCore.Adapter.DependencyInjection\DataCore.Adapter.DependencyInjection.csproj", "{5CD15B99-02B0-4BBD-9033-5DF46520F77D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Testing", "Testing", "{5E4F5BAB-DAA5-47B0-862A-B6E4173F146C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.Tests.Helpers", "src\DataCore.Adapter.Tests.Helpers\DataCore.Adapter.Tests.Helpers.csproj", "{7A247D52-A607-4810-B5DC-ACC3650CE5BF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -195,6 +199,10 @@ Global
 		{5CD15B99-02B0-4BBD-9033-5DF46520F77D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5CD15B99-02B0-4BBD-9033-5DF46520F77D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5CD15B99-02B0-4BBD-9033-5DF46520F77D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A247D52-A607-4810-B5DC-ACC3650CE5BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A247D52-A607-4810-B5DC-ACC3650CE5BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A247D52-A607-4810-B5DC-ACC3650CE5BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A247D52-A607-4810-B5DC-ACC3650CE5BF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -229,6 +237,8 @@ Global
 		{3B99AA8E-5B75-4188-BC84-5BFBA5265A00} = {041CEC9C-1271-4A4E-BEF6-6279A8B0FC97}
 		{D50F25F4-A0B1-4897-99B2-9E091B3516E5} = {1BF8C809-6F14-4C52-B172-D43A96295884}
 		{5CD15B99-02B0-4BBD-9033-5DF46520F77D} = {B158078F-D217-46FE-A9B8-7BD1B99922BA}
+		{5E4F5BAB-DAA5-47B0-862A-B6E4173F146C} = {004EC5B0-7D4E-4382-A139-A9BD049D99C4}
+		{7A247D52-A607-4810-B5DC-ACC3650CE5BF} = {5E4F5BAB-DAA5-47B0-862A-B6E4173F146C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {323415F4-D394-4EAA-B259-7C6834BFD819}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Some of the core projects in the repository are:
 * `DataCore.Adapter.Core` ([source](/src/DataCore.Adapter.Core)) - a library containing request and response types used by adapters.
 * `DataCore.Adapter.Abstractions` ([source](/src/DataCore.Adapter.Abstractions)) - a library that describes adapters themselves, and the features that they can expose.
 * `DataCore.Adapter` ([source](/src/DataCore.Adapter)) - a library that contains base classes and utility classes for simplifying the implementation of adapters and adapter features.
+* `DataCore.Adapter.DependencyInjection ([source](/src/DataCore.Adapter.DependencyInjection))` - types and extension methods for `Microsoft.Extensions.DependencyInjection`, to simplify the registration of required services with a dependency injection container.
+* `DataCore.Adapter.Json` ([source](/src/DataCore.Adapter.Json)) - converters for model types for the `System.Text.Json` JSON serializer.
 
 ## Hosting
 
@@ -47,6 +49,10 @@ Additionally, the [OpenAPI](https://swagger.io/) [swagger.json](/swagger.json) f
 ## Adapter Implementations
 
 * `DataCore.Adapter.Csv` ([source](/src/DataCore.Adapter.Csv)) - a library containing an adapter that uses CSV files to serve real-time and historical tag values.
+
+## Testing
+
+* `DataCore.Adapter.Tests.Helpers` ([source](/src/DataCore.Adapter.Tests.Helpers)) - base classes that provide MSTest unit tests for standard adapter features.
 
 ## Example Projects
 

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -46,7 +46,7 @@
   <PropertyGroup>
     <CastleCoreVersion>4.4.1</CastleCoreVersion>
     <CsvHelperVersion>15.0.5</CsvHelperVersion>
-    <IntelligentPlantBackgroundTasksVersion>4.0.0</IntelligentPlantBackgroundTasksVersion>
+    <IntelligentPlantBackgroundTasksVersion>4.0.1</IntelligentPlantBackgroundTasksVersion>
     <JaahasHttpRequestTransformerVersion>1.0.1</JaahasHttpRequestTransformerVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
     <NSwagAspNetCoreVersion>13.7.0</NSwagAspNetCoreVersion>

--- a/src/DataCore.Adapter.DependencyInjection/README.md
+++ b/src/DataCore.Adapter.DependencyInjection/README.md
@@ -1,0 +1,8 @@
+﻿# DataCore.Adapter.DependencyInjection
+
+`Microsoft.Extensions.DependencyInjection` extensions for registering support features for App Store Connect adapters.
+
+
+# Installation
+
+Add a NuGet package reference to [IntelligentPlant.AppStoreConnect.Adapter.DependencyInjection](https://www.nuget.org/packages/IntelligentPlant.AppStoreConnect.Adapter.DependencyInjection).

--- a/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
+++ b/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -61,7 +62,14 @@ namespace DataCore.Adapter.Tests {
         /// <returns>
         ///   A new <see cref="IAdapterCallContext"/> instance.
         /// </returns>
-        protected abstract IAdapterCallContext CreateCallContext(TestContext context);
+        protected virtual IAdapterCallContext CreateCallContext(TestContext context) {
+            var identity = new ClaimsIdentity(GetType().FullName, ClaimTypes.Name, ClaimTypes.Role);
+            identity.AddClaim(new Claim(ClaimTypes.Name, context!.TestName));
+
+            var principal = new ClaimsPrincipal(identity);
+
+            return new DefaultAdapterCallContext(principal);
+        }
 
 
         /// <summary>

--- a/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
+++ b/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
@@ -1,0 +1,1908 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.AssetModel;
+using DataCore.Adapter.Common;
+using DataCore.Adapter.Diagnostics;
+using DataCore.Adapter.Events;
+using DataCore.Adapter.Extensions;
+using DataCore.Adapter.RealTimeData;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DataCore.Adapter.Tests {
+
+    /// <summary>
+    /// Base class that defines basic tests for adapter features.
+    /// </summary>
+    /// <typeparam name="TAdapter">
+    ///   The adapter type for the tests.
+    /// </typeparam>
+    public abstract class AdapterTestsBase<TAdapter> : TestsBase where TAdapter : class, IAdapter {
+
+        /// <summary>
+        /// Creates an <see cref="IServiceScope"/> for the current test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="IServiceScope"/> instance.
+        /// </returns>
+        protected abstract IServiceScope CreateServiceScope(TestContext context);
+
+
+        /// <summary>
+        /// Creates a <typeparamref name="TAdapter"/> instance for use the the current test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <param name="serviceProvider">
+        ///   The service provider for the test.
+        /// </param>
+        /// <returns>
+        ///   A new <typeparamref name="TAdapter"/> instance.
+        /// </returns>
+        protected abstract TAdapter CreateAdapter(TestContext context, IServiceProvider serviceProvider);
+
+
+        /// <summary>
+        /// Creates an <see cref="IAdapterCallContext"/> for use in the current test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="IAdapterCallContext"/> instance.
+        /// </returns>
+        protected abstract IAdapterCallContext CreateCallContext(TestContext context);
+
+
+        /// <summary>
+        /// Creates and initialises a <typeparamref name="TAdapter"/> instance and runs an adapter 
+        /// test.
+        /// </summary>
+        /// <param name="callback">
+        ///   The callback delegate that will perform the test.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        protected async Task RunAdapterTest(Func<TAdapter, IAdapterCallContext, CancellationToken, Task> callback) {
+            if (callback == null) {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
+            using (var scope = CreateServiceScope(TestContext)) {
+                var adapter = CreateAdapter(TestContext, scope.ServiceProvider);
+                if (adapter == null) {
+                    Assert.Inconclusive("Adapter creation delegate returned null.");
+                    return;
+                }
+
+                try {
+                    await adapter.StartAsync(CancellationToken).ConfigureAwait(false);
+                    var context = CreateCallContext(TestContext);
+                    await callback(adapter, context, CancellationToken).ConfigureAwait(false);
+                }
+                finally {
+                    if (adapter is IAsyncDisposable iad) {
+                        await iad.DisposeAsync().ConfigureAwait(false);
+                    }
+                    else if (adapter is IDisposable id) {
+                        id.Dispose();
+                    }
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="AssertInconclusiveException"/> that indicates that a test was 
+        /// skipped due to a required feature not being implemented on the adapter.
+        /// </summary>
+        /// <typeparam name="TFeature">
+        ///   The missing feature.
+        /// </typeparam>
+        protected void AssertFeatureNotImplemented<TFeature>() {
+            Assert.Inconclusive($"Feature not implemented: {typeof(TFeature).Name}");
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="AssertInconclusiveException"/> that indicates that a test was 
+        /// skipped due to a required feature not being implemented on the adapter.
+        /// </summary>
+        /// <param name="feature">
+        ///   The missing feature name.
+        /// </param>
+        protected void AssertFeatureNotImplemented(string feature) {
+            Assert.Inconclusive($"Feature not implemented: {feature}");
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="AssertInconclusiveException"/> that indicates that a test was 
+        /// skipped due to a input data generation method returning <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="TFeature">
+        ///   The missing feature.
+        /// </typeparam>
+        /// <param name="methodName">
+        ///   The method that must be overridden.
+        /// </param>
+        private void AssertInconclusiveDueToMissingTestInput<TFeature>(string methodName) {
+            Assert.Fail($"Adapter implements {typeof(TFeature).Name}, but the '{methodName}' method used to generate input data for test '{TestContext.TestName}' returned null. Override {methodName} in your test class to return the input data to use for this test.");
+        }
+
+
+        /// <summary>
+        /// Reads all items from a <see cref="ChannelReader{T}"/> into an <see cref="IEnumerable{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The channel item type.
+        /// </typeparam>
+        /// <param name="channel">
+        ///   The channel reader.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that will return the items that were read from the channel.
+        /// </returns>
+        private static async Task<IEnumerable<T>> ReadAllAsync<T>(ChannelReader<T> channel, CancellationToken cancellationToken) {
+            var result = new List<T>();
+
+            while (await channel.WaitToReadAsync(cancellationToken).ConfigureAwait(false)) {
+                while (channel.TryRead(out var item)) {
+                    result.Add(item);
+                }
+            }
+
+            return result;
+        }
+
+        #region [ IAdapter ]
+
+        /// <summary>
+        /// Verifies that the adapter's <see cref="IBackgroundTaskServiceProvider.BackgroundTaskService"/> 
+        /// property is not <see langword="null"/>.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public Task AdapterBackgroundTaskServiceShouldNotBeNull() {
+            return RunAdapterTest((adapter, context, ct) => {
+                Assert.IsNotNull(adapter.BackgroundTaskService);
+                return Task.CompletedTask;
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that the adapter's <see cref="IAdapter.Descriptor"/> property is not 
+        /// <see langword="null"/>.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public Task AdapterDescriptorShouldNotBeNull() {
+            return RunAdapterTest((adapter, context, ct) => {
+                Assert.IsNotNull(adapter.Descriptor);
+                return Task.CompletedTask;
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that the adapter's <see cref="IAdapter.Features"/> property is not 
+        /// <see langword="null"/>.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public Task AdapterFeaturesShouldNotBeNull() {
+            return RunAdapterTest((adapter, context, ct) => {
+                Assert.IsNotNull(adapter.Features);
+                return Task.CompletedTask;
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that the adapter's <see cref="IAdapter.Properties"/> property is not 
+        /// <see langword="null"/>, and that none of the entries in the collection are 
+        /// <see langword="null"/>.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public Task AdapterPropertiesShouldNotBeNull() {
+            return RunAdapterTest((adapter, context, ct) => {
+                Assert.IsNotNull(adapter.Properties);
+                if (adapter.Properties.Any()) {
+                    Assert.IsTrue(adapter.Properties.All(x => x != null), $"{nameof(IAdapter)}.{nameof(IAdapter.Properties)} entries should not be null.");
+                }
+                return Task.CompletedTask;
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that the adapter's <see cref="IAdapter.TypeDescriptor"/> property is not 
+        /// <see langword="null"/>.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public Task AdapterTypeDescriptorShouldNotBeNull() {
+            return RunAdapterTest((adapter, context, ct) => {
+                Assert.IsNotNull(adapter.TypeDescriptor);
+                return Task.CompletedTask;
+            });
+        }
+
+        #endregion
+
+        #region [ IHealthCheck ]
+
+        /// <summary>
+        /// Verifies that a <see cref="HealthCheckResult.Status"/> property matches the aggregate 
+        /// status of its inner results.
+        /// </summary>
+        /// <param name="health">
+        ///   The health check result.
+        /// </param>
+        private void VerifyHealthCheckResult(HealthCheckResult health) {
+            if (health.InnerResults != null && health.InnerResults.Any()) {
+                foreach (var item in health.InnerResults) {
+                    VerifyHealthCheckResult(item);
+                }
+
+                // If there are any inner results, ensure that the overall status matches the 
+                // aggregate status of the inner results.
+                Assert.AreEqual(health.Status, HealthCheckResult.GetAggregateHealthStatus(health.InnerResults.Select(x => x.Status)));
+            }
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IHealthCheck.CheckHealthAsync"/> returns a value.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will perform the test.
+        /// </returns>
+        [TestMethod]
+        public virtual Task CheckHealthRequestShouldSucceed() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IHealthCheck>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IHealthCheck>();
+                    return;
+                }
+
+                var health = await feature.CheckHealthAsync(context, ct).ConfigureAwait(false);
+                Assert.AreNotEqual(default, health, $"Adapter should not return default({nameof(HealthCheckResult)}) as their health status.");
+                VerifyHealthCheckResult(health);
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IHealthCheck.Subscribe"/> pushes an initial value when a 
+        /// subscription is created.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will perform the test.
+        /// </returns>
+        [TestMethod]
+        public virtual Task HealthCheckSubscriptionShouldReceiveInitialValue() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IHealthCheck>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IHealthCheck>();
+                    return;
+                }
+
+                var subscription = await feature.Subscribe(context, ct).ConfigureAwait(false);
+                Assert.IsNotNull(subscription);
+
+                var health = await subscription.ReadAsync(ct).ConfigureAwait(false);
+                VerifyHealthCheckResult(health);
+            });
+        }
+
+        #endregion
+
+        #region [ ITagInfo ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="GetTagPropertiesRequestShouldSucceed"/> test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="GetTagsPropertiesRequest"/> to use.
+        /// </returns>
+        protected virtual GetTagPropertiesRequest CreateGetTagPropertiesRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="GetTagsRequestShouldReturnResults"/> test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="GetTagsRequest"/> to use.
+        /// </returns>
+        protected virtual GetTagsRequest CreateGetTagsRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="ITagInfo.GetTagProperties"/> returns a non-null channel, that 
+        /// the channel completes, and that none of the property definitions returned are 
+        /// <see langword="null"/>.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public virtual Task GetTagPropertiesRequestShouldSucceed() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<ITagInfo>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<ITagInfo>();
+                    return;
+                }
+
+                var request = CreateGetTagPropertiesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<ITagInfo>(nameof(CreateGetTagPropertiesRequest));
+                    return;
+                }
+
+                var channel = await feature.GetTagProperties(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+
+                var props = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.IsTrue(props.Count() <= request.PageSize, $"Response contained {props.Count()} items, but the request page size was {request.PageSize}.");
+
+                if (props.Any()) {
+                    Assert.IsTrue(props.All(x => x != null), "Adapters must not return null tag properties.");
+                }
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="ITagInfo.GetTags"/> returns the expected results.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public virtual Task GetTagsRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<ITagInfo>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<ITagInfo>();
+                    return;
+                }
+
+                var request = CreateGetTagsRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<ITagInfo>(nameof(CreateGetTagsRequest));
+                    return;
+                }
+
+                var channel = await feature.GetTags(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+
+                var tags = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+
+                Assert.AreEqual(request.Tags.Count(), tags.Count());
+
+                var remainingTags = new HashSet<string>(request.Tags);
+
+                foreach (var tag in tags) {
+                    Assert.IsNotNull(tag);
+                    Assert.IsTrue(remainingTags.Remove(tag.Id) || remainingTags.Remove(tag.Name), $"Expected tags list does not contain ID '{tag.Id}' or name '{tag.Name}'.");
+                    if (tag.Properties.Any()) {
+                        Assert.IsTrue(tag.Properties.All(x => x != null), $"Tag '{tag.Name}' (ID: '{tag.Id}') contains a null entry in its {nameof(TagDefinition.Properties)} collection.");
+                    }
+                }
+
+                Assert.AreEqual(0, remainingTags.Count, $"Definitions were not received for the following tags: {string.Join(", ", remainingTags)}");
+            });
+        }
+
+        #endregion
+
+        #region [ ITagSearch ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="FindTagsRequestShouldReturnResults"/> test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="FindTagsRequest"/> to use.
+        /// </returns>
+        protected virtual FindTagsRequest CreateFindTagsRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="ITagSearch.FindTags"/> returns results, and that the results 
+        /// match the constraints specified in the request.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public virtual Task FindTagsRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<ITagSearch>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<ITagSearch>();
+                    return;
+                }
+
+                var request = CreateFindTagsRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<ITagSearch>(nameof(CreateFindTagsRequest));
+                    return;
+                }
+
+                var channel = await feature.FindTags(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+
+                var tags = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+
+                Assert.IsTrue(tags.Count() <= request.PageSize);
+
+                foreach (var tag in tags) {
+                    Assert.IsNotNull(tag);
+                    if (tag.Properties.Any()) {
+                        Assert.IsTrue(tag.Properties.All(x => x != null), $"Tag '{tag.Name}' (ID: '{tag.Id}') contains a null entry in its {nameof(TagDefinition.Properties)} collection.");
+                    }
+                }
+            });
+        }
+
+        #endregion
+
+        #region [ IReadSnapshotTagValues ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="ReadSnapshotTagValuesRequestShouldReturnResults"/>, 
+        /// <see cref="SnapshotTagValueSubscriptionShouldReceiveInitialValues"/> and 
+        /// <see cref="SnapshotTagValueSubscriptionShouldAllowSubscriptionChanges"/> tests.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ReadSnapshotTagValuesRequest"/> to use.
+        /// </returns>
+        protected virtual ReadSnapshotTagValuesRequest CreateReadSnapshotTagValuesRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IReadSnapshotTagValues.ReadSnapshotTagValues"/> returns values.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadSnapshotTagValuesRequest"/>
+        [TestMethod]
+        public virtual Task ReadSnapshotTagValuesRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadSnapshotTagValues>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadSnapshotTagValues>();
+                    return;
+                }
+
+                var request = CreateReadSnapshotTagValuesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IReadSnapshotTagValues>(nameof(CreateReadSnapshotTagValuesRequest));
+                    return;
+                }
+
+                var channel = await feature.ReadSnapshotTagValues(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+                var values = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+
+                var remainingTags = new HashSet<string>(request.Tags);
+
+                Assert.AreEqual(remainingTags.Count, values.Count());
+
+                foreach (var value in values) {
+                    Assert.IsNotNull(value);
+                    Assert.IsTrue(remainingTags.Remove(value.TagId) || remainingTags.Remove(value.TagName), $"Expected tags list does not contain ID '{value.TagId}' or name '{value.TagName}'.");
+                }
+
+                Assert.AreEqual(0, remainingTags.Count, $"Values were not received for the following tags: {string.Join(", ", remainingTags)}");
+            });
+        }
+
+        #endregion
+
+        #region [ ISnapshotTagValuePush ]
+
+        /// <summary>
+        /// Verifies that <see cref="ISnapshotTagValuePush.Subscribe"/> returns values for tags 
+        /// that are specified in the initial subscription request.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadSnapshotTagValuesRequest"/>
+        [TestMethod]
+        public virtual Task SnapshotTagValueSubscriptionShouldReceiveInitialValues() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<ISnapshotTagValuePush>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<ISnapshotTagValuePush>();
+                    return;
+                }
+
+                var request = CreateReadSnapshotTagValuesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<ISnapshotTagValuePush>(nameof(CreateReadSnapshotTagValuesRequest));
+                    return;
+                }
+
+                var subscription = await feature.Subscribe(context, new CreateSnapshotTagValueSubscriptionRequest() {
+                    Tags = request.Tags,
+                    Properties = request.Properties
+                }, ct).ConfigureAwait(false);
+
+                Assert.IsNotNull(subscription);
+
+                var allTags = new HashSet<string>(request.Tags);
+                var remainingTags = new HashSet<string>(request.Tags);
+
+                while (await subscription.WaitToReadAsync(ct).ConfigureAwait(false)) {
+                    while (subscription.TryRead(out var value)) {
+                        Assert.IsNotNull(value);
+                        if (allTags.Contains(value.TagId)) {
+                            remainingTags.Remove(value.TagId);
+                        }
+                        else if (allTags.Contains(value.TagName)) {
+                            remainingTags.Remove(value.TagName);
+                        }
+                        else {
+                            Assert.Fail($"Expected tags list does not contain ID '{value.TagId}' or name '{value.TagName}'.");
+                        }
+                    }
+
+                    if (remainingTags.Count == 0) {
+                        break;
+                    }
+                }
+
+                Assert.AreEqual(0, remainingTags.Count, $"Values were not received for the following tags: {string.Join(", ", remainingTags)}");
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="ISnapshotTagValuePush.Subscribe"/> returns values for tags 
+        /// that are added to a subscription after the subscription has been created.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadSnapshotTagValuesRequest"/>
+        [TestMethod]
+        public virtual Task SnapshotTagValueSubscriptionShouldAllowSubscriptionChanges() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<ISnapshotTagValuePush>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<ISnapshotTagValuePush>();
+                    return;
+                }
+
+                var request = CreateReadSnapshotTagValuesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<ISnapshotTagValuePush>(nameof(CreateReadSnapshotTagValuesRequest));
+                    return;
+                }
+
+                var channel = Channel.CreateUnbounded<TagValueSubscriptionUpdate>();
+
+                var subscription = await feature.Subscribe(context, new CreateSnapshotTagValueSubscriptionRequest() { Properties = request.Properties }, channel.Reader, ct).ConfigureAwait(false);
+
+                Assert.IsNotNull(subscription);
+
+                // Now add the tags to the subscription.
+
+                channel.Writer.TryWrite(new TagValueSubscriptionUpdate() {
+                    Action = SubscriptionUpdateAction.Subscribe,
+                    Tags = request.Tags
+                });
+
+                var allTags = new HashSet<string>(request.Tags);
+                var remainingTags = new HashSet<string>(request.Tags);
+
+                while (await subscription.WaitToReadAsync(ct).ConfigureAwait(false)) {
+                    while (subscription.TryRead(out var val)) {
+                        Assert.IsNotNull(val);
+                        if (allTags.Contains(val.TagId)) {
+                            remainingTags.Remove(val.TagId);
+                        }
+                        else if (allTags.Contains(val.TagName)) {
+                            remainingTags.Remove(val.TagName);
+                        }
+                        else {
+                            Assert.Fail($"Expected tags list does not contain ID '{val.TagId}' or name '{val.TagName}'.");
+                        }
+                    }
+
+                    if (remainingTags.Count == 0) {
+                        break;
+                    }
+                }
+
+                Assert.AreEqual(0, remainingTags.Count, $"Values were not received for the following tags: {string.Join(", ", remainingTags)}");
+            });
+        }
+
+        #endregion
+
+        #region [ IReadRawTagValues ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="ReadRawTagValuesRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ReadRawTagValuesRequest"/> to use.
+        /// </returns>
+        protected virtual ReadRawTagValuesRequest CreateReadRawTagValuesRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IReadRawTagValues.ReadRawTagValues"/> returns values, and 
+        /// that the values returned match the constraints specified in the data request.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadRawTagValuesRequest"/>
+        [TestMethod]
+        public virtual Task ReadRawTagValuesRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadRawTagValues>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadRawTagValues>();
+                    return;
+                }
+
+                var request = CreateReadRawTagValuesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IReadRawTagValues>(nameof(CreateReadRawTagValuesRequest));
+                    return;
+                }
+
+                var channel = await feature.ReadRawTagValues(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+                var values = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+
+                var allTags = new HashSet<string>(request.Tags);
+                var remainingTags = new HashSet<string>(request.Tags);
+
+                Assert.IsTrue(values.Any());
+
+                foreach (var value in values) {
+                    Assert.IsNotNull(value);
+
+                    if (allTags.Contains(value.TagId)) {
+                        remainingTags.Remove(value.TagId);
+                    }
+                    else if (allTags.Contains(value.TagName)) {
+                        remainingTags.Remove(value.TagName);
+                    }
+                    else {
+                        Assert.Fail($"Expected tags list does not contain ID '{value.TagId}' or name '{value.TagName}'.");
+                    }
+                }
+
+                Assert.AreEqual(0, remainingTags.Count, $"Values were not received for the following tags: {string.Join(", ", remainingTags)}");
+
+                foreach (var valuesForTag in values.ToLookup(x => x.TagId)) {
+                    if (request.BoundaryType == RawDataBoundaryType.Inside) {
+                        Assert.IsTrue(valuesForTag.All(x => x.Value.UtcSampleTime >= request.UtcStartTime));
+                        Assert.IsTrue(valuesForTag.All(x => x.Value.UtcSampleTime <= request.UtcEndTime));
+                    }
+                    else {
+                        // Allow zero or one values earlier than the query start time.
+                        Assert.AreEqual(0, valuesForTag.Count(x => x.Value.UtcSampleTime < request.UtcStartTime), 1);
+                        // Allow zero or one values later than the query end time.
+                        Assert.AreEqual(0, valuesForTag.Count(x => x.Value.UtcSampleTime > request.UtcEndTime), 1);
+                    }
+
+                    if (request.SampleCount > 0) {
+                        Assert.IsTrue(valuesForTag.Count() <= request.SampleCount, $"Expected a maximum of {request.SampleCount} samples for tag '{valuesForTag.Key}', but {valuesForTag.Count()} samples were received.");
+                    }
+                }
+            });
+        }
+
+        #endregion
+
+        #region [ IReadPlotTagValues ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="ReadPlotTagValuesRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ReadPlotTagValuesRequest"/> to use.
+        /// </returns>
+        protected virtual ReadPlotTagValuesRequest CreateReadPlotTagValuesRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IReadPlotTagValues.ReadPlotTagValues"/> returns values, and 
+        /// that the values returned match the constraints specified in the data request.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadPlotTagValuesRequest"/>
+        [TestMethod]
+        public virtual Task ReadPlotTagValuesRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadPlotTagValues>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadPlotTagValues>();
+                    return;
+                }
+
+                var request = CreateReadPlotTagValuesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IReadPlotTagValues>(nameof(CreateReadPlotTagValuesRequest));
+                    return;
+                }
+
+                var channel = await feature.ReadPlotTagValues(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+                var values = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+
+                var allTags = new HashSet<string>(request.Tags);
+                var remainingTags = new HashSet<string>(request.Tags);
+
+                Assert.IsTrue(values.Any());
+
+                foreach (var value in values) {
+                    Assert.IsNotNull(value);
+
+                    if (allTags.Contains(value.TagId)) {
+                        remainingTags.Remove(value.TagId);
+                    }
+                    else if (allTags.Contains(value.TagName)) {
+                        remainingTags.Remove(value.TagName);
+                    }
+                    else {
+                        Assert.Fail($"Expected tags list does not contain ID '{value.TagId}' or name '{value.TagName}'.");
+                    }
+
+                    Assert.IsTrue(value.Value.UtcSampleTime >= request.UtcStartTime, $"Request start time was {request.UtcStartTime}, but sample time was {value.Value.UtcSampleTime}.");
+                    Assert.IsTrue(value.Value.UtcSampleTime <= request.UtcEndTime, $"Request end time was {request.UtcEndTime}, but sample time was {value.Value.UtcSampleTime}.");
+                }
+
+                Assert.AreEqual(0, remainingTags.Count, $"Values were not received for the following tags: {string.Join(", ", remainingTags)}");
+            });
+        }
+
+        #endregion
+
+        #region [ IReadProcessedTagValues ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="ReadProcessedTagValuesRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ReadProcessedTagValuesRequest"/> to use.
+        /// </returns>
+        protected virtual ReadProcessedTagValuesRequest CreateReadProcessedTagValuesRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IReadProcessedTagValues.GetSupportedDataFunctions"/> returns values.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadProcessedTagValuesRequest"/>
+        [TestMethod]
+        public virtual Task GetSupportedDataFunctionsRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadProcessedTagValues>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadProcessedTagValues>();
+                    return;
+                }
+
+                var channel = await feature.GetSupportedDataFunctions(context, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+                var dataFunctions = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+
+                Assert.IsTrue(dataFunctions.Any(), $"Adapters implementing {nameof(IReadProcessedTagValues)} should define at least one data function that can be called.");
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IReadProcessedTagValues.ReadProcessedTagValues"/> returns values, and 
+        /// that the values returned match the constraints specified in the data request.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadProcessedTagValuesRequest"/>
+        [TestMethod]
+        public virtual Task ReadProcessedTagValuesRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadProcessedTagValues>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadProcessedTagValues>();
+                    return;
+                }
+
+                var request = CreateReadProcessedTagValuesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IReadProcessedTagValues>(nameof(CreateReadProcessedTagValuesRequest));
+                    return;
+                }
+
+                var channel = await feature.ReadProcessedTagValues(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+                var values = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+
+                var dataFunctions = new List<string>(request.DataFunctions);
+                var allTags = new HashSet<string>(request.Tags);
+                var remainingTags = new HashSet<string>(request.Tags);
+
+                Assert.IsTrue(values.Any());
+
+                foreach (var value in values) {
+                    Assert.IsNotNull(value);
+
+                    Assert.IsTrue(dataFunctions.Contains(value.DataFunction), $"Data function '{value.DataFunction}' is unexpected.");
+
+                    if (allTags.Contains(value.TagId)) {
+                        remainingTags.Remove(value.TagId);
+                    }
+                    else if (allTags.Contains(value.TagName)) {
+                        remainingTags.Remove(value.TagName);
+                    }
+                    else {
+                        Assert.Fail($"Expected tags list does not contain ID '{value.TagId}' or name '{value.TagName}'.");
+                    }
+
+                    Assert.IsTrue(value.Value.UtcSampleTime >= request.UtcStartTime, $"Request start time was {request.UtcStartTime}, but sample time was {value.Value.UtcSampleTime}.");
+                    Assert.IsTrue(value.Value.UtcSampleTime <= request.UtcEndTime, $"Request end time was {request.UtcEndTime}, but sample time was {value.Value.UtcSampleTime}.");
+                }
+
+                Assert.AreEqual(0, remainingTags.Count, $"Values were not received for the following tags: {string.Join(", ", remainingTags)}");
+            });
+        }
+
+        #endregion
+
+        #region [ IReadTagValuesAtTimes ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="ReadTagValuesAtTimesRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ReadTagValuesAtTimesRequest"/> to use.
+        /// </returns>
+        protected virtual ReadTagValuesAtTimesRequest CreateReadTagValuesAtTimesRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IReadProcessedTagValues.ReadProcessedTagValues"/> returns values, and 
+        /// that the values returned match the constraints specified in the data request.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadTagValuesAtTimesRequest"/>
+        [TestMethod]
+        public virtual Task ReadTagValuesAtTimesRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadTagValuesAtTimes>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadTagValuesAtTimes>();
+                    return;
+                }
+
+                var request = CreateReadTagValuesAtTimesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IReadTagValuesAtTimes>(nameof(CreateReadTagValuesAtTimesRequest));
+                    return;
+                }
+
+                var channel = await feature.ReadTagValuesAtTimes(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+                var values = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+
+                var allTimestamps = new HashSet<DateTime>(request.UtcSampleTimes);
+                var allTags = new HashSet<string>(request.Tags);
+                var remainingTags = new HashSet<string>(request.Tags);
+
+                Assert.IsTrue(values.Any());
+
+                foreach (var value in values) {
+                    Assert.IsNotNull(value);
+
+                    if (allTags.Contains(value.TagId)) {
+                        remainingTags.Remove(value.TagId);
+                    }
+                    else if (allTags.Contains(value.TagName)) {
+                        remainingTags.Remove(value.TagName);
+                    }
+                    else {
+                        Assert.Fail($"Expected tags list does not contain ID '{value.TagId}' or name '{value.TagName}'.");
+                    }
+
+                    Assert.IsTrue(allTimestamps.Contains(value.Value.UtcSampleTime), $"Sample time {value.Value.UtcSampleTime} was not found in the expected sample times list.");
+                }
+
+                Assert.AreEqual(0, remainingTags.Count, $"Values were not received for the following tags: {string.Join(", ", remainingTags)}");
+
+                foreach (var valuesForTag in values.ToLookup(x => x.TagId)) {
+                    var remainingTimestamps = new HashSet<DateTime>(request.UtcSampleTimes);
+                    foreach (var value in valuesForTag) {
+                        Assert.IsTrue(remainingTimestamps.Remove(value.Value.UtcSampleTime), $"Sample time {value.Value.UtcSampleTime} was not found in the expected sample times list. This indicates that multiple values were received with this timestamp for tag '{value.TagName}'.");
+                    }
+                    Assert.AreEqual(0, remainingTimestamps.Count, $"Values were not received for the following timestamps for tag '{valuesForTag.Key}': {string.Join(", ", remainingTimestamps)}");
+                }
+            });
+        }
+
+        #endregion
+
+        #region [ IReadTagValueAnnotations ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="ReadTagValueAnnotationsRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ReadAnnotationsRequest"/> to use.
+        /// </returns>
+        protected virtual ReadAnnotationsRequest CreateReadAnnotationsRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="ReadTagValueAnnotationRequestShouldReturnResult"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ReadAnnotationRequest"/> to use.
+        /// </returns>
+        protected virtual ReadAnnotationRequest CreateReadAnnotationRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IReadTagValueAnnotations.ReadAnnotations"/> returns values, 
+        /// and that the values match the constraints of the request.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadAnnotationsRequest"/>
+        [TestMethod]
+        public virtual Task ReadTagValueAnnotationsRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadTagValueAnnotations>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadTagValueAnnotations>();
+                    return;
+                }
+
+                var request = CreateReadAnnotationsRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IReadTagValueAnnotations>(nameof(CreateReadAnnotationsRequest));
+                    return;
+                }
+
+                var channel = await feature.ReadAnnotations(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+
+                var annotations = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.IsTrue(annotations.Any());
+
+                var allTags = new HashSet<string>(request.Tags);
+                var remainingTags = new HashSet<string>(request.Tags);
+
+                foreach (var annotation in annotations) {
+                    Assert.IsNotNull(annotation);
+
+                    if (allTags.Contains(annotation.TagId)) {
+                        remainingTags.Remove(annotation.TagId);
+                    }
+                    else if (allTags.Contains(annotation.TagName)) {
+                        remainingTags.Remove(annotation.TagName);
+                    }
+                    else {
+                        Assert.Fail($"Expected tags list does not contain ID '{annotation.TagId}' or name '{annotation.TagName}'.");
+                    }
+
+                    if (annotation.Annotation.AnnotationType == AnnotationType.TimeRange) {
+                        // Time range
+                        if (annotation.Annotation.UtcEndTime.HasValue) {
+                            // Annotation has completed.
+                            Assert.IsTrue(
+                                annotation.Annotation.UtcStartTime <= annotation.Annotation.UtcEndTime.Value, 
+                                $"Annotation cannot end before it has started: '{annotation.TagName}' @ {annotation.Annotation.UtcStartTime}"
+                            );
+
+                            if (annotation.Annotation.UtcStartTime < request.UtcStartTime) {
+                                // Annotation started before request start time; it must end at or after the request start time.
+                                Assert.IsTrue(
+                                    annotation.Annotation.UtcEndTime.Value >= request.UtcStartTime, 
+                                    $"Annotations starting before the request start time must end after the request start time to be returned in the query: '{annotation.TagName}' @ {annotation.Annotation.UtcStartTime}"
+                                );
+                            }
+                            else {
+                                // Annotation started after the request start time; it must also start at or before the query end time.
+                                Assert.IsTrue(
+                                    annotation.Annotation.UtcStartTime <= request.UtcEndTime, 
+                                    $"Annotation time range does not overlap with the query time range: '{annotation.TagName}' @ {annotation.Annotation.UtcStartTime}"
+                                );
+                            }
+                        }
+                        else {
+                            // The annotation is ongoing. It must have started at or before the request end time.
+                            Assert.IsTrue(
+                                annotation.Annotation.UtcStartTime <= request.UtcEndTime,
+                                $"Annotation started after the query end time: '{annotation.TagName}' @ {annotation.Annotation.UtcStartTime}"
+                            );
+                        }
+                    }
+                    else {
+                        // Instantaneous
+                        Assert.IsTrue(annotation.Annotation.UtcStartTime >= request.UtcStartTime);
+                        Assert.IsTrue(annotation.Annotation.UtcStartTime <= request.UtcEndTime);
+                    }
+                }
+
+                Assert.AreEqual(0, remainingTags.Count, $"Annotations were not received for the following tags: {string.Join(", ", remainingTags)}");
+
+                if (request.AnnotationCount > 0) {
+                    foreach (var valuesForTag in annotations.ToLookup(x => x.TagId)) {
+                        Assert.IsTrue(valuesForTag.Count() <= request.AnnotationCount, $"Expected a maximum of {request.AnnotationCount} annotations for tag '{valuesForTag.Key}', but {valuesForTag.Count()} annotations were received.");
+                    }
+                }
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IReadTagValueAnnotations.ReadAnnotation"/> returns values, 
+        /// and that the values match the constraints of the request.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadAnnotationRequest"/>
+        [TestMethod]
+        public virtual Task ReadTagValueAnnotationRequestShouldReturnResult() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadTagValueAnnotations>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadTagValueAnnotations>();
+                    return;
+                }
+
+                var request = CreateReadAnnotationRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IReadTagValueAnnotations>(nameof(CreateReadAnnotationRequest));
+                    return;
+                }
+
+                var annotation = await feature.ReadAnnotation(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(annotation);
+                Assert.AreEqual(request.AnnotationId, annotation.Id);
+            });
+        }
+
+        #endregion
+
+        #region [ IWriteSnapshotTagValues ]
+
+        /// <summary>
+        /// Gets the items to write for the <see cref="WriteSnapshotTagValuesShouldSucceed"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The collection of <see cref="WriteTagValueItem"/> objects to use.
+        /// </returns>
+        protected virtual IEnumerable<WriteTagValueItem> CreateWriteSnapshotTagValueItems() {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IWriteSnapshotTagValues.WriteSnapshotTagValues"/> returns a 
+        /// result for every item that is written.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateWriteSnapshotTagValueItems"/>
+        [TestMethod]
+        public virtual Task WriteSnapshotTagValuesShouldSucceed() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IWriteSnapshotTagValues>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IWriteSnapshotTagValues>();
+                    return;
+                }
+
+                var writeItems = CreateWriteSnapshotTagValueItems();
+                if (writeItems == null) {
+                    AssertInconclusiveDueToMissingTestInput<IWriteSnapshotTagValues>(nameof(CreateWriteSnapshotTagValueItems));
+                    return;
+                }
+
+                var inChannel = Channel.CreateUnbounded<WriteTagValueItem>();
+                foreach (var item in writeItems) {
+                    item.CorrelationId = Guid.NewGuid().ToString();
+                    inChannel.Writer.TryWrite(item);
+                }
+                inChannel.Writer.TryComplete();
+
+                var channel = await feature.WriteSnapshotTagValues(context, inChannel.Reader, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+
+                var writeResults = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.AreEqual(writeItems.Count(), writeResults.Count(), "Incorrect number of write results received.");
+
+                var expectedCorrelationIds = new HashSet<string>(writeItems.Select(x => x.CorrelationId!));
+
+                foreach (var writeResult in writeResults) {
+                    Assert.IsNotNull(writeResult, "Null write result was returned.");
+                    Assert.IsNotNull(writeResult.CorrelationId, "Write result correlation ID should not be null because a correlation ID was specified on all values that were written.");
+                    Assert.IsTrue(expectedCorrelationIds.Remove(writeResult.CorrelationId!), $"Write result returned an unknown correlation ID: {writeResult.CorrelationId}");
+                    Assert.AreNotEqual(WriteStatus.Fail, writeResult.Status, "Write status indicates failure.");
+                }
+
+                Assert.AreEqual(0, expectedCorrelationIds.Count, $"Write results were not returned for the following correlation IDs: {string.Join(", ", expectedCorrelationIds)}");
+            });
+        }
+
+        #endregion
+
+        #region [ IWriteHistoricalTagValues ]
+
+        /// <summary>
+        /// Gets the items to write for the <see cref="WriteHistoricalTagValuesShouldSucceed"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The collection of <see cref="WriteTagValueItem"/> objects to use.
+        /// </returns>
+        protected virtual IEnumerable<WriteTagValueItem> CreateWriteHistoricalTagValueItems() {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IWriteHistoricalTagValues.WriteHistoricalTagValues"/> returns a 
+        /// result for every item that is written.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateWriteHistoricalTagValueItems"/>
+        [TestMethod]
+        public virtual Task WriteHistoricalTagValuesShouldSucceed() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IWriteHistoricalTagValues>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IWriteHistoricalTagValues>();
+                    return;
+                }
+
+                var writeItems = CreateWriteHistoricalTagValueItems();
+                if (writeItems == null) {
+                    AssertInconclusiveDueToMissingTestInput<IWriteHistoricalTagValues>(nameof(CreateWriteHistoricalTagValueItems));
+                    return;
+                }
+
+                var inChannel = Channel.CreateUnbounded<WriteTagValueItem>();
+                foreach (var item in writeItems) {
+                    item.CorrelationId = Guid.NewGuid().ToString();
+                    inChannel.Writer.TryWrite(item);
+                }
+                inChannel.Writer.TryComplete();
+
+                var channel = await feature.WriteHistoricalTagValues(context, inChannel.Reader, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+
+                var writeResults = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.AreEqual(writeItems.Count(), writeResults.Count(), "Incorrect number of write results received.");
+
+                var expectedCorrelationIds = new HashSet<string>(writeItems.Select(x => x.CorrelationId!));
+
+                foreach (var writeResult in writeResults) {
+                    Assert.IsNotNull(writeResult, "Null write result was returned.");
+                    Assert.IsNotNull(writeResult.CorrelationId, "Write result correlation ID should not be null because a correlation ID was specified on all values that were written.");
+                    Assert.IsTrue(expectedCorrelationIds.Remove(writeResult.CorrelationId!), $"Write result returned an unknown correlation ID: {writeResult.CorrelationId}");
+                    Assert.AreNotEqual(WriteStatus.Fail, writeResult.Status, "Write status indicates failure.");
+                }
+
+                Assert.AreEqual(0, expectedCorrelationIds.Count, $"Write results were not returned for the following correlation IDs: {string.Join(", ", expectedCorrelationIds)}");
+            });
+        }
+
+        #endregion
+
+        #region [ IWriteTagValueAnnotations ]
+
+        #endregion
+
+        #region [ IEventMessagePush ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="EventMessagePushShouldReceiveValues"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="CreateEventMessageSubscriptionRequest"/> to use.
+        /// </returns>
+        protected virtual CreateEventMessageSubscriptionRequest CreateEventMessageSubscriptionRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Emits a test event for <see cref="EventMessagePushShouldReceiveValues"/> and <see cref="EventMessageTopicPushShouldReceiveInitialMessages"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <param name="adapter">
+        ///   The adapter that must to emit the event.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that returns a flag specifying if a test event was emitted.
+        /// </returns>
+        protected virtual Task<bool> EmitTestEvent(TestContext context, TAdapter adapter, CancellationToken cancellationToken) {
+            return Task.FromResult(false);
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IEventMessagePush.Subscribe"/> emits event messages.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateEventMessageSubscriptionRequest"/>
+        [TestMethod]
+        public virtual Task EventMessagePushShouldReceiveValues() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IEventMessagePush>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IEventMessagePush>();
+                    return;
+                }
+
+                var request = CreateEventMessageSubscriptionRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IEventMessagePush>(nameof(CreateEventMessageSubscriptionRequest));
+                    return;
+                }
+
+                var subscription = await feature.Subscribe(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(subscription);
+
+                var testEventEmitted = await EmitTestEvent(TestContext, adapter, ct).ConfigureAwait(false);
+                if (!testEventEmitted) {
+                    AssertInconclusiveDueToMissingTestInput<IEventMessagePush>(nameof(EmitTestEvent));
+                    return;
+                }
+
+                var received = await subscription.ReadAsync(ct).ConfigureAwait(false);
+                Assert.IsNotNull(received);
+            });
+        }
+
+        #endregion
+
+        #region [ IEventMessagePushWithTopics ]
+
+        /// <summary>
+        /// Gets the request to use with the <see cref="EventMessageTopicPushShouldReceiveInitialMessages"/> 
+        /// and <see cref="EventMessageTopicPushShouldReceiveMessagesAfterSubscriptionChange"/> tests.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ReadAnnotationRequest"/> to use.
+        /// </returns>
+        protected virtual CreateEventMessageTopicSubscriptionRequest CreateEventMessageTopicSubscriptionRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IEventMessagePushWithTopics.Subscribe"/> emits event messages.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateEventMessageTopicSubscriptionRequest"/>
+        [TestMethod]
+        public virtual Task EventMessageTopicPushShouldReceiveInitialMessages() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IEventMessagePushWithTopics>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IEventMessagePushWithTopics>();
+                    return;
+                }
+
+                var request = CreateEventMessageTopicSubscriptionRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IEventMessagePushWithTopics>(nameof(CreateEventMessageTopicSubscriptionRequest));
+                    return;
+                }
+
+                var subscription = await feature.Subscribe(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(subscription);
+
+                var testEventEmitted = await EmitTestEvent(TestContext, adapter, ct).ConfigureAwait(false);
+                if (!testEventEmitted) {
+                    AssertInconclusiveDueToMissingTestInput<IEventMessagePushWithTopics>(nameof(EmitTestEvent));
+                    return;
+                }
+
+                var received = await subscription.ReadAsync(ct).ConfigureAwait(false);
+                Assert.IsNotNull(received);
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IEventMessagePushWithTopics.Subscribe"/> emits event messages 
+        /// after subscription changes occur.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateEventMessageTopicSubscriptionRequest"/>
+        [TestMethod]
+        public virtual Task EventMessageTopicPushShouldReceiveMessagesAfterSubscriptionChange() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IEventMessagePushWithTopics>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IEventMessagePushWithTopics>();
+                    return;
+                }
+
+                var request = CreateEventMessageTopicSubscriptionRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IEventMessagePushWithTopics>(nameof(CreateEventMessageTopicSubscriptionRequest));
+                    return;
+                }
+
+                var channel = Channel.CreateUnbounded<EventMessageSubscriptionUpdate>();
+
+                var subscription = await feature.Subscribe(context, new CreateEventMessageTopicSubscriptionRequest() { SubscriptionType = request.SubscriptionType, Properties = request.Properties }, channel.Reader, ct).ConfigureAwait(false);
+                Assert.IsNotNull(subscription);
+
+                // Now add the topics to the subscription.
+
+                channel.Writer.TryWrite(new EventMessageSubscriptionUpdate() {
+                    Action = SubscriptionUpdateAction.Subscribe,
+                    Topics = request.Topics
+                });
+
+                // Pause briefly to allow the subscription change to take effect, since the change 
+                // will be processed asynchronously to us writing the update into the channel.
+                await Task.Delay(200, ct).ConfigureAwait(false);
+
+                var testEventEmitted = await EmitTestEvent(TestContext, adapter, ct).ConfigureAwait(false);
+                if (!testEventEmitted) {
+                    AssertInconclusiveDueToMissingTestInput<IEventMessagePushWithTopics>(nameof(EmitTestEvent));
+                    return;
+                }
+
+                var received = await subscription.ReadAsync(ct).ConfigureAwait(false);
+                Assert.IsNotNull(received);
+            });
+        }
+
+        #endregion
+
+        #region [ IReadEventMessagesForTimeRange ]
+
+        /// <summary>
+        /// Gets the request to use in the <see cref="ReadEventMessagesForTimeRangeRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="ReadEventMessagesForTimeRangeRequest"/> object.
+        /// </returns>
+        protected virtual ReadEventMessagesForTimeRangeRequest CreateReadEventMessagesForTimeRangeRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Ensures that <see cref="IReadEventMessagesForTimeRange.ReadEventMessagesForTimeRange"/> 
+        /// returns results, and that these results meet the constraints specified by the query.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadEventMessagesForTimeRangeRequest(TestContext)"/>
+        [TestMethod]
+        public virtual Task ReadEventMessagesForTimeRangeRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadEventMessagesForTimeRange>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadEventMessagesForTimeRange>();
+                    return;
+                }
+
+                var request = CreateReadEventMessagesForTimeRangeRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IReadEventMessagesForTimeRange>(nameof(CreateReadEventMessagesForTimeRangeRequest));
+                    return;
+                }
+
+                var channel = await feature.ReadEventMessagesForTimeRange(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel, $"{nameof(IReadEventMessagesForTimeRange.ReadEventMessagesForTimeRange)} should not return null.");
+
+                var events = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.IsTrue(events.Count() <= request.PageSize, $"{events.Count()} events were returned, but the page size is {request.PageSize}.");
+
+                foreach (var evt in events) {
+                    Assert.IsNotNull(evt, "Null event messages should not be returned.");
+                    Assert.IsTrue(evt.UtcEventTime >= request.UtcStartTime, "Event time is earlier than query start time.");
+                    Assert.IsTrue(evt.UtcEventTime <= request.UtcEndTime, "Event time is later than query end time.");
+                }
+            });
+        }
+
+        #endregion
+
+        #region [ IReadEventMessagesUsingCursor ]
+
+        /// <summary>
+        /// Gets the request to use in the <see cref="ReadEventMessagesUsingCursorRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="ReadEventMessagesUsingCursorRequest"/> object.
+        /// </returns>
+        protected virtual ReadEventMessagesUsingCursorRequest CreateReadEventMessagesUsingCursorRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Ensures that <see cref="IReadEventMessagesUsingCursor.ReadEventMessagesUsingCursor"/> 
+        /// returns results, and that these results meet the constraints specified by the query.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateReadEventMessagesUsingCursorRequest(TestContext)"/>
+        [TestMethod]
+        public virtual Task ReadEventMessagesUsingCursorRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IReadEventMessagesUsingCursor>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IReadEventMessagesUsingCursor>();
+                    return;
+                }
+
+                var request = CreateReadEventMessagesUsingCursorRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IReadEventMessagesUsingCursor>(nameof(CreateReadEventMessagesUsingCursorRequest));
+                    return;
+                }
+
+                var channel = await feature.ReadEventMessagesUsingCursor(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel, $"{nameof(IReadEventMessagesUsingCursor.ReadEventMessagesUsingCursor)} should not return null.");
+
+                var events = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.IsTrue(events.Count() <= request.PageSize, $"{events.Count()} events were returned, but the page size is {request.PageSize}.");
+            });
+        }
+
+        #endregion
+
+        #region [ IWriteEventMessages ]
+
+        /// <summary>
+        /// Gets the items to write for the <see cref="WriteEventMessagesShouldSucceed"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   The collection of <see cref="WriteEventMessageItem"/> objects to use.
+        /// </returns>
+        protected virtual IEnumerable<WriteEventMessageItem> CreateWriteEventMessageItems() {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that <see cref="IWriteEventMessages.WriteEventMessages"/> returns a 
+        /// result for every item that is written.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateWriteEventMessageItems"/>
+        [TestMethod]
+        public virtual Task WriteEventMessagesShouldSucceed() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IWriteEventMessages>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IWriteEventMessages>();
+                    return;
+                }
+
+                var writeItems = CreateWriteEventMessageItems();
+                if (writeItems == null) {
+                    AssertInconclusiveDueToMissingTestInput<IWriteEventMessages>(nameof(CreateWriteEventMessageItems));
+                    return;
+                }
+
+                var inChannel = Channel.CreateUnbounded<WriteEventMessageItem>();
+                foreach (var item in writeItems) {
+                    item.CorrelationId = Guid.NewGuid().ToString();
+                    inChannel.Writer.TryWrite(item);
+                }
+                inChannel.Writer.TryComplete();
+
+                var channel = await feature.WriteEventMessages(context, inChannel.Reader, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel);
+
+                var writeResults = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.AreEqual(writeItems.Count(), writeResults.Count(), "Incorrect number of write results received.");
+
+                var expectedCorrelationIds = new HashSet<string>(writeItems.Select(x => x.CorrelationId!));
+
+                foreach (var writeResult in writeResults) {
+                    Assert.IsNotNull(writeResult, "Null write result was returned.");
+                    Assert.IsNotNull(writeResult.CorrelationId, "Write result correlation ID should not be null because a correlation ID was specified on all items that were written.");
+                    Assert.IsTrue(expectedCorrelationIds.Remove(writeResult.CorrelationId!), $"Write result returned an unknown correlation ID: {writeResult.CorrelationId}");
+                    Assert.AreNotEqual(WriteStatus.Fail, writeResult.Status, "Write status indicates failure.");
+                }
+
+                Assert.AreEqual(0, expectedCorrelationIds.Count, $"Write results were not returned for the following correlation IDs: {string.Join(", ", expectedCorrelationIds)}");
+            });
+        }
+
+        #endregion
+
+        #region [ IAssetModelBrowse ]
+
+        /// <summary>
+        /// Gets the request to use in the <see cref="BrowseAssetModelNodesRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="BrowseAssetModelNodesRequest"/> object.
+        /// </returns>
+        protected virtual BrowseAssetModelNodesRequest CreateBrowseAssetModelNodesRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Gets the request to use in the <see cref="GetAssetModelNodesRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="BrowseAssetModelNodesRequest"/> object.
+        /// </returns>
+        protected virtual GetAssetModelNodesRequest CreateGetAssetModelNodesRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that a call to <see cref="IAssetModelBrowse.BrowseAssetModelNodes"/> returns results.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateBrowseAssetModelNodesRequest"/>
+        [TestMethod]
+        public virtual Task BrowseAssetModelNodesRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IAssetModelBrowse>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IAssetModelBrowse>();
+                    return;
+                }
+
+                var request = CreateBrowseAssetModelNodesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IAssetModelBrowse>(nameof(CreateBrowseAssetModelNodesRequest));
+                    return;
+                }
+
+                var channel = await feature.BrowseAssetModelNodes(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel, $"{nameof(IAssetModelBrowse.BrowseAssetModelNodes)} should not return null.");
+
+                var nodes = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.IsTrue(nodes.Any(), "Request should return one or more nodes.");
+                Assert.IsTrue(nodes.All(x => x != null), "Null nodes should not be returned.");
+
+                Assert.IsTrue(nodes.Count() <= request.PageSize, $"{nodes.Count()} nodes were returned, but the page size is {request.PageSize}.");
+            });
+        }
+
+
+        /// <summary>
+        /// Verifies that a call to <see cref="IAssetModelBrowse.GetAssetModelNodes"/> returns results.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateGetAssetModelNodesRequest"/>
+        [TestMethod]
+        public virtual Task GetAssetModelNodesRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IAssetModelBrowse>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IAssetModelBrowse>();
+                    return;
+                }
+
+                var request = CreateGetAssetModelNodesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IAssetModelBrowse>(nameof(CreateGetAssetModelNodesRequest));
+                    return;
+                }
+
+                var channel = await feature.GetAssetModelNodes(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel, $"{nameof(IAssetModelBrowse.GetAssetModelNodes)} should not return null.");
+
+                var nodes = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.IsTrue(nodes.Any(), "Request should return one or more nodes.");
+
+                var allNodeIds = new HashSet<string>(request.Nodes);
+                var remainingNodeIds = new HashSet<string>(request.Nodes);
+
+                foreach (var node in nodes) {
+                    Assert.IsNotNull(node, "Null nodes should not be returned.");
+                    Assert.IsTrue(allNodeIds.Contains(node.Id), $"Received node with ID '{node.Id}', but this node was not requested.");
+                    Assert.IsTrue(remainingNodeIds.Remove(node.Id), $"Expected nodes list does not contain ID '{node.Id}'.");
+                }
+
+                Assert.AreEqual(0, remainingNodeIds.Count, $"Nodes were not received for the following node IDs: {string.Join(", ", remainingNodeIds)}");
+            });
+        }
+
+        #endregion
+
+        #region [ IAssetModelSearch ]
+
+        /// <summary>
+        /// Gets the request to use in the <see cref="FindAssetModelNodesRequestShouldReturnResults"/> 
+        /// test.
+        /// </summary>
+        /// <param name="context">
+        ///   The test context.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="FindAssetModelNodesRequest"/> object.
+        /// </returns>
+        protected virtual FindAssetModelNodesRequest CreateFindAssetModelNodesRequest(TestContext context) {
+            return null!;
+        }
+
+
+        /// <summary>
+        /// Verifies that a call to <see cref="IAssetModelSearch.FindAssetModelNodes"/> returns results.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        /// <seealso cref="CreateFindAssetModelNodesRequest"/>
+        [TestMethod]
+        public virtual Task FindAssetModelNodesRequestShouldReturnResults() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var feature = adapter.Features.Get<IAssetModelSearch>();
+                if (feature == null) {
+                    AssertFeatureNotImplemented<IAssetModelSearch>();
+                    return;
+                }
+
+                var request = CreateFindAssetModelNodesRequest(TestContext);
+                if (request == null) {
+                    AssertInconclusiveDueToMissingTestInput<IAssetModelSearch>(nameof(CreateFindAssetModelNodesRequest));
+                    return;
+                }
+
+                var channel = await feature.FindAssetModelNodes(context, request, ct).ConfigureAwait(false);
+                Assert.IsNotNull(channel, $"{nameof(IAssetModelSearch.FindAssetModelNodes)} should not return null.");
+
+                var nodes = await ReadAllAsync(channel, ct).ConfigureAwait(false);
+                Assert.IsTrue(nodes.Any(), "Request should return one or more nodes.");
+                Assert.IsTrue(nodes.All(x => x != null), "Null nodes should not be returned.");
+
+                Assert.IsTrue(nodes.Count() <= request.PageSize, $"{nodes.Count()} nodes were returned, but the page size is {request.PageSize}.");
+            });
+        }
+
+        #endregion
+
+        #region [ Extensions ]
+
+        /// <summary>
+        /// Ensures that, for every extension feature implemented by the adapter, the feature 
+        /// returns a descriptor and a set of available operations.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public Task ExtensionFeaturesShouldReturnDescriptors() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var extensionUris = adapter.Features.Keys.Where(x => x.IsChildOf(WellKnownFeatures.Extensions.ExtensionFeatureBasePath)).ToArray();
+                if (extensionUris.Length == 0) {
+                    Assert.Inconclusive("Adapter does not implement any extension features.");
+                    return;
+                }
+
+                foreach (var extensionUri in extensionUris) {
+                    var feature = adapter.GetExtensionFeature(extensionUri);
+                    Assert.IsNotNull(feature, $"Unable to resolve extension feature: {extensionUri}");
+
+                    var descriptor = await feature.GetDescriptor(context, extensionUri, ct).ConfigureAwait(false);
+                    Assert.IsNotNull(descriptor, $"Feature descriptor for {extensionUri} was null.");
+                    Assert.AreEqual(extensionUri, descriptor!.Uri, "Descriptor URI mismatch.");
+
+                    var operations = await feature.GetOperations(context, extensionUri, ct).ConfigureAwait(false);
+                    Assert.IsNotNull(operations, $"{nameof(IAdapterExtensionFeature.GetOperations)} for feature {extensionUri} returned null.");
+                    if (operations.Any()) {
+                        Assert.IsTrue(operations.All(x => x != null), $"One or more operations for feature {extensionUri} were null.");
+                    }
+                }
+            });
+        }
+
+        #endregion
+
+        #region [ Miscellaneous Other Tests ]
+
+        /// <summary>
+        /// This test ensures that background tasks that are registered with an adapter's 
+        /// <see cref="IBackgroundTaskServiceProvider.BackgroundTaskService"/> are cancelled when 
+        /// the adapter is stopped.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public Task BackgroundTaskShouldCancelWhenAdapterIsStopped() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                var tcs = new TaskCompletionSource<bool>();
+
+                adapter.BackgroundTaskService.QueueBackgroundWorkItem(new IntelligentPlant.BackgroundTasks.BackgroundWorkItem(async ct2 => {
+                    using (var compositeCtSource = CancellationTokenSource.CreateLinkedTokenSource(ct, ct2)) {
+                        try {
+                            await Task.Delay(-1, compositeCtSource.Token).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) { 
+                            if (ct.IsCancellationRequested) {
+                                tcs.TrySetCanceled(ct);
+                            }
+                        }
+                        catch (Exception e) {
+                            tcs.TrySetException(e);
+                        }
+                        finally {
+                            tcs.TrySetResult(true);
+                        }
+                    }
+                }));
+
+                await adapter.StopAsync(ct).ConfigureAwait(false);
+                await tcs.Task.ConfigureAwait(false);
+            });
+        }
+
+        #endregion
+
+    }
+}

--- a/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
+++ b/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <RootNamespace>DataCore.Adapter.Tests</RootNamespace>
+    <PackageId>$(PackagePrefix).Adapter.Tests.Helpers</PackageId>
+    <Description>Base MSTest test classes for testing App Store Connect adapters.</Description>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DataCore.Adapter\DataCore.Adapter.csproj" />
+    <ProjectReference Include="..\DataCore.Adapter.DependencyInjection\DataCore.Adapter.DependencyInjection.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/src/DataCore.Adapter.Tests.Helpers/README.md
+++ b/src/DataCore.Adapter.Tests.Helpers/README.md
@@ -1,0 +1,19 @@
+﻿# DataCore.Adapter.Tests.Helpers
+
+This project defines base MSTest classes that can be used to add stock unit tests for an App Store Connect adapter to a unit test project.
+
+
+## Installation
+
+Add a NuGet package reference to [IntelligentPlant.AppStoreConnect.Adapter.Tests.Helpers](https://www.nuget.org/packages/IntelligentPlant.AppStoreConnect.Adapter.Tests.Helpers) to your MSTest project.
+
+
+## Usage
+
+Add a test class to your unit test project that inherits from [AdapterTestsBase<TAdapter>](./AdapterTestsBase.cs) (remember to annotate your test class with `[TestClass]`!). Implement the `CreateServiceScope` and `CreateAdapter` methods. You can also optionally override the `CreateCallContext` method if you need to customise the `IAdapterCallContext` that will be passed to the adapter during tests.
+
+`AdapterTestsBase<TAdapter>` defines tests for all standard adapter features. If your adapter does not support a given feature, tests for that feature will be marked as inconclusive.
+
+Different tests also require the implementation of different supporting methods. If you run a test without overridding the associated support method(s), the test will fail, and the failure message will highlight which method you need to override. The vast majority of the support methods are named `CreateXXX`, where `XXX` refers to the type of test input that the method creates.
+
+Most of the built-in test methods are declared as `virtual`, so you can override these methods in your test class if required (e.g. to perform some additional test bootstrapping).

--- a/src/DataCore.Adapter.Tests.Helpers/TestsBase.cs
+++ b/src/DataCore.Adapter.Tests.Helpers/TestsBase.cs
@@ -6,19 +6,21 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DataCore.Adapter.Tests {
 
     /// <summary>
-    /// Base class for other test classes to inherit from.
+    /// Base class that other test classes can inherit from.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "Resources are disposed during test cleanup.")]
     public abstract class TestsBase {
 
         /// <summary>
-        /// The test context for the current test.
+        /// The context for the current test.
         /// </summary>
-        public TestContext TestContext { get; set; }
+        public TestContext TestContext { get; set; } = default!;
+
 
         /// <summary>
         /// Cancellation token source that fires after every test.
         /// </summary>
-        private CancellationTokenSource _cancellationTokenSource;
+        private CancellationTokenSource _cancellationTokenSource = default!;
 
         /// <summary>
         /// A cancellation token that will fire during test cleanup.
@@ -31,7 +33,7 @@ namespace DataCore.Adapter.Tests {
         /// </summary>
         [TestInitialize]
         public virtual void Initialize() {
-            _cancellationTokenSource = new CancellationTokenSource();
+            _cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(1));
             CancellationToken = _cancellationTokenSource.Token;
         }
 

--- a/test/DataCore.Adapter.Tests/AdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterTests.cs
@@ -2,31 +2,17 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
-using DataCore.Adapter.Common;
-using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.Events;
 using DataCore.Adapter.Extensions;
 using DataCore.Adapter.RealTimeData;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DataCore.Adapter.Tests {
-    public abstract class AdapterTests<TAdapter> : TestsBase where TAdapter : class, IAdapter {
-
-        private IServiceScope _scope;
-
-        protected IServiceProvider ServiceProvider { get { return _scope?.ServiceProvider; } }
-
-        protected abstract TAdapter CreateAdapter();
-
-        protected abstract Task<ReadTagValuesQueryDetails> GetReadTagValuesQueryDetails();
-
-        protected abstract Task<ReadEventMessagesQueryDetails> GetReadEventMessagesQueryDetails();
-
-        protected abstract Task EmitTestEvent(TAdapter adapter, EventMessageSubscriptionType subscriptionType, string topic);
+    public abstract class AdapterTests<TAdapter> : AdapterTestsBase<TAdapter> where TAdapter : class, IAdapter {
 
         protected virtual IEnumerable<ExtensionFeatureOperationType> ExpectedExtensionFeatureOperationTypes() {
             return new[] { 
@@ -37,419 +23,32 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        [TestInitialize]
-        public void TestInitialize() {
-            _scope = AssemblyInitializer.ApplicationServices.CreateScope();
+        protected override IServiceScope CreateServiceScope(TestContext context) {
+            return AssemblyInitializer.ApplicationServices.CreateScope();
         }
 
 
-        [TestCleanup]
-        public void TestCleanup() {
-            _scope?.Dispose();
+        protected override IAdapterCallContext CreateCallContext(TestContext context) {
+            return new DefaultAdapterCallContext();
         }
 
-
-        protected async Task RunAdapterTest(Func<TAdapter, IAdapterCallContext, Task> callback) {
-            var adapter = CreateAdapter();
-            if (adapter == null) {
-                Assert.Inconclusive("Adapter creation delegate returned null.");
-            }
-
-            try {
-                await adapter.StartAsync(CancellationToken);
-                var context = ExampleCallContext.ForPrincipal(null);
-                await callback(adapter, context);
-            }
-            finally {
-                if (adapter is IAsyncDisposable iad) {
-                    await iad.DisposeAsync();
-                }
-                else if (adapter is IDisposable id) {
-                    id.Dispose();
-                }
-            }
-        }
-
-
-        protected void AssertFeatureNotImplemented<TFeature>() {
-            Assert.Inconclusive($"Feature not implemented: {typeof(TFeature).Name}");
-        }
-
-
-        protected void AssertFeatureNotImplemented(string feature) {
-            Assert.Inconclusive($"Feature not implemented: {feature}");
-        }
-
-        #region [ IHealthCheck ]
-
-        [TestMethod]
-        public Task CheckHealthRequestShouldSucceed() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IHealthCheck>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IHealthCheck>();
-                    return;
-                }
-
-                var health = await feature.CheckHealthAsync(context, CancellationToken);
-                VerifyHealthCheckResult(health);
-            });
-        }
-
-
-        private void VerifyHealthCheckResult(HealthCheckResult health) {
-            if (health.InnerResults != null && health.InnerResults.Any()) {
-                foreach (var item in health.InnerResults) {
-                    VerifyHealthCheckResult(item);
-                }
-
-                // If there are any inner results, ensure that the overall status matches the 
-                // aggregate status of the inner results.
-                Assert.AreEqual(health.Status, HealthCheckResult.GetAggregateHealthStatus(health.InnerResults.Select(x => x.Status)));
-            }
-        }
-
-
-        [TestMethod]
-        public Task HealthCheckSubscriptionShouldReceiveUpdates() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IHealthCheck>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IHealthCheck>();
-                    return;
-                }
-
-                var subscription = await feature.Subscribe(context, CancellationToken);
-                Assert.IsNotNull(subscription);
-
-                await Task.Delay(1000, CancellationToken);
-
-                using (var ctSource = new CancellationTokenSource(1000)) {
-                    var health = await subscription.ReadAsync(ctSource.Token);
-                    VerifyHealthCheckResult(health);
-                }
-            });
-        }
-
-        #endregion
-
-        #region [ ITagSearch ]
-
-        [TestMethod]
-        public Task FindTagsRequestShouldReturnResults() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<ITagSearch>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<ITagSearch>();
-                    return;
-                }
-
-                var channel = await feature.FindTags(context, new FindTagsRequest(), CancellationToken);
-                var tags = await channel.ToEnumerable();
-                Assert.IsTrue(tags.Any());
-            });
-        }
-
-
-        [TestMethod]
-        public Task GetTagsRequestShouldReturnResults() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<ITagSearch>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<ITagSearch>();
-                    return;
-                }
-
-                var tagDetails = await GetReadTagValuesQueryDetails();
-                var channel = await feature.GetTags(context, new GetTagsRequest() {
-                    Tags = new[] { tagDetails.Id }
-                }, CancellationToken);
-                var tags = await channel.ToEnumerable();
-
-                Assert.AreEqual(1, tags.Count());
-                Assert.AreEqual(tagDetails.Id, tags.First().Id);
-            });
-        }
-
-        #endregion
-
-        #region [ IReadSnapshotTagValues ]
-
-        [TestMethod]
-        public Task ReadSnapshotTagValuesRequestShouldReturnResults() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IReadSnapshotTagValues>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IReadSnapshotTagValues>();
-                    return;
-                }
-
-                var tagDetails = await GetReadTagValuesQueryDetails();
-                var channel = await feature.ReadSnapshotTagValues(context, new ReadSnapshotTagValuesRequest() {
-                    Tags = new[] { tagDetails.Id }
-                }, CancellationToken);
-                var values = await channel.ToEnumerable();
-
-                Assert.AreEqual(1, values.Count());
-
-                var val = values.First();
-                Assert.IsNotNull(val);
-                Assert.IsTrue(tagDetails.Id.Equals(val.TagId) || tagDetails.Id.Equals(val.TagName, StringComparison.OrdinalIgnoreCase));
-            });
-        }
-
-        #endregion
-
-        #region [ ISnapshotTagValuePush ]
-
-        [TestMethod]
-        public Task SnapshotTagValueSubscriptionShouldReceiveInitialValues() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<ISnapshotTagValuePush>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<ISnapshotTagValuePush>();
-                    return;
-                }
-
-                var tagDetails = await GetReadTagValuesQueryDetails();
-
-                var subscription = await feature.Subscribe(context, new CreateSnapshotTagValueSubscriptionRequest() { 
-                    Tags = new[] { tagDetails.Id }
-                }, CancellationToken);
-                Assert.IsNotNull(subscription);
-
-                using (var ctSource = new CancellationTokenSource(1000)) {
-                    var val = await subscription.ReadAsync(ctSource.Token);
-                    Assert.IsNotNull(val);
-                    Assert.IsTrue(tagDetails.Id.Equals(val.TagId) || tagDetails.Id.Equals(val.TagName, StringComparison.OrdinalIgnoreCase));
-                }
-            });
-        }
-
-
-        [TestMethod]
-        public Task SnapshotTagValueSubscriptionShouldAllowSubscriptionChanges() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<ISnapshotTagValuePush>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<ISnapshotTagValuePush>();
-                    return;
-                }
-
-                var tagDetails = await GetReadTagValuesQueryDetails();
-                var channel = Channel.CreateUnbounded<TagValueSubscriptionUpdate>();
-
-                var subscription = await feature.Subscribe(
-                    context, 
-                    new CreateSnapshotTagValueSubscriptionRequest(), 
-                    channel,
-                    CancellationToken
-                );
-                Assert.IsNotNull(subscription);
-
-                // Now add the tag to the subscription.
-
-                channel.Writer.TryWrite(new TagValueSubscriptionUpdate() {
-                    Action = SubscriptionUpdateAction.Subscribe,
-                    Tags = new[] { tagDetails.Id }
-                });
-
-                using (var ctSource = new CancellationTokenSource(1000)) {
-                    var val = await subscription.ReadAsync(ctSource.Token);
-                    Assert.IsNotNull(val);
-                    Assert.IsTrue(tagDetails.Id.Equals(val.TagId) || tagDetails.Id.Equals(val.TagName, StringComparison.OrdinalIgnoreCase));
-                }
-            });
-        }
-
-        #endregion
-
-        #region [ IReadRawTagValues ]
-
-        [TestMethod]
-        public Task ReadRawTagValuesRequestShouldReturnResults() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IReadRawTagValues>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IReadRawTagValues>();
-                    return;
-                }
-
-                var tagDetails = await GetReadTagValuesQueryDetails();
-
-                var channel = await feature.ReadRawTagValues(
-                    context,
-                    new ReadRawTagValuesRequest() {
-                        Tags = new[] { tagDetails.Id },
-                        UtcStartTime = tagDetails.HistoryStartTime,
-                        UtcEndTime = tagDetails.HistoryEndTime,
-                        BoundaryType = RawDataBoundaryType.Inside,
-                        SampleCount = 0
-                    },
-                    CancellationToken
-                );
-                var values = await channel.ToEnumerable();
-
-                Assert.IsTrue(values.Any());
-                Assert.IsTrue(values.First().Value.UtcSampleTime >= tagDetails.HistoryStartTime);
-                Assert.IsTrue(values.Last().Value.UtcSampleTime <= tagDetails.HistoryEndTime);
-                Assert.IsTrue(values.All(v => tagDetails.Id.Equals(v.TagId) || tagDetails.Id.Equals(v.TagName, StringComparison.OrdinalIgnoreCase)));
-            });
-        }
-
-        #endregion
-
-        #region [ IReadPlotTagValues ]
-
-        [TestMethod]
-        public Task ReadPlotTagValuesRequestShouldReturnResults() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IReadPlotTagValues>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IReadPlotTagValues>();
-                    return;
-                }
-
-                var tagDetails = await GetReadTagValuesQueryDetails();
-
-                var channel = await feature.ReadPlotTagValues(
-                    context,
-                    new ReadPlotTagValuesRequest() {
-                        Tags = new[] { tagDetails.Id },
-                        UtcStartTime = tagDetails.HistoryStartTime,
-                        UtcEndTime = tagDetails.HistoryEndTime,
-                        Intervals = 10
-                    },
-                    CancellationToken
-                );
-                var values = await channel.ToEnumerable();
-
-                Assert.IsTrue(values.Any());
-                Assert.IsTrue(values.First().Value.UtcSampleTime >= tagDetails.HistoryStartTime);
-                Assert.IsTrue(values.Last().Value.UtcSampleTime <= tagDetails.HistoryEndTime);
-                Assert.IsTrue(values.All(v => tagDetails.Id.Equals(v.TagId) || tagDetails.Id.Equals(v.TagName, StringComparison.OrdinalIgnoreCase)));
-            });
-        }
-
-        #endregion
-
-        #region [ IReadProcessedTagValues ]
-
-        [DataTestMethod]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdAverage)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdCount)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdInterpolate)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdMaximum)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdMinimum)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdPercentBad)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdPercentGood)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdRange)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdDelta)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdVariance)]
-        [DataRow(DefaultDataFunctions.Constants.FunctionIdStandardDeviation)]
-        public Task ReadProcessedTagValuesRequestShouldReturnResults(string dataFunction) {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IReadProcessedTagValues>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IReadProcessedTagValues>();
-                    return;
-                }
-
-                var channel = await feature.GetSupportedDataFunctions(context, CancellationToken);
-                var supportedDataFunctions = await channel.ToEnumerable();
-                if (!supportedDataFunctions.Any(f => f.Id.Equals(dataFunction))) {
-                    Assert.Inconclusive($"Data function {dataFunction} is not supported.");
-                    return;
-                }
-
-                var tagDetails = await GetReadTagValuesQueryDetails();
-                // Calculate sample interval for 10 buckets.
-                var sampleInterval = TimeSpan.FromSeconds((tagDetails.HistoryEndTime - tagDetails.HistoryStartTime).TotalSeconds / 10);
-
-                var channel2 = await feature.ReadProcessedTagValues(
-                    context,
-                    new ReadProcessedTagValuesRequest() {
-                        Tags = new[] { tagDetails.Id },
-                        UtcStartTime = tagDetails.HistoryStartTime,
-                        UtcEndTime = tagDetails.HistoryEndTime,
-                        DataFunctions = new[] { dataFunction },
-                        SampleInterval = sampleInterval
-                    },
-                    CancellationToken
-                );
-                var values = await channel2.ToEnumerable();
-
-                Assert.IsTrue(values.Any());
-                Assert.IsTrue(values.First().Value.UtcSampleTime >= tagDetails.HistoryStartTime);
-                Assert.IsTrue(values.Last().Value.UtcSampleTime <= tagDetails.HistoryEndTime);
-                Assert.IsTrue(values.All(v => dataFunction.Equals(v.DataFunction)));
-                Assert.IsTrue(values.All(v => tagDetails.Id.Equals(v.TagId) || tagDetails.Id.Equals(v.TagName, StringComparison.OrdinalIgnoreCase)));
-            });
-        }
-
-        #endregion
-
-        #region [ IReadTagValuesAtTimes ]
-
-        [TestMethod]
-        public Task ReadTagValuesAtTimesRequestShouldReturnResults() {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IReadTagValuesAtTimes>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IReadTagValuesAtTimes>();
-                    return;
-                }
-
-                var tagDetails = await GetReadTagValuesQueryDetails();
-                var sampleTimes = new List<DateTime>();
-                var baseInterval = (tagDetails.HistoryEndTime - tagDetails.HistoryStartTime).TotalSeconds / 50;
-                var counter = 0;
-
-                for (var ts = tagDetails.HistoryStartTime; ts <= tagDetails.HistoryEndTime; ts = ts.AddSeconds(baseInterval * (counter % 10) + 1)) {
-                    ++counter;
-                    sampleTimes.Add(ts);
-                }
-
-                var channel = await feature.ReadTagValuesAtTimes(
-                    context,
-                    new ReadTagValuesAtTimesRequest() {
-                        Tags = new[] { tagDetails.Id },
-                        UtcSampleTimes = sampleTimes.ToArray()
-                    },
-                    CancellationToken
-                );
-                var values = await channel.ToEnumerable();
-
-                Assert.AreEqual(sampleTimes.Count, values.Count());
-                Assert.IsTrue(values.All(v => tagDetails.Id.Equals(v.TagId) || tagDetails.Id.Equals(v.TagName, StringComparison.OrdinalIgnoreCase)));
-
-                for (var i = 0; i < sampleTimes.Count; i++) {
-                    var expectedSampleTime = sampleTimes[i];
-                    var sample = values.ElementAt(i);
-
-                    Assert.AreEqual(expectedSampleTime, sample.Value.UtcSampleTime);
-                }
-            });
-        }
-
-        #endregion
 
         #region [ IEventMessagePush ]
 
         [TestMethod]
         public Task ActiveEventMessageSubscriptionShouldReceiveMessages() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get<IEventMessagePush>();
                 if (feature == null) {
                     AssertFeatureNotImplemented<IEventMessagePush>();
                     return;
                 }
 
-                var subscription = await feature.Subscribe(context, new CreateEventMessageSubscriptionRequest() { SubscriptionType = EventMessageSubscriptionType.Active }, CancellationToken);
+                var subscription = await feature.Subscribe(context, new CreateEventMessageSubscriptionRequest() { SubscriptionType = EventMessageSubscriptionType.Active }, ct);
                 Assert.IsNotNull(subscription);
 
-                await Task.Delay(1000, CancellationToken);
-                await EmitTestEvent(adapter, EventMessageSubscriptionType.Active, null);
+                await Task.Delay(1000, ct);
+                await EmitTestEvent(TestContext, adapter, ct).ConfigureAwait(false);
 
                 using (var ctSource = new CancellationTokenSource(1000)) {
                     var val = await subscription.ReadAsync(ctSource.Token);
@@ -461,7 +60,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task PassiveEventMessageSubscriptionShouldReceiveMessages() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get<IEventMessagePush>();
                 if (feature == null) {
                     AssertFeatureNotImplemented<IEventMessagePush>();
@@ -471,242 +70,17 @@ namespace DataCore.Adapter.Tests {
                 var subscription = await feature.Subscribe(
                     context, 
                     new CreateEventMessageSubscriptionRequest() { SubscriptionType = EventMessageSubscriptionType.Passive }, 
-                    CancellationToken
+                    ct
                 );
                 Assert.IsNotNull(subscription);
 
-                await Task.Delay(1000, CancellationToken);
-                await EmitTestEvent(adapter, EventMessageSubscriptionType.Passive, null);
+                await Task.Delay(1000, ct);
+                await EmitTestEvent(TestContext, adapter, ct).ConfigureAwait(false);
+
 
                 using (var ctSource = new CancellationTokenSource(1000)) {
                     var val = await subscription.ReadAsync(ctSource.Token);
                     Assert.IsNotNull(val);
-                }
-            });
-        }
-
-        #endregion
-
-        #region [ IEventMessagePushWithTopics ]
-
-        [TestMethod]
-        public Task EventTopicSubscriptionShouldReceiveMessages() {
-            var topic = TestContext.TestName;
-
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IEventMessagePushWithTopics>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IEventMessagePushWithTopics>();
-                    return;
-                }
-
-                var subscription = await feature.Subscribe(
-                    context, 
-                    new CreateEventMessageTopicSubscriptionRequest() { 
-                        SubscriptionType = EventMessageSubscriptionType.Active,
-                        Topics = new[] { topic }
-                    }, 
-                    CancellationToken
-                );
-
-                Assert.IsNotNull(subscription);
-
-                await Task.Delay(1000, CancellationToken);
-                await EmitTestEvent(adapter, EventMessageSubscriptionType.Active, topic);
-
-                using (var ctSource = new CancellationTokenSource(1000)) {
-                    var val = await subscription.ReadAsync(ctSource.Token);
-                    Assert.IsNotNull(val);
-                    Assert.AreEqual(topic, val.Topic);
-                }
-
-            });
-        }
-
-
-        [TestMethod]
-        public Task EventTopicSubscriptionShouldAllowSubscriptionChanges() {
-            var topic = TestContext.TestName;
-
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IEventMessagePushWithTopics>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IEventMessagePushWithTopics>();
-                    return;
-                }
-
-                var channel = Channel.CreateUnbounded<EventMessageSubscriptionUpdate>();
-
-                var subscription = await feature.Subscribe(
-                    context,
-                    new CreateEventMessageTopicSubscriptionRequest() {
-                        SubscriptionType = EventMessageSubscriptionType.Active
-                    },
-                    channel,
-                    CancellationToken
-                );
-
-                Assert.IsNotNull(subscription);
-
-                await Task.Delay(1000, CancellationToken);
-                await EmitTestEvent(adapter, EventMessageSubscriptionType.Active, topic);
-
-                await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () => {
-                    using (var ctSource = new CancellationTokenSource(1000)) {
-                        var val = await subscription.ReadAsync(ctSource.Token);
-                        Assert.Fail("Should not receive value.");
-                    }
-                });
-
-                channel.Writer.TryWrite(new EventMessageSubscriptionUpdate() {
-                    Action = SubscriptionUpdateAction.Subscribe,
-                    Topics = new[] { topic }
-                });
-
-                await Task.Delay(1000, CancellationToken);
-                await EmitTestEvent(adapter, EventMessageSubscriptionType.Active, topic);
-
-                using (var ctSource = new CancellationTokenSource(1000)) {
-                    var val = await subscription.ReadAsync(ctSource.Token);
-                    Assert.IsNotNull(val);
-                    Assert.AreEqual(topic, val.Topic);
-                }
-
-            });
-        }
-
-        #endregion
-
-        #region [ IReadEventMessagesForTimeRange ]
-
-        [DataTestMethod]
-        [DataRow(EventReadDirection.Forwards)]
-        [DataRow(EventReadDirection.Backwards)]
-        public Task ReadEventMessagesForTimeRangeRequestShouldReturnResults(EventReadDirection direction) {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IReadEventMessagesForTimeRange>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IReadEventMessagesForTimeRange>();
-                    return;
-                }
-
-                var queryDetails = await GetReadEventMessagesQueryDetails();
-
-                var channel = await feature.ReadEventMessagesForTimeRange(
-                    context,
-                    new ReadEventMessagesForTimeRangeRequest() {
-                        UtcStartTime = queryDetails.HistoryStartTime,
-                        UtcEndTime = queryDetails.HistoryEndTime,
-                        PageSize = 10,
-                        Page = 1,
-                        Direction = direction
-                    },
-                    CancellationToken
-                );
-                var messages = await channel.ToEnumerable();
-
-                Assert.IsTrue(messages.Any());
-                Assert.IsTrue(messages.All(m => m.UtcEventTime >= queryDetails.HistoryStartTime && m.UtcEventTime <= queryDetails.HistoryEndTime));
-
-                // Ensure that messages were returned in the correct chronological order.
-                if (direction == EventReadDirection.Forwards) {
-                    Assert.IsTrue(messages.First().UtcEventTime <= messages.Last().UtcEventTime);
-                }
-                else {
-                    Assert.IsTrue(messages.First().UtcEventTime >= messages.Last().UtcEventTime);
-                }
-
-                // Now ensure that the next page does not contain any messages returned in the 
-                // first page, and that the timestamps of the event messages are correct in 
-                // relation to the first page and the read direction.
-
-                var channel2 = await feature.ReadEventMessagesForTimeRange(
-                    context,
-                    new ReadEventMessagesForTimeRangeRequest() {
-                        UtcStartTime = queryDetails.HistoryStartTime,
-                        UtcEndTime = queryDetails.HistoryEndTime,
-                        PageSize = 10,
-                        Page = 2,
-                        Direction = direction
-                    },
-                    CancellationToken
-                );
-                var messages2 = await channel2.ToEnumerable();
-
-                if (messages2.Any()) {
-                    if (direction == EventReadDirection.Forwards) {
-                        Assert.IsTrue(messages2.First().UtcEventTime >= messages.Last().UtcEventTime);
-                    }
-                    else {
-                        Assert.IsTrue(messages2.First().UtcEventTime <= messages.Last().UtcEventTime);
-                    }
-                }
-            });
-        }
-
-        #endregion
-
-        #region [ IReadEventMessagesUsingCursor ]
-
-        [DataTestMethod]
-        [DataRow(EventReadDirection.Forwards)]
-        [DataRow(EventReadDirection.Backwards)]
-        public Task ReadEventMessagesUsingCursorRequestShouldReturnResults(EventReadDirection direction) {
-            return RunAdapterTest(async (adapter, context) => {
-                var feature = adapter.Features.Get<IReadEventMessagesUsingCursor>();
-                if (feature == null) {
-                    AssertFeatureNotImplemented<IReadEventMessagesUsingCursor>();
-                    return;
-                }
-
-                var queryDetails = await GetReadEventMessagesQueryDetails();
-
-                var channel = await feature.ReadEventMessagesUsingCursor(
-                    context,
-                    new ReadEventMessagesUsingCursorRequest() {
-                        CursorPosition = null,
-                        PageSize = 10,
-                        Direction = direction
-                    },
-                    CancellationToken
-                );
-                var messages = await channel.ToEnumerable();
-
-                Assert.IsTrue(messages.Any());
-
-                // Ensure that messages were returned in the correct chronological order.
-                if (direction == EventReadDirection.Forwards) {
-                    Assert.IsTrue(messages.First().UtcEventTime <= messages.Last().UtcEventTime);
-                }
-                else {
-                    Assert.IsTrue(messages.First().UtcEventTime >= messages.Last().UtcEventTime);
-                }
-
-                var nextCursor = messages.Last().CursorPosition;
-                Assert.IsNotNull(nextCursor);
-
-                // Now ensure that the next page does not contain any messages returned in the 
-                // first page, and that the timestamps of the event messages are correct in 
-                // relation to the first page and the read direction.
-
-                var channel2 = await feature.ReadEventMessagesUsingCursor(
-                    context,
-                    new ReadEventMessagesUsingCursorRequest() {
-                        CursorPosition = nextCursor,
-                        PageSize = 10,
-                        Direction = direction
-                    },
-                    CancellationToken
-                );
-                var messages2 = await channel2.ToEnumerable();
-
-                if (messages2.Any()) {
-                    if (direction == EventReadDirection.Forwards) {
-                        Assert.IsTrue(messages2.First().UtcEventTime >= messages.Last().UtcEventTime);
-                    }
-                    else {
-                        Assert.IsTrue(messages2.First().UtcEventTime <= messages.Last().UtcEventTime);
-                    }
                 }
             });
         }
@@ -717,7 +91,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task WriteSnapshotTagValuesViaChannelShouldSucceed() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get<IWriteSnapshotTagValues>();
                 if (feature == null) {
                     AssertFeatureNotImplemented<IWriteSnapshotTagValues>();
@@ -734,12 +108,10 @@ namespace DataCore.Adapter.Tests {
                     });
                 }
 
-                var writeResults = await feature.WriteSnapshotTagValues(context, values.PublishToChannel(), CancellationToken);
+                var writeResults = await feature.WriteSnapshotTagValues(context, values.PublishToChannel(), ct);
                 var index = 0;
 
-                CancelAfter(TimeSpan.FromSeconds(1));
-
-                while (await writeResults.WaitToReadAsync(CancellationToken)) {
+                while (await writeResults.WaitToReadAsync(ct)) {
                     while (writeResults.TryRead(out var item)) {
                         if (index > values.Count) {
                             Assert.Fail("Too many results received");
@@ -758,7 +130,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task WriteSnapshotTagValuesViaEnumerableShouldSucceed() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get<IWriteSnapshotTagValues>();
                 if (feature == null) {
                     AssertFeatureNotImplemented<IWriteSnapshotTagValues>();
@@ -775,8 +147,7 @@ namespace DataCore.Adapter.Tests {
                     });
                 }
 
-                CancelAfter(TimeSpan.FromSeconds(1));
-                var writeResults = await feature.WriteSnapshotTagValues(context, values, CancellationToken);
+                var writeResults = await feature.WriteSnapshotTagValues(context, values, ct);
                 
                 Assert.AreEqual(values.Count, writeResults.Count());
 
@@ -795,7 +166,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task WriteHistoricalTagValuesViaChannelShouldSucceed() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get<IWriteHistoricalTagValues>();
                 if (feature == null) {
                     AssertFeatureNotImplemented<IWriteHistoricalTagValues>();
@@ -812,12 +183,10 @@ namespace DataCore.Adapter.Tests {
                     });
                 }
 
-                var writeResults = await feature.WriteHistoricalTagValues(context, values.PublishToChannel(), CancellationToken);
+                var writeResults = await feature.WriteHistoricalTagValues(context, values.PublishToChannel(), ct);
                 var index = 0;
 
-                CancelAfter(TimeSpan.FromSeconds(1));
-
-                while (await writeResults.WaitToReadAsync(CancellationToken)) {
+                while (await writeResults.WaitToReadAsync(ct)) {
                     while (writeResults.TryRead(out var item)) {
                         if (index > values.Count) {
                             Assert.Fail("Too many results received");
@@ -836,7 +205,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task WriteHistoricalTagValuesViaEnumerableShouldSucceed() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get<IWriteHistoricalTagValues>();
                 if (feature == null) {
                     AssertFeatureNotImplemented<IWriteHistoricalTagValues>();
@@ -853,8 +222,7 @@ namespace DataCore.Adapter.Tests {
                     });
                 }
 
-                CancelAfter(TimeSpan.FromSeconds(1));
-                var writeResults = await feature.WriteHistoricalTagValues(context, values, CancellationToken);
+                var writeResults = await feature.WriteHistoricalTagValues(context, values, ct);
 
                 Assert.AreEqual(values.Count, writeResults.Count());
 
@@ -876,7 +244,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task WriteEventMessagesViaChannelShouldSucceed() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get<IWriteEventMessages>();
                 if (feature == null) {
                     AssertFeatureNotImplemented<IWriteEventMessages>();
@@ -892,12 +260,10 @@ namespace DataCore.Adapter.Tests {
                     });
                 }
 
-                var writeResults = await feature.WriteEventMessages(context, values.PublishToChannel(), CancellationToken);
+                var writeResults = await feature.WriteEventMessages(context, values.PublishToChannel(), ct);
                 var index = 0;
 
-                CancelAfter(TimeSpan.FromSeconds(1));
-
-                while (await writeResults.WaitToReadAsync(CancellationToken)) {
+                while (await writeResults.WaitToReadAsync(ct)) {
                     while (writeResults.TryRead(out var item)) {
                         if (index > values.Count) {
                             Assert.Fail("Too many results received");
@@ -916,7 +282,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task WriteEventMessagesViaEnumerableShouldSucceed() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get<IWriteEventMessages>();
                 if (feature == null) {
                     AssertFeatureNotImplemented<IWriteEventMessages>();
@@ -932,8 +298,7 @@ namespace DataCore.Adapter.Tests {
                     });
                 }
 
-                CancelAfter(TimeSpan.FromSeconds(1));
-                var writeResults = await feature.WriteEventMessages(context, values, CancellationToken);
+                var writeResults = await feature.WriteEventMessages(context, values, ct);
 
                 Assert.AreEqual(values.Count, writeResults.Count());
 
@@ -955,7 +320,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task ExtensionShouldBeResolvedViaAbsoluteUri() {
-            return RunAdapterTest((adapter, context) => {
+            return RunAdapterTest((adapter, context, ct) => {
                 Assert.IsNotNull(adapter.GetExtensionFeature(new Uri(PingPongExtension.FeatureUri)));
                 Assert.IsTrue(adapter.TryGetExtensionFeature(new Uri(PingPongExtension.FeatureUri), out var f));
                 Assert.IsNotNull(f);
@@ -967,7 +332,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task ExtensionShouldBeResolvedViaRelativeUri() {
-            return RunAdapterTest((adapter, context) => {
+            return RunAdapterTest((adapter, context, ct) => {
                 Assert.IsNotNull(adapter.GetExtensionFeature(new Uri(PingPongExtension.RelativeFeatureUri, UriKind.Relative)));
                 Assert.IsTrue(adapter.TryGetExtensionFeature(new Uri(PingPongExtension.RelativeFeatureUri, UriKind.Relative), out var f));
                 Assert.IsNotNull(f);
@@ -979,7 +344,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task ExtensionShouldBeResolvedViaAbsoluteUriString() {
-            return RunAdapterTest((adapter, context) => {
+            return RunAdapterTest((adapter, context, ct) => {
                 Assert.IsNotNull(adapter.GetExtensionFeature(PingPongExtension.FeatureUri));
                 Assert.IsTrue(adapter.TryGetExtensionFeature(PingPongExtension.FeatureUri, out var f));
                 Assert.IsNotNull(f);
@@ -991,7 +356,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task ExtensionShouldBeResolvedViaRelativeUriString() {
-            return RunAdapterTest((adapter, context) => {
+            return RunAdapterTest((adapter, context, ct) => {
                 Assert.IsNotNull(adapter.GetExtensionFeature(PingPongExtension.RelativeFeatureUri));
                 Assert.IsTrue(adapter.TryGetExtensionFeature(PingPongExtension.RelativeFeatureUri, out var f));
                 Assert.IsNotNull(f);
@@ -1003,7 +368,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task PingPongExtensionShouldReturnDescriptor() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get(PingPongExtension.FeatureUri) as IAdapterExtensionFeature;
                 if (feature == null) {
                     AssertFeatureNotImplemented(PingPongExtension.FeatureUri);
@@ -1011,7 +376,7 @@ namespace DataCore.Adapter.Tests {
                 }
 
                 var expected = typeof(PingPongExtension).CreateFeatureDescriptor();
-                var actual = await feature.GetDescriptor(context, PingPongExtension.FeatureUri, default).ConfigureAwait(false);
+                var actual = await feature.GetDescriptor(context, PingPongExtension.FeatureUri, ct).ConfigureAwait(false);
 
                 Assert.IsNotNull(actual);
                 Assert.AreEqual(expected.Uri, actual.Uri);
@@ -1030,7 +395,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task HelloWorldExtensionShouldReturnDescriptor() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get(HelloWorldConstants.FeatureUri) as IAdapterExtensionFeature;
                 if (feature == null) {
                     AssertFeatureNotImplemented(HelloWorldConstants.FeatureUri);
@@ -1038,7 +403,7 @@ namespace DataCore.Adapter.Tests {
                 }
 
                 var expected = typeof(IHelloWorld).CreateFeatureDescriptor();
-                var actual = await feature.GetDescriptor(context, HelloWorldConstants.FeatureUri, default).ConfigureAwait(false);
+                var actual = await feature.GetDescriptor(context, HelloWorldConstants.FeatureUri, ct).ConfigureAwait(false);
 
                 Assert.IsNotNull(actual);
                 Assert.AreEqual(expected.Uri, actual.Uri);
@@ -1057,14 +422,14 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task PingPongExtensionShouldReturnAvailableOperations() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get(PingPongExtension.FeatureUri) as IAdapterExtensionFeature;
                 if (feature == null) {
                     AssertFeatureNotImplemented(PingPongExtension.FeatureUri);
                     return;
                 }
 
-                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, default).ConfigureAwait(false);
+                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, ct).ConfigureAwait(false);
                 var expectedOperations = ExpectedExtensionFeatureOperationTypes();
 
                 foreach (var type in expectedOperations) {
@@ -1076,14 +441,14 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task HelloWorldExtensionShouldReturnAvailableOperations() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get(HelloWorldConstants.FeatureUri) as IAdapterExtensionFeature;
                 if (feature == null) {
                     AssertFeatureNotImplemented(HelloWorldConstants.FeatureUri);
                     return;
                 }
 
-                var operations = await feature.GetOperations(context, HelloWorldConstants.FeatureUri, default).ConfigureAwait(false);
+                var operations = await feature.GetOperations(context, HelloWorldConstants.FeatureUri, ct).ConfigureAwait(false);
                 Assert.AreEqual(1, operations.Count());
 
                 var op = operations.First();
@@ -1102,7 +467,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task PingPongExtensionShouldReturnAvailableOperationsViaInvoke() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 if (!ExpectedExtensionFeatureOperationTypes().Contains(ExtensionFeatureOperationType.Invoke)) {
                     Assert.Inconclusive("Invoke operation not available.");
                 }
@@ -1113,7 +478,7 @@ namespace DataCore.Adapter.Tests {
                     return;
                 }
 
-                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, default).ConfigureAwait(false);
+                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, ct).ConfigureAwait(false);
                 var expectedOperations = ExpectedExtensionFeatureOperationTypes();
 
                 operations = operations.Where(x => expectedOperations.Contains(x.OperationType)).ToArray();
@@ -1126,7 +491,7 @@ namespace DataCore.Adapter.Tests {
                     "/"
                 ));
 
-                var operationsFromInvoke = await feature.Invoke<IEnumerable<ExtensionFeatureOperationDescriptor>>(context, operationId, default);
+                var operationsFromInvoke = await feature.Invoke<IEnumerable<ExtensionFeatureOperationDescriptor>>(context, operationId, ct);
 
                 Assert.IsNotNull(operationsFromInvoke);
                 foreach (var op in operations) {
@@ -1139,14 +504,14 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task HelloWorldExtensionShouldReturnAvailableOperationsViaInvoke() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get(HelloWorldConstants.FeatureUri) as IAdapterExtensionFeature;
                 if (feature == null) {
                     AssertFeatureNotImplemented(HelloWorldConstants.FeatureUri);
                     return;
                 }
 
-                var operations = await feature.GetOperations(context, HelloWorldConstants.FeatureUri, default).ConfigureAwait(false);
+                var operations = await feature.GetOperations(context, HelloWorldConstants.FeatureUri, ct).ConfigureAwait(false);
 
                 var operationId = new Uri(string.Concat(
                     HelloWorldConstants.FeatureUri,
@@ -1156,7 +521,7 @@ namespace DataCore.Adapter.Tests {
                     "/"
                 ));
 
-                var operationsFromInvoke = await feature.Invoke<IEnumerable<ExtensionFeatureOperationDescriptor>>(context, operationId, default);
+                var operationsFromInvoke = await feature.Invoke<IEnumerable<ExtensionFeatureOperationDescriptor>>(context, operationId, ct);
 
                 Assert.IsNotNull(operationsFromInvoke);
                 foreach (var op in operations) {
@@ -1169,7 +534,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task PingPongInvokeMethodShouldReturnCorrectValue() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 if (!ExpectedExtensionFeatureOperationTypes().Contains(ExtensionFeatureOperationType.Invoke)) {
                     Assert.Inconclusive("Invoke operation not available.");
                 }
@@ -1180,7 +545,7 @@ namespace DataCore.Adapter.Tests {
                     return;
                 }
 
-                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, default).ConfigureAwait(false);
+                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, ct).ConfigureAwait(false);
 
                 var operationId = operations.FirstOrDefault(x => x.OperationType == ExtensionFeatureOperationType.Invoke)?.OperationId;
                 if (operationId == null) {
@@ -1196,7 +561,7 @@ namespace DataCore.Adapter.Tests {
                     context,
                     operationId,
                     pingMessage,
-                    default
+                    ct
                 );
 
                 Assert.IsNotNull(pongMessage);
@@ -1207,7 +572,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task PingPongStreamMethodShouldReturnCorrectValue() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 if (!ExpectedExtensionFeatureOperationTypes().Contains(ExtensionFeatureOperationType.Stream)) {
                     Assert.Inconclusive("Stream operation not available.");
                 }
@@ -1218,7 +583,7 @@ namespace DataCore.Adapter.Tests {
                     return;
                 }
 
-                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, default).ConfigureAwait(false);
+                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, ct).ConfigureAwait(false);
 
                 var operationId = operations.FirstOrDefault(x => x.OperationType == ExtensionFeatureOperationType.Stream)?.OperationId;
                 if (operationId == null) {
@@ -1234,26 +599,23 @@ namespace DataCore.Adapter.Tests {
                     context,
                     operationId,
                     pingMessage,
-                    default
+                    ct
                 );
 
-                using (var ctSource = new CancellationTokenSource(TimeSpan.FromSeconds(5))) {
-                    var ct = ctSource.Token;
-                    var pongMessage = await reader.ReadAsync(ct);
+                var pongMessage = await reader.ReadAsync(ct);
 
-                    Assert.IsNotNull(pongMessage);
-                    Assert.AreEqual(pingMessage.CorrelationId, pongMessage.CorrelationId);
+                Assert.IsNotNull(pongMessage);
+                Assert.AreEqual(pingMessage.CorrelationId, pongMessage.CorrelationId);
 
-                    // Should be no more values in the stream
-                    Assert.IsFalse(await reader.WaitToReadAsync(ct));
-                }
+                // Should be no more values in the stream
+                Assert.IsFalse(await reader.WaitToReadAsync(ct));
             });
         }
 
 
         [TestMethod]
         public Task PingPongDuplexStreamMethodShouldReturnCorrectValue() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 if (!ExpectedExtensionFeatureOperationTypes().Contains(ExtensionFeatureOperationType.Stream)) {
                     Assert.Inconclusive("DuplexStream operation not available.");
                 }
@@ -1264,7 +626,7 @@ namespace DataCore.Adapter.Tests {
                     return;
                 }
 
-                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, default).ConfigureAwait(false);
+                var operations = await feature.GetOperations(context, PingPongExtension.FeatureUri, ct).ConfigureAwait(false);
 
                 var operationId = operations.FirstOrDefault(x => x.OperationType == ExtensionFeatureOperationType.DuplexStream)?.OperationId;
                 if (operationId == null) {
@@ -1283,97 +645,30 @@ namespace DataCore.Adapter.Tests {
                     context,
                     operationId,
                     pingMessages.PublishToChannel(),
-                    default
+                    ct
                 );
 
-                using (var ctSource = new CancellationTokenSource(TimeSpan.FromSeconds(5))) {
-                    var ct = ctSource.Token;
+                var messagesRead = 0;
 
-                    var messagesRead = 0;
-
-                    while (await reader.WaitToReadAsync(CancellationToken)) {
-                        while (reader.TryRead(out var pongMessage)) {
-                            ++messagesRead;
-                            if (messagesRead > pingMessages.Count) {
-                                Assert.Fail("Incorrect number of pong messages received.");
-                            }
-
-                            var pingMessage = pingMessages[messagesRead - 1];
-
-                            Assert.IsNotNull(pongMessage);
-                            Assert.AreEqual(pingMessage.CorrelationId, pongMessage.CorrelationId);
+                while (await reader.WaitToReadAsync(ct)) {
+                    while (reader.TryRead(out var pongMessage)) {
+                        ++messagesRead;
+                        if (messagesRead > pingMessages.Count) {
+                            Assert.Fail("Incorrect number of pong messages received.");
                         }
-                    }
 
-                    Assert.AreEqual(pingMessages.Count, messagesRead, "Incorrect number of pong messages received.");
+                        var pingMessage = pingMessages[messagesRead - 1];
+
+                        Assert.IsNotNull(pongMessage);
+                        Assert.AreEqual(pingMessage.CorrelationId, pongMessage.CorrelationId);
+                    }
                 }
+
+                Assert.AreEqual(pingMessages.Count, messagesRead, "Incorrect number of pong messages received.");
             });
         }
 
         #endregion
-
-        #region [ Miscellaneous Other Tests ]
-
-        [TestMethod]
-        public Task BackgroundTaskShouldCancelWhenAdapterIsStopped() {
-            return RunAdapterTest(async (adapter, context) => { 
-                if (!(adapter is AdapterBase adapterBase)) {
-                    Assert.Inconclusive("Test is only applicable to implementations of AdapterBase.");
-                    return;
-                }
-
-                var tcs = new TaskCompletionSource<bool>();
-
-                adapterBase.BackgroundTaskService.QueueBackgroundWorkItem(new IntelligentPlant.BackgroundTasks.BackgroundWorkItem(async ct => {
-                    try {
-                        await Task.Delay(-1, ct);
-                    }
-                    catch (OperationCanceledException) { }
-                    catch (Exception e) {
-                        tcs.TrySetException(e);
-                    }
-                    finally {
-                        tcs.TrySetResult(true);
-                    }
-                }));
-
-                await adapter.StopAsync(CancellationToken);
-
-                using (var ctSource = new CancellationTokenSource(1000)) {
-                    await Task.WhenAny(Task.Delay(-1, ctSource.Token), tcs.Task);
-                    ctSource.Token.ThrowIfCancellationRequested();
-
-                    await tcs.Task;
-                }
-            });
-        }
-
-        #endregion
-
-    }
-
-
-    public class ReadTagValuesQueryDetails {
-
-        public string Id { get; }
-
-        public DateTime HistoryStartTime { get; set; }
-
-        public DateTime HistoryEndTime { get; set; }
-
-
-        public ReadTagValuesQueryDetails(string id) {
-            Id = id ?? throw new ArgumentNullException(nameof(id));
-        }
-
-    }
-
-
-    public class ReadEventMessagesQueryDetails {
-
-        public DateTime HistoryStartTime { get; set; }
-
-        public DateTime HistoryEndTime { get; set; }
 
     }
 

--- a/test/DataCore.Adapter.Tests/AdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterTests.cs
@@ -27,12 +27,6 @@ namespace DataCore.Adapter.Tests {
             return AssemblyInitializer.ApplicationServices.CreateScope();
         }
 
-
-        protected override IAdapterCallContext CreateCallContext(TestContext context) {
-            return new DefaultAdapterCallContext();
-        }
-
-
         #region [ IEventMessagePush ]
 
         [TestMethod]

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\src\DataCore.Adapter.Csv\DataCore.Adapter.Csv.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.Grpc.Proxy\DataCore.Adapter.Grpc.Proxy.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.Http.Proxy\DataCore.Adapter.Http.Proxy.csproj" />
+    <ProjectReference Include="..\..\src\DataCore.Adapter.Tests.Helpers\DataCore.Adapter.Tests.Helpers.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter\DataCore.Adapter.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.Json\DataCore.Adapter.Json.csproj" />
   </ItemGroup>

--- a/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
@@ -1,50 +1,93 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Events;
 using DataCore.Adapter.RealTimeData;
+
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DataCore.Adapter.Tests {
+
     [TestClass]
-    public class ExampleAdapterTests : AdapterTests<ExampleAdapter> {
+    public class ExampleAdapterTests : AdapterTestsBase<ExampleAdapter> {
 
-        private static readonly ReadTagValuesQueryDetails TestTag1 = new ReadTagValuesQueryDetails("Test Tag 1");
+        #region [ AdapterTestsBase<TAdapter> Overrides ]
+
+        protected override IServiceScope CreateServiceScope(TestContext context) {
+            return AssemblyInitializer.ApplicationServices.CreateScope();
+        }
 
 
-        protected override ExampleAdapter CreateAdapter() {
+        protected override ExampleAdapter CreateAdapter(TestContext context, IServiceProvider serviceProvider) {
             return new ExampleAdapter();
         }
 
 
-        protected override Task<ReadTagValuesQueryDetails> GetReadTagValuesQueryDetails() {
-            return Task.FromResult(TestTag1);
+        protected override IAdapterCallContext CreateCallContext(TestContext context) {
+            return new DefaultAdapterCallContext();
         }
 
 
-        protected override Task<ReadEventMessagesQueryDetails> GetReadEventMessagesQueryDetails() {
-            return Task.FromResult<ReadEventMessagesQueryDetails>(null);
+        protected override GetTagPropertiesRequest CreateGetTagPropertiesRequest(TestContext context) {
+            return new GetTagPropertiesRequest();
         }
 
 
-        protected override async Task EmitTestEvent(ExampleAdapter adapter, EventMessageSubscriptionType subscriptionType, string topic) {
+        protected override GetTagsRequest CreateGetTagsRequest(TestContext context) {
+            return new GetTagsRequest() {
+                Tags = new[] { context.TestName }
+            };
+        }
+
+
+        protected override ReadSnapshotTagValuesRequest CreateReadSnapshotTagValuesRequest(TestContext context) {
+            return new ReadSnapshotTagValuesRequest() { 
+                Tags = new[] { context.TestName }
+            };
+        }
+
+
+        protected override async Task<bool> EmitTestEvent(TestContext context, ExampleAdapter adapter, CancellationToken cancellationToken) {
             await adapter.WriteTestEventMessage(
                 EventMessageBuilder
                     .Create()
-                    .WithTopic(topic)
+                    .WithTopic(context.TestName)
                     .WithUtcEventTime(DateTime.UtcNow)
                     .WithCategory(TestContext.FullyQualifiedTestClassName)
                     .WithMessage(TestContext.TestName)
                     .WithPriority(EventPriority.Low)
                     .Build()
             );
+            return true;
         }
 
 
+        protected override CreateEventMessageSubscriptionRequest CreateEventMessageSubscriptionRequest(TestContext context) {
+            return new CreateEventMessageSubscriptionRequest() { 
+                SubscriptionType = EventMessageSubscriptionType.Active
+            };
+        }
+
+
+        protected override CreateEventMessageTopicSubscriptionRequest CreateEventMessageTopicSubscriptionRequest(TestContext context) {
+            return new CreateEventMessageTopicSubscriptionRequest() { 
+                SubscriptionType = EventMessageSubscriptionType.Active,
+                Topics = new[] { context.TestName }
+            };
+        }
+
+        #endregion
+
+        #region [ Additional Tests ]
+
         [TestMethod]
         public Task UnsupportedFeatureShouldNotBeFound() {
-            return RunAdapterTest((adapter, context) => {
+            return RunAdapterTest((adapter, context, ct) => {
                 var feature = adapter.Features.Get<IFakeAdapterFeature>();
                 Assert.IsNull(feature);
                 return Task.CompletedTask;
@@ -54,7 +97,7 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task SupportedFeatureShouldBeFound() {
-            return RunAdapterTest((adapter, context) => { 
+            return RunAdapterTest((adapter, context, ct) => {
                 var feature = adapter.Features.Get<IReadSnapshotTagValues>();
                 Assert.IsNotNull(feature);
                 return Task.CompletedTask;
@@ -64,21 +107,21 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public Task SnapshotSubscriptionShouldReceiveAdditionalValues() {
-            return RunAdapterTest(async (adapter, context) => {
+            return RunAdapterTest(async (adapter, context, ct) => {
                 var feature = adapter.Features.Get<ISnapshotTagValuePush>();
 
 
-                var subscription = await feature.Subscribe(context, new CreateSnapshotTagValueSubscriptionRequest() { 
-                    Tags = new[] { TestTag1.Id }
-                }, CancellationToken);
+                var subscription = await feature.Subscribe(context, new CreateSnapshotTagValueSubscriptionRequest() {
+                    Tags = new[] { TestContext.TestName }
+                }, ct);
 
                 // Write a couple of values that we should then be able to read out again via 
                 // the subscription's channel.
-                var now = System.DateTime.UtcNow;
+                var now = DateTime.UtcNow;
                 await adapter.WriteSnapshotValue(
                     TagValueQueryResult.Create(
-                        TestTag1.Id,
-                        TestTag1.Id,
+                        TestContext.TestName,
+                        TestContext.TestName,
                         TagValueBuilder
                             .Create()
                             .WithUtcSampleTime(now.AddSeconds(-5))
@@ -88,8 +131,8 @@ namespace DataCore.Adapter.Tests {
                 );
                 await adapter.WriteSnapshotValue(
                     TagValueQueryResult.Create(
-                        TestTag1.Id,
-                        TestTag1.Id,
+                        TestContext.TestName,
+                        TestContext.TestName,
                         TagValueBuilder
                             .Create()
                             .WithUtcSampleTime(now.AddSeconds(-1))
@@ -122,6 +165,8 @@ namespace DataCore.Adapter.Tests {
                 }
             });
         }
+
+        #endregion
 
     }
 }

--- a/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
@@ -28,11 +28,6 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected override IAdapterCallContext CreateCallContext(TestContext context) {
-            return new DefaultAdapterCallContext();
-        }
-
-
         protected override GetTagPropertiesRequest CreateGetTagPropertiesRequest(TestContext context) {
             return new GetTagPropertiesRequest();
         }

--- a/test/DataCore.Adapter.Tests/GrpcProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/GrpcProxyTests.cs
@@ -1,4 +1,6 @@
-﻿using DataCore.Adapter.Grpc.Proxy;
+﻿using System;
+
+using DataCore.Adapter.Grpc.Proxy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -7,8 +9,8 @@ namespace DataCore.Adapter.Tests {
     [TestClass]
     public class GrpcProxyTests : ProxyAdapterTests<GrpcAdapterProxy> {
 
-        protected override GrpcAdapterProxy CreateProxy(string remoteAdapterId) {
-            return ActivatorUtilities.CreateInstance<GrpcAdapterProxy>(ServiceProvider, nameof(GrpcProxyTests), new GrpcAdapterProxyOptions() {
+        protected override GrpcAdapterProxy CreateProxy(string remoteAdapterId, IServiceProvider serviceProvider) {
+            return ActivatorUtilities.CreateInstance<GrpcAdapterProxy>(serviceProvider, nameof(GrpcProxyTests), new GrpcAdapterProxyOptions() {
                 RemoteId = remoteAdapterId
             });
         }

--- a/test/DataCore.Adapter.Tests/HttpProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/HttpProxyTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Extensions;
@@ -28,8 +29,8 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected override HttpAdapterProxy CreateProxy(string remoteAdapterId) {
-            return ActivatorUtilities.CreateInstance<HttpAdapterProxy>(ServiceProvider, nameof(HttpProxyTests), new HttpAdapterProxyOptions() {
+        protected override HttpAdapterProxy CreateProxy(string remoteAdapterId, IServiceProvider serviceProvider) {
+            return ActivatorUtilities.CreateInstance<HttpAdapterProxy>(serviceProvider, nameof(HttpProxyTests), new HttpAdapterProxyOptions() {
                 RemoteId = remoteAdapterId
             });
         }

--- a/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
@@ -1,4 +1,6 @@
-﻿using DataCore.Adapter.AspNetCore.SignalR.Proxy;
+﻿using System;
+
+using DataCore.Adapter.AspNetCore.SignalR.Proxy;
 
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,8 +10,8 @@ namespace DataCore.Adapter.Tests {
 
     public abstract class SignalRProxyTests : ProxyAdapterTests<SignalRAdapterProxy> {
 
-        protected sealed override SignalRAdapterProxy CreateProxy(string remoteAdapterId) {
-            return ActivatorUtilities.CreateInstance<SignalRAdapterProxy>(ServiceProvider, nameof(SignalRProxyTests), new SignalRAdapterProxyOptions() {
+        protected sealed override SignalRAdapterProxy CreateProxy(string remoteAdapterId, IServiceProvider serviceProvider) {
+            return ActivatorUtilities.CreateInstance<SignalRAdapterProxy>(serviceProvider, nameof(SignalRProxyTests), new SignalRAdapterProxyOptions() {
                 RemoteId = remoteAdapterId,
                 ConnectionFactory = key => {
                     var builder = new HubConnectionBuilder()

--- a/test/DataCore.Adapter.Tests/SubscriptionTests.cs
+++ b/test/DataCore.Adapter.Tests/SubscriptionTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;


### PR DESCRIPTION
Add unit test helpers project. This project is used by the unit tests in this repository, and will also be made available as a NuGet package to provide base testing capabilities in external adapter projects.