### PR TITLE
Add subscription added/cancelled methods to SubscriptionManager

### DIFF
--- a/src/DataCore.Adapter/Events/EventMessagePush.cs
+++ b/src/DataCore.Adapter/Events/EventMessagePush.cs
@@ -97,12 +97,14 @@ namespace DataCore.Adapter.Events {
         /// <inheritdoc/>
         protected override void OnSubscriptionAdded(EventSubscriptionChannel subscription) {
             HasActiveSubscriptions = HasSubscriptions && GetSubscriptions().Any(x => x.SubscriptionType == EventMessageSubscriptionType.Active);
+            base.OnSubscriptionAdded(subscription);
         }
 
 
         /// <inheritdoc/>
         protected override void OnSubscriptionCancelled(EventSubscriptionChannel subscription) { 
             HasActiveSubscriptions = HasSubscriptions && GetSubscriptions().Any(x => x.SubscriptionType == EventMessageSubscriptionType.Active);
+            base.OnSubscriptionCancelled(subscription);
         }
 
 

--- a/src/DataCore.Adapter/SubscriptionManager.cs
+++ b/src/DataCore.Adapter/SubscriptionManager.cs
@@ -91,6 +91,16 @@ namespace DataCore.Adapter {
         public event Action<TValue>? Publish;
 
         /// <summary>
+        /// Raised whenever a subscription is added to the subscription manager.
+        /// </summary>
+        public event Action<TSubscription>? SubscriptionAdded;
+
+        /// <summary>
+        /// Raised whenever a subscription is cancelled.
+        /// </summary>
+        public event Action<TSubscription>? SubscriptionCancelled;
+
+        /// <summary>
         /// Channel that is used to publish new event messages. This is a single-consumer channel; the 
         /// consumer thread will then re-publish to subscribers as required.
         /// </summary>
@@ -128,7 +138,9 @@ namespace DataCore.Adapter {
         /// <param name="subscription">
         ///   The subscription.
         /// </param>
-        protected virtual void OnSubscriptionAdded(TSubscription subscription) { }
+        protected virtual void OnSubscriptionAdded(TSubscription subscription) {
+            SubscriptionAdded?.Invoke(subscription);
+        }
 
 
         /// <summary>
@@ -137,7 +149,9 @@ namespace DataCore.Adapter {
         /// <param name="subscription">
         ///   The subscription.
         /// </param>
-        protected virtual void OnSubscriptionCancelled(TSubscription subscription) { }
+        protected virtual void OnSubscriptionCancelled(TSubscription subscription) {
+            SubscriptionCancelled?.Invoke(subscription);
+        }
 
 
         /// <summary>

--- a/test/DataCore.Adapter.Tests/SubscriptionTests.cs
+++ b/test/DataCore.Adapter.Tests/SubscriptionTests.cs
@@ -16,6 +16,58 @@ namespace DataCore.Adapter.Tests {
     public class SubscriptionTests : TestsBase {
 
         [TestMethod]
+        public async Task SnapshotSubscriptionManagerShouldNotifyWhenSubscriptionIsAdded() {
+            var options = new SnapshotTagValuePushOptions() {
+                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray())
+            };
+
+            using (var feature = new SnapshotTagValuePush(options, null, null)) {
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                feature.SubscriptionAdded += sub => tcs.TrySetResult(true);
+
+                var subscription = await feature.Subscribe(
+                    ExampleCallContext.ForPrincipal(null),
+                    new CreateSnapshotTagValueSubscriptionRequest() {
+                        Tags = new[] { TestContext.TestName }
+                    },
+                    CancellationToken
+                );
+
+                CancelAfter(TimeSpan.FromSeconds(1));
+                var success = await tcs.Task.WithCancellation(CancellationToken);
+                Assert.IsTrue(success);
+            }
+        }
+
+
+        [TestMethod]
+        public async Task SnapshotSubscriptionManagerShouldNotifyWhenSubscriptionIsCancelled() {
+            var options = new SnapshotTagValuePushOptions() {
+                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray())
+            };
+
+            using (var feature = new SnapshotTagValuePush(options, null, null)) {
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                feature.SubscriptionCancelled += sub => tcs.TrySetResult(true);
+
+                var subscription = await feature.Subscribe(
+                    ExampleCallContext.ForPrincipal(null),
+                    new CreateSnapshotTagValueSubscriptionRequest() {
+                        Tags = new[] { TestContext.TestName }
+                    },
+                    CancellationToken
+                );
+
+                Cancel();
+                var success = await tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                Assert.IsTrue(success);
+            }
+        }
+
+
+        [TestMethod]
         public async Task SnapshotSubscriptionShouldEmitValues() {
             var now = DateTime.UtcNow;
 
@@ -288,6 +340,50 @@ namespace DataCore.Adapter.Tests {
 
 
         [TestMethod]
+        public async Task EventSubscriptionManagerShouldNotifyWhenSubscriptionIsAdded() {
+            var options = new EventMessagePushOptions();
+
+            using (var feature = new EventMessagePush(options, null, null)) {
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                feature.SubscriptionAdded += sub => tcs.TrySetResult(true);
+
+                var subscription = await feature.Subscribe(
+                    ExampleCallContext.ForPrincipal(null),
+                    new CreateEventMessageSubscriptionRequest(),
+                    CancellationToken
+                );
+
+                CancelAfter(TimeSpan.FromSeconds(1));
+                var success = await tcs.Task.WithCancellation(CancellationToken);
+                Assert.IsTrue(success);
+            }
+        }
+
+
+        [TestMethod]
+        public async Task EventSubscriptionManagerShouldNotifyWhenSubscriptionIsCancelled() {
+            var options = new EventMessagePushOptions();
+
+            using (var feature = new EventMessagePush(options, null, null)) {
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                feature.SubscriptionCancelled += sub => tcs.TrySetResult(true);
+
+                var subscription = await feature.Subscribe(
+                    ExampleCallContext.ForPrincipal(null),
+                    new CreateEventMessageSubscriptionRequest(),
+                    CancellationToken
+                );
+
+                Cancel();
+                var success = await tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                Assert.IsTrue(success);
+            }
+        }
+
+
+        [TestMethod]
         public async Task EventSubscriptionShouldEmitValues() {
             var now = DateTime.UtcNow;
 
@@ -331,6 +427,50 @@ namespace DataCore.Adapter.Tests {
                     new CreateEventMessageSubscriptionRequest(),
                     CancellationToken
                 ));
+            }
+        }
+
+
+        [TestMethod]
+        public async Task EventTopicSubscriptionManagerShouldNotifyWhenSubscriptionIsAdded() {
+            var options = new EventMessagePushWithTopicsOptions();
+
+            using (var feature = new EventMessagePushWithTopics(options, null, null)) {
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                feature.SubscriptionAdded += sub => tcs.TrySetResult(true);
+
+                var subscription = await feature.Subscribe(
+                    ExampleCallContext.ForPrincipal(null),
+                    new CreateEventMessageTopicSubscriptionRequest(),
+                    CancellationToken
+                );
+
+                CancelAfter(TimeSpan.FromSeconds(1));
+                var success = await tcs.Task.WithCancellation(CancellationToken);
+                Assert.IsTrue(success);
+            }
+        }
+
+
+        [TestMethod]
+        public async Task EventTopicSubscriptionManagerShouldNotifyWhenSubscriptionIsCancelled() {
+            var options = new EventMessagePushWithTopicsOptions();
+
+            using (var feature = new EventMessagePushWithTopics(options, null, null)) {
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                feature.SubscriptionCancelled += sub => tcs.TrySetResult(true);
+
+                var subscription = await feature.Subscribe(
+                    ExampleCallContext.ForPrincipal(null),
+                    new CreateEventMessageTopicSubscriptionRequest(),
+                    CancellationToken
+                );
+
+                Cancel();
+                var success = await tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                Assert.IsTrue(success);
             }
         }
 


### PR DESCRIPTION
Add SubscriptionAdded and SubscriptionCancelled methods to SubscriptionManager. These are intended to be used in testing/debugging scenarios.