### PR TITLE
Tag value channel extensions

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -34,7 +34,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
                 cancellationToken
             ).ConfigureAwait(false);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 await hubChannel.Forward(ch, ct).ConfigureAwait(false);

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -54,7 +54,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
                 cancellationToken
             ).ConfigureAwait(false);
 
-            var result = ChannelExtensions.CreateTagValueChannel<ProcessedTagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateProcessedTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 await hubChannel.Forward(ch, ct).ConfigureAwait(false);

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -34,7 +34,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
                 cancellationToken
             ).ConfigureAwait(false);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 await hubChannel.Forward(ch, ct).ConfigureAwait(false);

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -34,7 +34,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
                 cancellationToken
             ).ConfigureAwait(false);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 await hubChannel.Forward(ch, ct).ConfigureAwait(false);

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -34,7 +34,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
                 cancellationToken
             ).ConfigureAwait(false);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 await hubChannel.Forward(ch, ct).ConfigureAwait(false);

--- a/src/DataCore.Adapter.Csv/CsvAdapter.cs
+++ b/src/DataCore.Adapter.Csv/CsvAdapter.cs
@@ -543,7 +543,7 @@ namespace DataCore.Adapter.Csv {
             CheckStarted();
             ValidationExtensions.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>();
+            var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 await ReadSnapshotTagValues(context, request, ch, ct).ConfigureAwait(false);
@@ -719,7 +719,7 @@ namespace DataCore.Adapter.Csv {
             CheckStarted();
             ValidationExtensions.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>();
+            var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 await ReadRawTagValues(context, request, ch, ct).ConfigureAwait(false);

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -45,7 +45,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
             var grpcResponse = client.ReadPlotTagValues(grpcRequest, GetCallOptions(context, cancellationToken));
 
-            var result = ChannelExtensions.CreateTagValueChannel<Adapter.RealTimeData.TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 try {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -79,7 +79,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
             var grpcResponse = client.ReadProcessedTagValues(grpcRequest, GetCallOptions(context, cancellationToken));
 
-            var result = ChannelExtensions.CreateTagValueChannel<Adapter.RealTimeData.ProcessedTagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateProcessedTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 try {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -46,7 +46,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
             var grpcResponse = client.ReadRawTagValues(grpcRequest, GetCallOptions(context, cancellationToken));
 
-            var result = ChannelExtensions.CreateTagValueChannel<Adapter.RealTimeData.TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 try {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -42,7 +42,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
             var grpcResponse = client.ReadSnapshotTagValues(grpcRequest, GetCallOptions(context, cancellationToken));
 
-            var result = ChannelExtensions.CreateTagValueChannel<Adapter.RealTimeData.TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 try {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -44,7 +44,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
             var grpcResponse = client.ReadTagValuesAtTimes(grpcRequest, GetCallOptions(context, cancellationToken));
 
-            var result = ChannelExtensions.CreateTagValueChannel<Adapter.RealTimeData.TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 try {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
@@ -93,7 +93,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             }, BackgroundTaskService, cancellationToken);
 
             // Stream the results.
-            var result = ChannelExtensions.CreateTagValueChannel<Adapter.RealTimeData.TagValueQueryResult>(0);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 // Read tag values.

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -27,7 +27,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             }
             HttpAdapterProxy.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var client = GetClient();

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -47,7 +47,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             }
             HttpAdapterProxy.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<ProcessedTagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateProcessedTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var client = GetClient();

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -27,7 +27,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             }
             HttpAdapterProxy.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var client = GetClient();

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -27,7 +27,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             }
             HttpAdapterProxy.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var client = GetClient();

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -27,7 +27,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             }
             HttpAdapterProxy.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>(-1);
+            var result = ChannelExtensions.CreateTagValueChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var client = GetClient();

