### PR TITLE
Move SnapshotTagValuePushOptions tag resolver delegate creation

### DIFF
--- a/src/DataCore.Adapter/RealTimeData/PollingSnapshotTagValuePush.cs
+++ b/src/DataCore.Adapter/RealTimeData/PollingSnapshotTagValuePush.cs
@@ -83,7 +83,7 @@ namespace DataCore.Adapter.RealTimeData {
         ) : base(
             new SnapshotTagValuePushOptions() {
                 MaxSubscriptionCount = maxConcurrentSubscriptions,
-                TagResolver = SnapshotTagValuePushOptions.CreateTagResolver(tagInfoFeature)
+                TagResolver = CreateTagResolver(tagInfoFeature)
             }, 
             backgroundTaskService,
             logger

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -142,7 +142,7 @@ namespace DataCore.Adapter.Tests {
 
 
             public SnapshotSubscriptionManager(ITagInfo tagInfo) : base(new SnapshotTagValuePushOptions() {
-                TagResolver = SnapshotTagValuePushOptions.CreateTagResolver(tagInfo)
+                TagResolver = CreateTagResolver(tagInfo)
             }, null, null) { }
 
 


### PR DESCRIPTION
- Remove `SnapshotTagValuePushOptions.CreateTagResolver(ITagInfo)`
- Add `SnapshotTagValuePush.CreateTagResolver(ITagInfo)`
- Add `SnapshotTagValuePush.CreateTagResolver(IAdapter)`