### PR TITLE
Polling snapshot tag value push cleanup

### DIFF
--- a/src/DataCore.Adapter.Csv/CsvAdapter.cs
+++ b/src/DataCore.Adapter.Csv/CsvAdapter.cs
@@ -106,9 +106,14 @@ namespace DataCore.Adapter.Csv {
 
             var snapshotPushUpdateInterval = Options.SnapshotPushUpdateInterval;
             if (snapshotPushUpdateInterval > 0) {
-                var simulatedPush = PollingSnapshotTagValuePush.ForAdapter(
-                    this,
-                    TimeSpan.FromMilliseconds(snapshotPushUpdateInterval)
+                var simulatedPush = new PollingSnapshotTagValuePush(
+                    this.GetFeature<IReadSnapshotTagValues>(),
+                    new PollingSnapshotTagValuePushOptions() {
+                        PollingInterval = TimeSpan.FromMilliseconds(snapshotPushUpdateInterval),
+                        TagResolver = SnapshotTagValuePush.CreateTagResolverFromAdapter(this)
+                    },
+                    BackgroundTaskService,
+                    Logger
                 );
                 AddFeature(typeof(ISnapshotTagValuePush), simulatedPush);
             }

--- a/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
+++ b/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
@@ -88,7 +88,10 @@ namespace DataCore.Adapter.WaveGenerator {
             IBackgroundTaskService? backgroundTaskService = null, 
             ILogger<WaveGeneratorAdapter>? logger = null
         ) : base(id, options, backgroundTaskService, logger) {
-            AddFeatures(PollingSnapshotTagValuePush.ForAdapter(this, GetSampleInterval()));
+            AddFeatures(new PollingSnapshotTagValuePush(this, new PollingSnapshotTagValuePushOptions() { 
+                PollingInterval = GetSampleInterval(),
+                TagResolver = SnapshotTagValuePush.CreateTagResolverFromAdapter(this)
+            }, BackgroundTaskService, Logger));
             AddFeatures(ReadHistoricalTagValues.ForAdapter(this));
         }
 

--- a/src/DataCore.Adapter/RealTimeData/PollingSnapshotTagValuePush.cs
+++ b/src/DataCore.Adapter/RealTimeData/PollingSnapshotTagValuePush.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
@@ -43,21 +42,12 @@ namespace DataCore.Adapter.RealTimeData {
         /// <summary>
         /// Creates a new <see cref="PollingSnapshotTagValuePush"/> object.
         /// </summary>
-        /// <param name="tagInfoFeature">
-        ///   An <see cref="ITagInfo"/> adapter feature that will be used to resolve tag 
-        ///   identifiers.
-        /// </param>
         /// <param name="readSnapshotFeature">
         ///   An <see cref="IReadSnapshotTagValues"/> adapter feature that will be used to poll for 
         ///   new values on a periodic basis.
         /// </param>
-        /// <param name="pollingInterval">
-        ///   The polling interval to use. If the value specified is less than or equal to 
-        ///   <see cref="TimeSpan.Zero"/>, <see cref="DefaultPollingInterval"/> will be used.
-        /// </param>
-        /// <param name="maxConcurrentSubscriptions">
-        ///   The maximum number of concurrent subscriptions allowed. A value less than one 
-        ///   indicates no limit.
+        /// <param name="options">
+        ///   The feature options.
         /// </param>
         /// <param name="backgroundTaskService">
         ///   The <see cref="IBackgroundTaskService"/> to use when running background tasks. If the 
@@ -68,145 +58,24 @@ namespace DataCore.Adapter.RealTimeData {
         ///   The logger to use. Can be <see langword="null"/>.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        ///   <paramref name="tagInfoFeature"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
         ///   <paramref name="readSnapshotFeature"/> is <see langword="null"/>.
         /// </exception>
-        private PollingSnapshotTagValuePush(
-            ITagInfo tagInfoFeature, 
-            IReadSnapshotTagValues readSnapshotFeature, 
-            TimeSpan pollingInterval,
-            int maxConcurrentSubscriptions,
+        public PollingSnapshotTagValuePush(
+            IReadSnapshotTagValues readSnapshotFeature,
+            PollingSnapshotTagValuePushOptions? options,
             IBackgroundTaskService? backgroundTaskService,
             ILogger? logger
         ) : base(
-            new SnapshotTagValuePushOptions() {
-                MaxSubscriptionCount = maxConcurrentSubscriptions,
-                TagResolver = CreateTagResolver(tagInfoFeature)
-            }, 
+            options, 
             backgroundTaskService,
             logger
         ) {
             _readSnapshotFeature = readSnapshotFeature ?? throw new ArgumentNullException(nameof(readSnapshotFeature));
-            _pollingInterval = pollingInterval > TimeSpan.Zero
-                ? pollingInterval
+            _pollingInterval = options?.PollingInterval > TimeSpan.Zero
+                ? options.PollingInterval
                 : DefaultPollingInterval;
 
             BackgroundTaskService.QueueBackgroundWorkItem(RunSnapshotPollingLoop, null, DisposedToken);
-        }
-
-
-        /// <summary>
-        /// Creates a new <see cref="PollingSnapshotTagValuePush"/> object for the specified 
-        /// adapter.
-        /// </summary>
-        /// <param name="adapter">
-        ///   The adapter.
-        /// </param>
-        /// <param name="pollingInterval">
-        ///   The polling interval to use when refreshing values for subscribed tags.
-        /// </param>
-        /// <param name="maxConcurrentSubscriptions">
-        ///   The maximum number of concurrent subscriptions allowed. A value less than one 
-        ///   indicates no limit.
-        /// </param>
-        /// <returns>
-        ///   A new <see cref="PollingSnapshotTagValuePush"/> object.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="adapter"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///   <paramref name="adapter"/> does not meet the requirements specified by 
-        ///   <see cref="IsCompatible"/>.
-        /// </exception>
-        public static PollingSnapshotTagValuePush ForAdapter(
-            AdapterBase adapter,
-            TimeSpan pollingInterval,
-            int maxConcurrentSubscriptions = 0
-        ) {
-            return ForAdapter(adapter, pollingInterval, maxConcurrentSubscriptions, adapter?.BackgroundTaskService, adapter?.Logger);
-        }
-
-
-        /// <summary>
-        /// Creates a new <see cref="PollingSnapshotTagValuePush"/> object for the specified 
-        /// adapter.
-        /// </summary>
-        /// <param name="adapter">
-        ///   The adapter.
-        /// </param>
-        /// <param name="pollingInterval">
-        ///   The polling interval to use when refreshing values for subscribed tags.
-        /// </param>
-        /// <param name="maxConcurrentSubscriptions">
-        ///   The maximum number of concurrent subscriptions allowed. A value less than one 
-        ///   indicates no limit.
-        /// </param>
-        /// <param name="backgroundTaskService">
-        ///   The <see cref="IBackgroundTaskService"/> to use when running background tasks. If the 
-        ///   value specified is <see langword="null"/>, <see cref="BackgroundTaskService.Default"/> 
-        ///   will be used.
-        /// </param>
-        /// <param name="logger">
-        ///   The logger to use. Can be <see langword="null"/>.
-        /// </param>
-        /// <returns>
-        ///   A new <see cref="PollingSnapshotTagValuePush"/> object.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="adapter"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///   <paramref name="adapter"/> does not meet the requirements specified by 
-        ///   <see cref="IsCompatible"/>.
-        /// </exception>
-        public static PollingSnapshotTagValuePush ForAdapter(
-            IAdapter adapter,
-            TimeSpan pollingInterval,
-            int maxConcurrentSubscriptions = 0,
-            IBackgroundTaskService? backgroundTaskService = null,
-            ILogger? logger = null
-        ) {
-            if (adapter == null) {
-                throw new ArgumentNullException(nameof(adapter));
-            }
-            if (!IsCompatible(adapter)) {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Error_AdapterIsNotCompatibleWithHelperClass, adapter.Descriptor.Name, nameof(PollingSnapshotTagValuePush)), nameof(adapter));
-            }
-
-            return new PollingSnapshotTagValuePush(
-                adapter.Features.Get<ITagInfo>(),
-                adapter.Features.Get<IReadSnapshotTagValues>(),
-                pollingInterval,
-                maxConcurrentSubscriptions,
-                backgroundTaskService,
-                logger
-            );
-        }
-
-
-        /// <summary>
-        /// Tests if an adapter is compatible with <see cref="PollingSnapshotTagValuePush"/>. An 
-        /// adapter is compatible if it implements both <see cref="ITagInfo"/> and 
-        /// <see cref="IReadSnapshotTagValues"/> features.
-        /// </summary>
-        /// <param name="adapter">
-        ///   The adapter.
-        /// </param>
-        /// <returns>
-        ///   <see langword="true"/> if the <paramref name="adapter"/> is compatible with 
-        ///   <see cref="PollingSnapshotTagValuePush"/>, or <see langword="false"/> otherwise.
-        /// </returns>
-        public static bool IsCompatible(IAdapter adapter) {
-            if (adapter == null) {
-                return false;
-            }
-
-            return 
-                adapter.Features.Get<ITagInfo>() != null &&
-                adapter.Features.Get<IReadSnapshotTagValues>() != null;
         }
 
 
@@ -256,7 +125,6 @@ namespace DataCore.Adapter.RealTimeData {
         /// <returns>
         ///   A task that will run the polling loop.
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Recovery from errors in long-running task")]
         private async Task RunSnapshotPollingLoop(CancellationToken cancellationToken) {
             try {
                 while (!cancellationToken.IsCancellationRequested) {
@@ -324,6 +192,23 @@ namespace DataCore.Adapter.RealTimeData {
                 _subscribedTags.Clear();
             }
         }
+
+    }
+
+
+    /// <summary>
+    /// Options for <see cref="PollingSnapshotTagValuePush"/>.
+    /// </summary>
+    public class PollingSnapshotTagValuePushOptions : SnapshotTagValuePushOptions {
+
+        /// <summary>
+        /// The polling interval to use when refreshing values for subscribed tags.
+        /// </summary>
+        /// <remarks>
+        ///   If the value specified is less than or equal to <see cref="TimeSpan.Zero"/>, 
+        ///   <see cref="PollingSnapshotTagValuePush.DefaultPollingInterval"/> will be used.
+        /// </remarks>
+        public TimeSpan PollingInterval { get; set; }
 
     }
 }

--- a/src/DataCore.Adapter/RealTimeData/SnapshotTagValuePush.cs
+++ b/src/DataCore.Adapter/RealTimeData/SnapshotTagValuePush.cs
@@ -71,7 +71,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="feature"/> is <see langword="null"/>.
         /// </exception>
-        public static Func<IAdapterCallContext, IEnumerable<string>, CancellationToken, ValueTask<IEnumerable<TagIdentifier>>> CreateTagResolver(ITagInfo feature) {
+        public static Func<IAdapterCallContext, IEnumerable<string>, CancellationToken, ValueTask<IEnumerable<TagIdentifier>>> CreateTagResolverFromFeature(ITagInfo feature) {
             if (feature == null) {
                 throw new ArgumentNullException(nameof(feature));
             }
@@ -104,7 +104,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="adapter"/> is <see langword="null"/>.
         /// </exception>
-        public static Func<IAdapterCallContext, IEnumerable<string>, CancellationToken, ValueTask<IEnumerable<TagIdentifier>>> CreateTagResolver(IAdapter adapter) {
+        public static Func<IAdapterCallContext, IEnumerable<string>, CancellationToken, ValueTask<IEnumerable<TagIdentifier>>> CreateTagResolverFromAdapter(IAdapter adapter) {
             if (adapter == null) {
                 throw new ArgumentNullException(nameof(adapter));
             }
@@ -570,9 +570,10 @@ namespace DataCore.Adapter.RealTimeData {
         /// <see cref="TagIdentifier"/>.
         /// </summary>
         /// <remarks>
-        ///   <see cref="SnapshotTagValuePush.CreateTagResolver(IAdapter)"/> or <see cref="SnapshotTagValuePush.CreateTagResolver(ITagInfo)"/> 
-        ///   can be used to generate a compatible delegate using an existing adapter or <see cref="ITagInfo"/> 
-        ///   implementation.
+        ///   <see cref="SnapshotTagValuePush.CreateTagResolverFromAdapter(IAdapter)"/> or 
+        ///   <see cref="SnapshotTagValuePush.CreateTagResolverFromFeature(ITagInfo)"/> can be 
+        ///   used to generate a compatible delegate using an existing adapter or 
+        ///   <see cref="ITagInfo"/> implementation.
         /// </remarks>
         public Func<IAdapterCallContext, IEnumerable<string>, CancellationToken, ValueTask<IEnumerable<TagIdentifier>>>? TagResolver { get; set; }
 

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -142,7 +142,7 @@ namespace DataCore.Adapter.Tests {
 
 
             public SnapshotSubscriptionManager(ITagInfo tagInfo) : base(new SnapshotTagValuePushOptions() {
-                TagResolver = CreateTagResolver(tagInfo)
+                TagResolver = CreateTagResolverFromFeature(tagInfo)
             }, null, null) { }
 
 


### PR DESCRIPTION
- PollingSnapshotTagValuePush now has its own options class (extending from SnapshotTagValuePushOptions) for defining polling interval etc.
- Removed static methods from PollingSnapshotTagValuePush for creating instances and made constructor public.

These changes are intended to allow creation of PollingSnapshotTagValuePush instances to have the configuration options as SnapshotTagValuePush, instead of hiding various configuration settings.