### PR TITLE
Dependency injection breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Package versions are defined in a [common build properties file](/build/Dependen
 // Register the adapter and required services.
 
 services
-    .AddDataCoreAdapterServices()
+    .AddDataCoreAdapterAspNetCoreServices()
     .AddHostInfo(HostInfo.Create(
         "My Host",
         "A brief description of the hosting application",
@@ -134,7 +134,7 @@ To implement authorization in an ASP.NET Core host application, you can extend t
 
 ```csharp
 services
-    .AddDataCoreAdapterServices()
+    .AddDataCoreAdapterAspNetCoreServices()
     // - snip -
     .AddAdapterFeatureAuthorization<MyAdapterFeatureAuthHandler>();
 ```

--- a/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
@@ -23,7 +23,7 @@ namespace DataCore.Adapter.AspNetCoreExample {
             // Add adapter services
 
             services
-                .AddDataCoreAdapterServices()
+                .AddDataCoreAdapterAspNetCoreServices()
                 .AddHostInfo(
                     "Example .NET Core Host",
                     "An example App Store Connect Adapters host running on ASP.NET Core",

--- a/examples/DataCore.Adapter.NetFxExample/Startup.cs
+++ b/examples/DataCore.Adapter.NetFxExample/Startup.cs
@@ -12,7 +12,7 @@ namespace DataCore.Adapter.NetFxExample {
         public void ConfigureServices(IServiceCollection services) {
 
             services
-                .AddDataCoreAdapterServices()
+                .AddDataCoreAdapterAspNetCoreServices()
                 .AddAdapter<ExampleAdapter>()
                 .AddHostInfo(
                     "Example .NET Framework Host",

--- a/src/DataCore.Adapter.AspNetCore.Common/Configuration/CommonAdapterConfigurationExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/Configuration/CommonAdapterConfigurationExtensions.cs
@@ -31,15 +31,12 @@ namespace Microsoft.Extensions.DependencyInjection {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="services"/> is <see langword="null"/>.
         /// </exception>
-        public static IAdapterConfigurationBuilder AddDataCoreAdapterServices(this IServiceCollection services) {
+        public static IAdapterConfigurationBuilder AddDataCoreAdapterAspNetCoreServices(this IServiceCollection services) {
             if (services == null) {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            var builder = new DefaultAdapterConfigurationBuilder(services);
-            builder.AddDefaultAspNetCoreServices();
-
-            return builder;
+            return services.AddDataCoreAdapterServices().AddDefaultAspNetCoreServices();
         }
 
 

--- a/src/DataCore.Adapter.AspNetCore.Common/Configuration/CommonAdapterConfigurationExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/Configuration/CommonAdapterConfigurationExtensions.cs
@@ -8,6 +8,7 @@ using DataCore.Adapter.AspNetCore.Authorization;
 using DataCore.Adapter.Common;
 using DataCore.Adapter.DependencyInjection;
 
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Extensions.DependencyInjection {
@@ -36,7 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection {
             }
 
             var builder = new DefaultAdapterConfigurationBuilder(services);
-            builder.AddDefaultServices();
+            builder.AddDefaultAspNetCoreServices();
 
             return builder;
         }
@@ -349,9 +350,16 @@ namespace Microsoft.Extensions.DependencyInjection {
         /// <returns>
         ///   The <see cref="IAdapterConfigurationBuilder"/>.
         /// </returns>
-        private static IAdapterConfigurationBuilder AddDefaultServices(this IAdapterConfigurationBuilder builder) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static IAdapterConfigurationBuilder AddDefaultAspNetCoreServices(this IAdapterConfigurationBuilder builder) {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             builder.Services.AddAspNetCoreBackgroundTaskService(options => options.AllowWorkItemRegistrationWhileStopped = true);
-            builder.Services.AddSingleton(HostInfo.Unspecified);
+            builder.Services.TryAddSingleton(HostInfo.Unspecified);
             builder.AddAdapterAccessor<AspNetCoreAdapterAccessor>();
             builder.Services.AddSingleton(typeof(IAdapterAuthorizationService), sp => new DefaultAdapterAuthorizationService(false, sp.GetService<AspNetCore.Authorization.IAuthorizationService>()));
             builder.AddAutomaticInitialization();

--- a/src/DataCore.Adapter.AspNetCore.Common/README.md
+++ b/src/DataCore.Adapter.AspNetCore.Common/README.md
@@ -58,7 +58,7 @@ Adapter services must be added to the application in the `Startup.cs` file's `Co
 
 ```csharp
 services
-    .AddDataCoreAdapterServices()
+    .AddDataCoreAdapterAspNetCoreServices()
     .AddHostInfo(HostInfo.Create(
         "My Host",
         "A brief description of the hosting application",

--- a/src/DataCore.Adapter.AspNetCore.Grpc/README.md
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/README.md
@@ -14,7 +14,7 @@ Adapter services must be added to the application in the `Startup.cs` file's `Co
 
 ```csharp
 services
-    .AddDataCoreAdapterServices()
+    .AddDataCoreAdapterAspNetCoreServices()
     .AddHostInfo(HostInfo.Create(
         "My Host",
         "A brief description of the hosting application",

--- a/src/DataCore.Adapter.AspNetCore.Mvc/README.md
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/README.md
@@ -14,7 +14,7 @@ Adapter services must be added to the application in the `Startup.cs` file's `Co
 
 ```csharp
 services
-    .AddDataCoreAdapterServices()
+    .AddDataCoreAdapterAspNetCoreServices()
     .AddHostInfo(HostInfo.Create(
         "My Host",
         "A brief description of the hosting application",

--- a/src/DataCore.Adapter.AspNetCore.SignalR/README.md
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/README.md
@@ -14,7 +14,7 @@ Adapter services must be added to the application in the `Startup.cs` file's `Co
 
 ```csharp
 services
-    .AddDataCoreAdapterServices()
+    .AddDataCoreAdapterAspNetCoreServices()
     .AddHostInfo(HostInfo.Create(
         "My Host",
         "A brief description of the hosting application",

--- a/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationExtensions.cs
+++ b/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+using DataCore.Adapter.DependencyInjection;
+
+namespace Microsoft.Extensions.DependencyInjection {
+
+    /// <summary>
+    /// DI extensions for configuring adapter services.
+    /// </summary>
+    public static class AdapterConfigurationExtensions {
+
+        /// <summary>
+        /// Adds App Store Connect adapter services to the service collection.
+        /// </summary>
+        /// <param name="services">
+        ///   The service collection.
+        /// </param>
+        /// <returns>
+        ///   An <see cref="IAdapterConfigurationBuilder"/> that can be used to further configure 
+        ///   the App Store Connect adapter services.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="services"/> is <see langword="null"/>.
+        /// </exception>
+        public static IAdapterConfigurationBuilder AddDataCoreAdapterServices(this IServiceCollection services) {
+            if (services == null) {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            var builder = new DefaultAdapterConfigurationBuilder(services);
+            builder.AddDefaultBackgroundTaskService();
+
+            return builder;
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
+++ b/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
@@ -146,7 +146,7 @@ namespace DataCore.Adapter.Tests {
         ///   The method that must be overridden.
         /// </param>
         private void AssertInconclusiveDueToMissingTestInput<TFeature>(string methodName) {
-            Assert.Fail($"Adapter implements {typeof(TFeature).Name}, but the '{methodName}' method used to generate input data for test '{TestContext.TestName}' returned a value that indicates that it has not been overridden. Override {methodName} in your test class to return the input data to use for this test.");
+            Assert.Inconclusive($"Adapter implements {typeof(TFeature).Name}, but the '{methodName}' method used to generate input data for test '{TestContext.TestName}' returned a null value, indicating that the test should be skipped. Override {methodName} in your test class to return a non-null value if you wish to run this test.");
         }
 
 

--- a/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
+++ b/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DataCore.Adapter.Tests.Helpers/ServiceCollectionExtensions.cs
+++ b/src/DataCore.Adapter.Tests.Helpers/ServiceCollectionExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+using DataCore.Adapter.DependencyInjection;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace DataCore.Adapter.Tests {
+
+    /// <summary>
+    /// <see cref="IServiceCollection"/> extensions.
+    /// </summary>
+    public static class ServiceCollectionExtensions {
+
+        /// <summary>
+        /// Adds default App Store Connect adapter services.
+        /// </summary>
+        /// <param name="services">
+        ///   The <see cref="IServiceCollection"/>.
+        /// </param>
+        /// <param name="configure">
+        ///   A delegate that can be used to perform additional adapter-related configuration.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IServiceCollection"/>.
+        /// </returns>
+        public static IServiceCollection AddDefaultAdapterUnitTestServices(
+            this IServiceCollection services, 
+            Action<IAdapterConfigurationBuilder>? configure = null
+        ) {
+            if (services == null) {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddLogging();
+            var adapterConfig = services.AddDataCoreAdapterServices();
+            configure?.Invoke(adapterConfig);
+
+            return services;
+        }
+
+    }
+}

--- a/test/DataCore.Adapter.Tests.WebHost/WebHostStartup.cs
+++ b/test/DataCore.Adapter.Tests.WebHost/WebHostStartup.cs
@@ -29,7 +29,7 @@ namespace DataCore.Adapter.Tests {
             // Add adapter services
 
             services
-                .AddDataCoreAdapterServices()
+                .AddDataCoreAdapterAspNetCoreServices()
                 .AddHostInfo(
                     "Unit Test Standalone Host",
                     "Unit Test App Store Connect Adapters host running on ASP.NET Core",


### PR DESCRIPTION
- Move `AddDataCoreAdapterServices` extension method to DataCore.Adapter.DependencyInjection project.
- DataCore.Adapter.AspNetCore.Common project now defines `AddDataCoreAdapterAspNetCoreServices` extension method, which must be called in ASP.NET Core host apps instead of `AddDataCoreAdapterServices`.

The reasoning behind this breaking change is that it allows registration of adapter services that are not ASP.NET Core-specific to be done in applications using the general .NET Core host instead of having to take a dependency on ASP.NET Core.