### PR TITLE
Regressions and updates

### DIFF
--- a/src/DataCore.Adapter.Core/RealTimeData/TagIdentifier.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagIdentifier.cs
@@ -58,8 +58,32 @@ namespace DataCore.Adapter.RealTimeData {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="name"/> is <see langword="null"/>.
         /// </exception>
+        /// <returns>
+        ///   A new <see cref="TagIdentifier"/> instance.
+        /// </returns>
         public static TagIdentifier Create(string id, string name) {
             return new TagIdentifier(id, name);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="TagIdentifier"/> object that is a copy of an existing instance.
+        /// </summary>
+        /// <param name="other">
+        ///   The <see cref="TagIdentifier"/> to copy.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="other"/> is <see langword="null"/>.
+        /// </exception>
+        /// <returns>
+        ///   A new <see cref="TagIdentifier"/> instance.
+        /// </returns>
+        public static TagIdentifier FromExisting(TagIdentifier other) {
+            if (other == null) {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            return Create(other.Id, other.Name);
         }
 
 

--- a/src/DataCore.Adapter.Core/RealTimeData/TagSummary.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagSummary.cs
@@ -85,5 +85,26 @@ namespace DataCore.Adapter.RealTimeData {
             return new TagSummary(id, name, description, units, dataType);
         }
 
+
+        /// <summary>
+        /// Creates a new <see cref="TagSummary"/> object that is a copy of an existing instance.
+        /// </summary>
+        /// <param name="other">
+        ///   The <see cref="TagSummary"/> to copy.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="other"/> is <see langword="null"/>.
+        /// </exception>
+        /// <returns>
+        ///   A new <see cref="TagSummary"/> instance.
+        /// </returns>
+        public static TagSummary FromExisting(TagSummary other) {
+            if (other == null) {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            return Create(other.Id, other.Name, other.Description, other.Units, other.DataType);
+        }
+
     }
 }

--- a/src/DataCore.Adapter/Events/EventMessagePushWithTopics.cs
+++ b/src/DataCore.Adapter/Events/EventMessagePushWithTopics.cs
@@ -124,6 +124,20 @@ namespace DataCore.Adapter.Events {
         }
 
 
+        /// <summary>
+        /// Gets the composite set of topics that are currently being subscribed to by all 
+        /// subscribers.
+        /// </summary>
+        /// <returns>
+        ///   The subscribed topics.
+        /// </returns>
+        public IEnumerable<string> GetSubscribedTopics() {
+            lock (_subscriberCount) {
+                return _subscriberCount.Keys.ToArray();
+            }
+        }
+
+
         /// <inheritdoc/>
         protected override bool IsTopicMatch(EventMessage value, IEnumerable<string> topics) {
             if (value?.Topic == null) {


### PR DESCRIPTION
- Fixes a regression in #29 that meant that `GetSubscribedTopics` had been removed from `EventMessagePushWithTopics`.
- Adds static `FromExisting` methods to `TagIdentifier` and `TagSummary` classes