--- a/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
+++ b/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
@@ -568,7 +568,7 @@ namespace DataCore.Adapter.WaveGenerator {
             ValidateContext(context);
             ValidateRequest(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>();
+            var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var sampleTime = RoundDownToNearestSampleTime(DateTime.UtcNow, GetSampleInterval());
@@ -598,7 +598,7 @@ namespace DataCore.Adapter.WaveGenerator {
             ValidateContext(context);
             ValidateRequest(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>();
+            var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var sampleInterval = GetSampleInterval();
@@ -651,7 +651,7 @@ namespace DataCore.Adapter.WaveGenerator {
             ValidateContext(context);
             ValidateRequest(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>();
+            var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 foreach (var tag in request.Tags) {

--- a/src/DataCore.Adapter/ChannelExtensions.cs
+++ b/src/DataCore.Adapter/ChannelExtensions.cs
@@ -182,6 +182,70 @@ namespace DataCore.Adapter {
         /// <summary>
         /// Creates a channel that can be used to return results to tag value queries.
         /// </summary>
+        /// <param name="fullMode">
+        ///   The action to take when a write is attempted on a full channel.
+        /// </param>
+        /// <param name="capacity">
+        ///   The capacity of the channel. An unbounded channel will be created if the capacity is 
+        ///   less than or equal to zero.
+        /// </param>
+        /// <param name="singleReader">
+        ///   Indicates if the channel should be optimised for a single reader.
+        /// </param>
+        /// <param name="singleWriter">
+        ///   Indicates if the channel should be optimised for a single writer.
+        /// </param>
+        /// <returns>
+        ///   The channel.
+        /// </returns>
+        /// <remarks>
+        ///   The default capacity of the created channel is set to <see cref="TagValueChannelCapacity"/>.
+        /// </remarks>
+        public static Channel<RealTimeData.TagValueQueryResult> CreateTagValueChannel(
+            BoundedChannelFullMode fullMode,
+            int capacity = TagValueChannelCapacity,
+            bool singleReader = true,
+            bool singleWriter = true
+        ) {
+            return CreateTagValueChannel<RealTimeData.TagValueQueryResult>(fullMode, capacity, singleReader, singleWriter);
+        }
+
+
+        /// <summary>
+        /// Creates a channel that can be used to return results to processed tag value queries.
+        /// </summary>
+        /// <param name="fullMode">
+        ///   The action to take when a write is attempted on a full channel.
+        /// </param>
+        /// <param name="capacity">
+        ///   The capacity of the channel. An unbounded channel will be created if the capacity is 
+        ///   less than or equal to zero.
+        /// </param>
+        /// <param name="singleReader">
+        ///   Indicates if the channel should be optimised for a single reader.
+        /// </param>
+        /// <param name="singleWriter">
+        ///   Indicates if the channel should be optimised for a single writer.
+        /// </param>
+        /// <returns>
+        ///   The channel.
+        /// </returns>
+        /// <remarks>
+        ///   The default capacity of the created channel is set to <see cref="TagValueChannelCapacity"/>.
+        /// </remarks>
+        public static Channel<RealTimeData.ProcessedTagValueQueryResult> CreateProcessedTagValueChannel(
+            BoundedChannelFullMode fullMode,
+            int capacity = TagValueChannelCapacity,
+            bool singleReader = true,
+            bool singleWriter = true
+        ) {
+            return CreateTagValueChannel<RealTimeData.ProcessedTagValueQueryResult>(fullMode, capacity, singleReader, singleWriter);
+        }
+
+
+        /// <summary>
+        /// Creates a channel that can be used to return results to tag value queries.
+        /// </summary>
         /// <typeparam name="T">
         ///   The result type.
         /// </typeparam>
@@ -207,6 +271,62 @@ namespace DataCore.Adapter {
             bool singleWriter = true
         ) where T : RealTimeData.TagValueQueryResult {
             return CreateChannel<T>(capacity, singleReader, singleWriter);
+        }
+
+
+        /// <summary>
+        /// Creates a channel that can be used to return results to tag value queries.
+        /// </summary>
+        /// <param name="capacity">
+        ///   The capacity of the channel. An unbounded channel will be created if the capacity is 
+        ///   less than or equal to zero.
+        /// </param>
+        /// <param name="singleReader">
+        ///   Indicates if the channel should be optimised for a single reader.
+        /// </param>
+        /// <param name="singleWriter">
+        ///   Indicates if the channel should be optimised for a single writer.
+        /// </param>
+        /// <returns>
+        ///   The channel.
+        /// </returns>
+        /// <remarks>
+        ///   The default capacity of the created channel is set to <see cref="TagValueChannelCapacity"/>.
+        /// </remarks>
+        public static Channel<RealTimeData.TagValueQueryResult> CreateTagValueChannel(
+            int capacity = TagValueChannelCapacity,
+            bool singleReader = true,
+            bool singleWriter = true
+        ) {
+            return CreateTagValueChannel<RealTimeData.TagValueQueryResult>(capacity, singleReader, singleWriter);
+        }
+
+
+        /// <summary>
+        /// Creates a channel that can be used to return results to processed tag value queries.
+        /// </summary>
+        /// <param name="capacity">
+        ///   The capacity of the channel. An unbounded channel will be created if the capacity is 
+        ///   less than or equal to zero.
+        /// </param>
+        /// <param name="singleReader">
+        ///   Indicates if the channel should be optimised for a single reader.
+        /// </param>
+        /// <param name="singleWriter">
+        ///   Indicates if the channel should be optimised for a single writer.
+        /// </param>
+        /// <returns>
+        ///   The channel.
+        /// </returns>
+        /// <remarks>
+        ///   The default capacity of the created channel is set to <see cref="TagValueChannelCapacity"/>.
+        /// </remarks>
+        public static Channel<RealTimeData.ProcessedTagValueQueryResult> CreateProcessedTagValueChannel(
+            int capacity = TagValueChannelCapacity,
+            bool singleReader = true,
+            bool singleWriter = true
+        ) {
+            return CreateTagValueChannel<RealTimeData.ProcessedTagValueQueryResult>(capacity, singleReader, singleWriter);
         }
 
 

--- a/src/DataCore.Adapter/RealTimeData/ReadHistoricalTagValues.cs
+++ b/src/DataCore.Adapter/RealTimeData/ReadHistoricalTagValues.cs
@@ -135,7 +135,7 @@ namespace DataCore.Adapter.RealTimeData {
 
             ValidationExtensions.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>();
+            var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var tagDefinitionsReader = await _tagInfoProvider.GetTags(context, new GetTagsRequest() {
@@ -248,7 +248,7 @@ namespace DataCore.Adapter.RealTimeData {
             }
             ValidationExtensions.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<ProcessedTagValueQueryResult>();
+            var result = ChannelExtensions.CreateProcessedTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var tagDefinitionsReader = await _tagInfoProvider.GetTags(context, new GetTagsRequest() {
@@ -296,7 +296,7 @@ namespace DataCore.Adapter.RealTimeData {
 
             ValidationExtensions.ValidateObject(request);
 
-            var result = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>();
+            var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
                 var tagDefinitionsReader = await _tagInfoProvider.GetTags(context, new GetTagsRequest() {
@@ -315,7 +315,7 @@ namespace DataCore.Adapter.RealTimeData {
                     // from the resulting channel into a master raw data channel, which is used 
                     // by the InterpolationHelper to calcukate the required values.
 
-                    var rawValuesChannel = ChannelExtensions.CreateTagValueChannel<TagValueQueryResult>();
+                    var rawValuesChannel = ChannelExtensions.CreateTagValueChannel();
 
                     rawValuesChannel.Writer.RunBackgroundOperation(async (ch2, ct2) => {
                         foreach (var sampleTime in request.UtcSampleTimes) {


### PR DESCRIPTION
Adds non-generic methods to `ChannelExtensions` to create channels for `TagValueQueryResult` and `ProcessedTagValueQueryResult`, and updates existing calls to use these new methods.