### PR TITLE
net46 targeting and supported features on tags

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AbstractionsResources.Designer.cs
+++ b/src/DataCore.Adapter.Abstractions/AbstractionsResources.Designer.cs
@@ -223,15 +223,6 @@ namespace DataCore.Adapter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Quality status is always &quot;Good&quot;..
-        /// </summary>
-        public static string DataFunction_Property_StatusCalculation_ValueGood {
-            get {
-                return ResourceManager.GetString("DataFunction_Property_StatusCalculation_ValueGood", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &quot;Uncertain&quot; if any non-good quality values were skipped, or &quot;Good&quot; otherwise..
         /// </summary>
         public static string DataFunction_Property_StatusCalculation_ValueGoodUnlessNonGoodSkipped {

--- a/src/DataCore.Adapter.Abstractions/AbstractionsResources.resx
+++ b/src/DataCore.Adapter.Abstractions/AbstractionsResources.resx
@@ -171,9 +171,6 @@
   <data name="DataFunction_Property_StatusCalculation_Description" xml:space="preserve">
     <value>The method used to calculate the quality status for the function.</value>
   </data>
-  <data name="DataFunction_Property_StatusCalculation_ValueGood" xml:space="preserve">
-    <value>Quality status is always "Good".</value>
-  </data>
   <data name="DataFunction_Property_StatusCalculation_ValueGoodUnlessNonGoodSkipped" xml:space="preserve">
     <value>"Uncertain" if any non-good quality values were skipped, or "Good" otherwise.</value>
   </data>

--- a/src/DataCore.Adapter.Abstractions/DataCore.Adapter.Abstractions.csproj
+++ b/src/DataCore.Adapter.Abstractions/DataCore.Adapter.Abstractions.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="IntelligentPlant.BackgroundTasks" Version="$(IntelligentPlantBackgroundTasksVersion)" />
+    <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/DataCore.Adapter.Abstractions/RealTimeData/DefaultDataFunctions.cs
+++ b/src/DataCore.Adapter.Abstractions/RealTimeData/DefaultDataFunctions.cs
@@ -81,14 +81,7 @@ namespace DataCore.Adapter.RealTimeData {
             AbstractionsResources.DataFunction_Interp_Name,
             AbstractionsResources.DataFunction_Interp_Description,
             DataFunctionSampleTimeType.StartTime,
-            DataFunctionStatusType.Custom,
-            new [] {
-                AdapterProperty.Create(
-                    AbstractionsResources.DataFunction_Property_StatusCalculation, 
-                    AbstractionsResources.DataFunction_Property_StatusCalculation_ValueWorstCase, 
-                    AbstractionsResources.DataFunction_Property_StatusCalculation_Description
-                )
-            }
+            DataFunctionStatusType.WorstCase
         );
 
         /// <summary>
@@ -217,14 +210,7 @@ namespace DataCore.Adapter.RealTimeData {
             AbstractionsResources.DataFunction_PercentGood_Name,
             AbstractionsResources.DataFunction_PercentGood_Description,
             DataFunctionSampleTimeType.StartTime,
-            DataFunctionStatusType.Custom,
-            new[] {
-                AdapterProperty.Create(
-                    AbstractionsResources.DataFunction_Property_StatusCalculation,
-                    AbstractionsResources.DataFunction_Property_StatusCalculation_ValueGood,
-                    AbstractionsResources.DataFunction_Property_StatusCalculation_Description
-                )
-            }
+            DataFunctionStatusType.AlwaysGood
         );
 
         /// <summary>
@@ -235,14 +221,7 @@ namespace DataCore.Adapter.RealTimeData {
             AbstractionsResources.DataFunction_PercentBad_Name,
             AbstractionsResources.DataFunction_PercentBad_Description,
             DataFunctionSampleTimeType.StartTime,
-            DataFunctionStatusType.Custom,
-            new[] {
-                AdapterProperty.Create(
-                    AbstractionsResources.DataFunction_Property_StatusCalculation,
-                    AbstractionsResources.DataFunction_Property_StatusCalculation_ValueGood,
-                    AbstractionsResources.DataFunction_Property_StatusCalculation_Description
-                )
-            }
+            DataFunctionStatusType.AlwaysGood
         );
 
 

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
@@ -1540,6 +1540,7 @@ namespace DataCore.Adapter {
                 tagDefinition.Units,
                 tagDefinition.DataType.ToAdapterVariantType(),
                 tagDefinition.States.Select(x => x.ToAdapterDigitalState()).ToArray(),
+                tagDefinition.SupportedFeatures.Select(x => Uri.TryCreate(x, UriKind.Absolute, out var uri) ? uri : null).Where(x => x != null).ToArray()!,
                 tagDefinition.Properties.Select(x => x.ToAdapterProperty()).ToArray(),
                 tagDefinition.Labels
             );
@@ -1574,6 +1575,15 @@ namespace DataCore.Adapter {
                         continue;
                     }
                     result.States.Add(item.ToGrpcDigitalState());
+                }
+            }
+
+            if (tag.SupportedFeatures != null) {
+                foreach (var item in tag.SupportedFeatures) {
+                    if (item == null) {
+                        continue;
+                    }
+                    result.SupportedFeatures.Add(item.ToString());
                 }
             }
 

--- a/src/DataCore.Adapter.Core/Common/Variant.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.cs
@@ -345,7 +345,7 @@ namespace DataCore.Adapter.Common {
 
         /// <inheritdoc/>
         public override int GetHashCode() {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET46
             return HashGenerator.Combine(Type, Value);
 #else
             return HashCode.Combine(Type, Value);

--- a/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
+++ b/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net45</TargetFrameworks>
     <RootNamespace>DataCore.Adapter</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Core</PackageId>
     <Description>Base types for App Store Connect adapters.</Description>
@@ -12,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotationsVersion)" />
-    <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
+++ b/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net46</TargetFrameworks>
     <RootNamespace>DataCore.Adapter</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Core</PackageId>
     <Description>Base types for App Store Connect adapters.</Description>

--- a/src/DataCore.Adapter.Core/HashGenerator.cs
+++ b/src/DataCore.Adapter.Core/HashGenerator.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NET46
 
 namespace DataCore.Adapter {
 

--- a/src/DataCore.Adapter.Core/RealTimeData/DataFunctionStatusType.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/DataFunctionStatusType.cs
@@ -8,22 +8,38 @@
         /// <summary>
         /// The computation method is not specified.
         /// </summary>
-        Unspecified,
+        Unspecified = 1,
 
         /// <summary>
         /// The status is calculated based on a percentage of value counts.
         /// </summary>
-        PercentValues,
+        PercentValues = 2,
 
         /// <summary>
         /// The status is calculated based on a percentage of the time interval.
         /// </summary>
-        PercentTime,
+        PercentTime = 3,
 
         /// <summary>
         /// The status calculation is custom to the data function.
         /// </summary>
-        Custom
+        Custom = 4,
+
+        /// <summary>
+        /// The quality status matches the status of a raw value selected by the function.
+        /// </summary>
+        Raw = 5,
+
+        /// <summary>
+        /// The status calculation always returns <see cref="TagValueStatus.Good"/>.
+        /// </summary>
+        AlwaysGood = 6,
+
+        /// <summary>
+        /// The quality status is the worst-case of all of the samples in the sample bucket used 
+        /// to calculate the data function result.
+        /// </summary>
+        WorstCase = 7
 
     }
 }

--- a/src/DataCore.Adapter.Core/RealTimeData/TagDefinition.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagDefinition.cs
@@ -18,6 +18,11 @@ namespace DataCore.Adapter.RealTimeData {
         public IEnumerable<DigitalState> States { get; }
 
         /// <summary>
+        /// The adapter features that can be used to read data from or write data to this tag.
+        /// </summary>
+        public IEnumerable<Uri> SupportedFeatures { get; }
+
+        /// <summary>
         /// Bespoke tag properties.
         /// </summary>
         public IEnumerable<AdapterProperty> Properties { get; }
@@ -50,6 +55,9 @@ namespace DataCore.Adapter.RealTimeData {
         ///   The discrete states for the tag. Ignored if <paramref name="dataType"/> is not 
         ///   <see cref="VariantType.Int32"/>.
         /// </param>
+        /// <param name="supportedFeatures">
+        ///   The adapter features that can be used to read data from or write data to this tag.
+        /// </param>
         /// <param name="properties">
         ///   Additional tag properties.
         /// </param>
@@ -69,12 +77,14 @@ namespace DataCore.Adapter.RealTimeData {
             string? units, 
             VariantType dataType, 
             IEnumerable<DigitalState>? states, 
+            IEnumerable<Uri>? supportedFeatures,
             IEnumerable<AdapterProperty>? properties, 
             IEnumerable<string>? labels
         ) : base(id, name, description, units, dataType) {
             States = dataType != VariantType.Int32
                 ? Array.Empty<DigitalState>()
                 : states?.ToArray() ?? Array.Empty<DigitalState>();
+            SupportedFeatures = supportedFeatures?.Where(x => x != null)?.ToArray() ?? Array.Empty<Uri>();
             Properties = properties?.ToArray() ?? Array.Empty<AdapterProperty>();
             Labels = labels?.ToArray() ?? Array.Empty<string>();
         }
@@ -102,6 +112,9 @@ namespace DataCore.Adapter.RealTimeData {
         ///   The discrete states for the tag. Ignored if <paramref name="dataType"/> is not 
         ///   <see cref="VariantType.Int32"/>.
         /// </param>
+        /// <param name="supportedFeatures">
+        ///   The adapter features that can be used to read data from or write data to this tag.
+        /// </param>
         /// <param name="properties">
         ///   Additional tag properties.
         /// </param>
@@ -114,8 +127,8 @@ namespace DataCore.Adapter.RealTimeData {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="name"/> is <see langword="null"/>.
         /// </exception>
-        public static TagDefinition Create(string id, string name, string? description, string? units, VariantType dataType, IEnumerable<DigitalState>? states, IEnumerable<AdapterProperty>? properties, IEnumerable<string>? labels) {
-            return new TagDefinition(id, name, description, units, dataType, states, properties, labels);
+        public static TagDefinition Create(string id, string name, string? description, string? units, VariantType dataType, IEnumerable<DigitalState>? states, IEnumerable<Uri>? supportedFeatures, IEnumerable<AdapterProperty>? properties, IEnumerable<string>? labels) {
+            return new TagDefinition(id, name, description, units, dataType, states, supportedFeatures, properties, labels);
         }
 
 
@@ -143,6 +156,7 @@ namespace DataCore.Adapter.RealTimeData {
                 tag.Units,
                 tag.DataType,
                 tag.States.Where(x => x != null).Select(x => new DigitalState(x.Name, x.Value)),
+                tag.SupportedFeatures,
                 tag.Properties.Where(x => x != null).Select(x => new AdapterProperty(x.Name, x.Value, x.Description)),
                 tag.Labels
             );

--- a/src/DataCore.Adapter.Core/RealTimeData/TagIdentifier.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagIdentifier.cs
@@ -184,7 +184,7 @@ namespace DataCore.Adapter.RealTimeData {
         ///   The hash code for the instance.
         /// </returns>
         public int GetHashCode(TagIdentifier obj) {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET46
             return _compareIdOnly
                 ? HashGenerator.Combine(obj?.Id?.ToUpperInvariant())
                 : HashGenerator.Combine(obj?.Id?.ToUpperInvariant(), obj?.Name?.ToUpperInvariant());

--- a/src/DataCore.Adapter.Csv/CsvAdapter.cs
+++ b/src/DataCore.Adapter.Csv/CsvAdapter.cs
@@ -183,6 +183,7 @@ namespace DataCore.Adapter.Csv {
                     null, 
                     Common.VariantType.Double, 
                     null, 
+                    null,
                     new[] { new AdapterProperty(nameof(definition), definition) }, 
                     new[] { "CSV" }
                 );
@@ -243,6 +244,7 @@ namespace DataCore.Adapter.Csv {
                 states.Count > 0
                     ? states.Select(x => DigitalState.Create(x.Key, x.Value))
                     : null,
+                null,
                 new[] { new AdapterProperty(nameof(definition), definitionOriginal) },
                 new[] { "CSV" }
             );

--- a/src/DataCore.Adapter.Http.Client/DataCore.Adapter.Http.Client.csproj
+++ b/src/DataCore.Adapter.Http.Client/DataCore.Adapter.Http.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net46</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.Http.Client</PackageId>
     <Description>HTTP client for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/DataCore.Adapter.Http.Client/DataCore.Adapter.Http.Client.csproj
+++ b/src/DataCore.Adapter.Http.Client/DataCore.Adapter.Http.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net45</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.Http.Client</PackageId>
     <Description>HTTP client for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/DataCore.Adapter.Json/TagDefinitionConverter.cs
+++ b/src/DataCore.Adapter.Json/TagDefinitionConverter.cs
@@ -23,6 +23,7 @@ namespace DataCore.Adapter.Json {
             string units = null!;
             VariantType dataType = VariantType.Unknown;
             DigitalState[] states = null!;
+            Uri[] supportedFeatures = null!;
             AdapterProperty[] properties = null!;
             string[] labels = null!;
 
@@ -54,6 +55,9 @@ namespace DataCore.Adapter.Json {
                 else if (string.Equals(propertyName, nameof(TagDefinition.States), StringComparison.OrdinalIgnoreCase)) {
                     states = JsonSerializer.Deserialize<DigitalState[]>(ref reader, options);
                 }
+                else if (string.Equals(propertyName, nameof(TagDefinition.SupportedFeatures), StringComparison.OrdinalIgnoreCase)) {
+                    supportedFeatures = JsonSerializer.Deserialize<Uri[]>(ref reader, options);
+                }
                 else if (string.Equals(propertyName, nameof(TagDefinition.Properties), StringComparison.OrdinalIgnoreCase)) {
                     properties = JsonSerializer.Deserialize<AdapterProperty[]>(ref reader, options);
                 }
@@ -65,7 +69,7 @@ namespace DataCore.Adapter.Json {
                 }
             }
 
-            return TagDefinition.Create(id, name, description, units, dataType, states, properties, labels);
+            return TagDefinition.Create(id, name, description, units, dataType, states, supportedFeatures, properties, labels);
         }
 
 
@@ -83,6 +87,7 @@ namespace DataCore.Adapter.Json {
             WritePropertyValue(writer, nameof(TagDefinition.Units), value.Units, options);
             WritePropertyValue(writer, nameof(TagDefinition.DataType), value.DataType, options);
             WritePropertyValue(writer, nameof(TagDefinition.States), value.States, options);
+            WritePropertyValue(writer, nameof(TagDefinition.SupportedFeatures), value.SupportedFeatures, options);
             WritePropertyValue(writer, nameof(TagDefinition.Properties), value.Properties, options);
             WritePropertyValue(writer, nameof(TagDefinition.Labels), value.Labels, options);
             writer.WriteEndObject();

--- a/src/DataCore.Adapter/RealTimeData/TagDefinitionBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagDefinitionBuilder.cs
@@ -42,6 +42,11 @@ namespace DataCore.Adapter.RealTimeData {
         private readonly List<DigitalState> _states = new List<DigitalState>();
 
         /// <summary>
+        /// The adapter features that can be used to read from or write to the tag.
+        /// </summary>
+        private readonly HashSet<Uri> _supportedFeatures = new HashSet<Uri>();
+
+        /// <summary>
         /// The bespoke tag properties.
         /// </summary>
         private readonly List<AdapterProperty> _properties = new List<AdapterProperty>();
@@ -72,6 +77,7 @@ namespace DataCore.Adapter.RealTimeData {
             WithUnits(existing.Units);
             WithDataType(existing.DataType);
             WithDigitalStates(existing.States);
+            WithSupportedFeatures(existing.SupportedFeatures);
             WithProperties(existing.Properties);
             WithLabels(existing.Labels);
         }
@@ -117,7 +123,7 @@ namespace DataCore.Adapter.RealTimeData {
         ///   A new <see cref="TagDefinition"/> object.
         /// </returns>
         public TagDefinition Build() {
-            return new TagDefinition(_id!, _name!, _description, _units, _dataType, _states, _properties, _labels);
+            return new TagDefinition(_id!, _name!, _description, _units, _dataType, _states, _supportedFeatures, _properties, _labels);
         }
 
 
@@ -249,6 +255,108 @@ namespace DataCore.Adapter.RealTimeData {
         /// </returns>
         public TagDefinitionBuilder ClearDigitalStates() {
             _states.Clear();
+            return this;
+        }
+
+
+        /// <summary>
+        /// Adds supported features to the tag.
+        /// </summary>
+        /// <param name="uris">
+        ///   The feature URIs.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TagDefinitionBuilder"/>.
+        /// </returns>
+        public TagDefinitionBuilder WithSupportedFeatures(params Uri[] uris) {
+            return WithSupportedFeatures((IEnumerable<Uri>) uris);
+        }
+
+
+        /// <summary>
+        /// Adds supported features to the tag.
+        /// </summary>
+        /// <param name="uris">
+        ///   The feature URIs.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TagDefinitionBuilder"/>.
+        /// </returns>
+        public TagDefinitionBuilder WithSupportedFeatures(IEnumerable<Uri> uris) {
+            if (uris != null) {
+                foreach (var uri in uris) {
+                    if (uri != null && (uri.IsStandardFeatureUri() || uri.IsExtensionFeatureUri())) {
+                        _supportedFeatures.Add(uri.EnsurePathHasTrailingSlash());
+                    }
+                }
+            }
+
+            return this;
+        }
+
+
+        /// <summary>
+        /// Adds supported features to the tag.
+        /// </summary>
+        /// <param name="uriStrings">
+        ///   The feature URIs.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TagDefinitionBuilder"/>.
+        /// </returns>
+        public TagDefinitionBuilder WithSupportedFeatures(params string[] uriStrings) {
+            return WithSupportedFeatures((IEnumerable<string>) uriStrings);
+        }
+
+
+        /// <summary>
+        /// Adds supported features to the tag.
+        /// </summary>
+        /// <param name="uriStrings">
+        ///   The feature URIs.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TagDefinitionBuilder"/>.
+        /// </returns>
+        public TagDefinitionBuilder WithSupportedFeatures(IEnumerable<string> uriStrings) {
+            if (uriStrings != null) {
+                foreach (var uriString in uriStrings) {
+                    if (Uri.TryCreate(uriString, UriKind.Absolute, out var uri)) {
+                        WithSupportedFeatures(uri);
+                    }
+                }
+            }
+
+            return this;
+        }
+
+
+        /// <summary>
+        /// Adds a supported feature to the tag.
+        /// </summary>
+        /// <typeparam name="TFeature">
+        ///   The feature type.
+        /// </typeparam>
+        /// <returns>
+        ///   The updated <see cref="TagDefinitionBuilder"/>.
+        /// </returns>
+        public TagDefinitionBuilder WithSupportedFeature<TFeature>() where TFeature : IAdapterFeature {
+            foreach (var uri in typeof(TFeature).GetAdapterFeatureUris()) {
+                _supportedFeatures.Add(uri.EnsurePathHasTrailingSlash());
+            }
+
+            return this;
+        }
+
+
+        /// <summary>
+        /// Removes all supported features from the tag.
+        /// </summary>
+        /// <returns>
+        ///   The updated <see cref="TagDefinitionBuilder"/>.
+        /// </returns>
+        public TagDefinitionBuilder ClearSupportedFeatures() {
+            _supportedFeatures.Clear();
             return this;
         }
 

--- a/src/DataCore.Adapter/SubscriptionChannel.cs
+++ b/src/DataCore.Adapter/SubscriptionChannel.cs
@@ -11,7 +11,6 @@ namespace DataCore.Adapter {
     /// <summary>
     /// Holds information about a subscription channel.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1063:Implement IDisposable Correctly", Justification = "Subclasses should only exist inside this library")]
     public class SubscriptionChannel<TTopic, TValue> : IDisposable {
 
         /// <summary>

--- a/src/Protos/datacore/adapter/Types.proto
+++ b/src/Protos/datacore/adapter/Types.proto
@@ -246,6 +246,7 @@ message TagDefinition {
     repeated DigitalState states = 6;
     repeated AdapterProperty properties = 7;
     repeated string labels = 8;
+    repeated string supported_features = 9;
 }
 
 

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -96,7 +96,7 @@ namespace DataCore.Adapter.Tests {
 
             var result = Channel.CreateUnbounded<TagDefinition>();
             foreach (var item in request.Tags) {
-                result.Writer.TryWrite(TagDefinition.Create(item, item, null, null, VariantType.Double, null, null, null));
+                result.Writer.TryWrite(TagDefinition.Create(item, item, null, null, VariantType.Double, null, null, null, null));
             }
             result.Writer.TryComplete();
             return Task.FromResult(result.Reader);

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -637,25 +637,25 @@ namespace DataCore.Adapter.Tests {
         [TestMethod]
         public void TagDefinition_ShouldRoundTrip() {
             var options = GetOptions();
-            var expected = new TagDefinition(
-               "Id",
-               "Name",
-               "Description",
-               "Units",
-               VariantType.Int32,
-               new[] { 
-                   DigitalState.Create("State1", 100),
-                   DigitalState.Create("State2", 200)
-               },
-               new [] {
-                   AdapterProperty.Create("Prop1", 100),
-                   AdapterProperty.Create("Prop2", "Value")
-               },
-               new [] {
-                   "Label1",
-                   "Label2"
-               }
-            );
+            var expected = TagDefinitionBuilder
+                .Create()
+                .WithId("Id")
+                .WithName("Name")
+                .WithDescription("Description")
+                .WithUnits("Units")
+                .WithDataType(VariantType.Int32)
+                .WithDigitalStates(
+                    DigitalState.Create("State1", 100),
+                    DigitalState.Create("State2", 200)
+                )
+                .WithSupportedFeature<IReadSnapshotTagValues>()
+                .WithSupportedFeature<IReadRawTagValues>()
+                .WithProperties(
+                    AdapterProperty.Create("Prop1", 100),
+                    AdapterProperty.Create("Prop2", "Value")
+                )
+                .WithLabels("Label1", "Label2")
+                .Build();
 
             var json = JsonSerializer.Serialize(expected, options);
             var actual = JsonSerializer.Deserialize<TagDefinition>(json, options);
@@ -673,6 +673,14 @@ namespace DataCore.Adapter.Tests {
 
                 Assert.AreEqual(expectedValue.Name, actualValue.Name);
                 Assert.AreEqual(expectedValue.Value, actualValue.Value);
+            }
+
+            Assert.AreEqual(expected.SupportedFeatures.Count(), actual.SupportedFeatures.Count());
+            for (var i = 0; i < expected.SupportedFeatures.Count(); i++) {
+                var expectedValue = expected.SupportedFeatures.ElementAt(i);
+                var actualValue = actual.SupportedFeatures.ElementAt(i);
+
+                Assert.AreEqual(expectedValue, actualValue);
             }
 
             Assert.AreEqual(expected.Properties.Count(), actual.Properties.Count());


### PR DESCRIPTION
- Move `System.Threading.Channels` reference from `DataCore.Adapter.Core` to `DataCore.Adapter.Abstractions`.
- Add `net46` targeting to `DataCore.Adapter.Core` and `DataCore.Adapter.Http.Client`.
- Add additional values to `DataFunctionStatusType` enum and update `DefaultDataFunctions` definitions.
- Add `SupportedFeatures` collection to `TagDefinitionExtended`, to allow adapters to describe on a tag-by-tag basis which types of queries can be performed. This is useful when e.g. aggregated queries can be performed on floating-point tags, but not on tags using digital states.