### PR TITLE
Stop TagValueBuilder.WithError from setting bad quality for null or white space error messages

### DIFF
--- a/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
@@ -218,11 +218,14 @@ namespace DataCore.Adapter.RealTimeData {
         ///   The updated <see cref="TagValueBuilder"/>.
         /// </returns>
         /// <remarks>
-        ///   The status of the value will also be set to <see cref="TagValueStatus.Bad"/>.
+        ///   If <paramref name="error"/> is not <see langword="null"/> or white space, the status 
+        ///   of the value will also be set to <see cref="TagValueStatus.Bad"/>.
         /// </remarks>
         public TagValueBuilder WithError(string? error) {
             _error = error;
-            _status = TagValueStatus.Bad;
+            if (!string.IsNullOrWhiteSpace(error)) {
+                _status = TagValueStatus.Bad;
+            }
             return this;
         }
 


### PR DESCRIPTION
Change `TagValueBuilder.WithError` so that the status of the value is only set to `Bad` if a non-null, non-white space error message is specified.