### PR TITLE
Return adapter descriptors via channel

### DIFF
--- a/examples/DataCore.Adapter.GrpcExampleClient/Program.cs
+++ b/examples/DataCore.Adapter.GrpcExampleClient/Program.cs
@@ -21,16 +21,22 @@ namespace DataCore.Adapter.GrpcExampleClient {
             Console.WriteLine($"{hostInfoResponse.HostInfo.VendorInfo.Name} ({hostInfoResponse.HostInfo.VendorInfo.Url})");
 
             var adaptersClient = new AdaptersService.AdaptersServiceClient(channel);
-            var adaptersResponse = await adaptersClient.FindAdaptersAsync(new FindAdaptersRequest());
+            var adaptersResponse = adaptersClient.FindAdapters(new FindAdaptersRequest());
+            var adapters = new List<AdapterDescriptor>();
+
             Console.WriteLine();
             Console.WriteLine("== Adapters ==");
-            foreach (var adapter in adaptersResponse.Adapters) {
+            while (await adaptersResponse.ResponseStream.MoveNext(default).ConfigureAwait(false)) {
+                var adapter = adaptersResponse.ResponseStream.Current.Adapter;
+                adapters.Add(adapter);
+
                 Console.WriteLine();
                 Console.WriteLine($"{adapter.Name} (ID: {adapter.Id})");
                 Console.WriteLine($"    Description: {adapter.Description}");
             }
+            
 
-            foreach (var adapter in adaptersResponse.Adapters) {
+            foreach (var adapter in adapters) {
 
                 var adapterId = adapter.Id;
 

--- a/src/DataCore.Adapter.Abstractions/IAdapterAccessor.cs
+++ b/src/DataCore.Adapter.Abstractions/IAdapterAccessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using DataCore.Adapter.Common;
 
@@ -34,14 +35,15 @@ namespace DataCore.Adapter {
         ///   The cancellation token for the operation.
         /// </param>
         /// <returns>
-        ///   The adapters available to the caller.
+        ///   A channel containing the adapters available to the caller.
         /// </returns>
-        Task<IEnumerable<IAdapter>> FindAdapters(
+        Task<ChannelReader<IAdapter>> FindAdapters(
             IAdapterCallContext context, 
             FindAdaptersRequest request, 
             bool enabledOnly = true,
             CancellationToken cancellationToken = default
         );
+
 
         /// <summary>
         /// Gets the specified adapter.
@@ -53,7 +55,7 @@ namespace DataCore.Adapter {
         ///   The ID of the adapter.
         /// </param>
         /// <param name="enabledOnly">
-        ///   When <see langword="true"/>, only enabled adapters will be returned.
+        ///   When <see langword="true"/>, the adapter will only be returned if it is enabled.
         /// </param>
         /// <param name="cancellationToken">
         ///   The cancellation token for the operation.

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/AdaptersClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/AdaptersClient.cs
@@ -44,16 +44,16 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
         ///   The cancellation token for the operation.
         /// </param>
         /// <returns>
-        ///   A task that will return information about the available adapters.
+        ///   A channel that will return information about the available adapters.
         /// </returns>
-        public async Task<IEnumerable<AdapterDescriptor>> FindAdaptersAsync(
+        public async Task<ChannelReader<AdapterDescriptor>> FindAdaptersAsync(
             FindAdaptersRequest request,
             CancellationToken cancellationToken = default
         ) {
             AdapterSignalRClient.ValidateObject(request);
 
             var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
-            return await connection.InvokeAsync<IEnumerable<AdapterDescriptor>>(
+            return await connection.StreamAsChannelAsync<AdapterDescriptor>(
                 "FindAdapters", 
                 request,
                 cancellationToken
@@ -131,8 +131,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
         ///   lost, the channel will be closed.
         /// </param>
         /// <returns>
-        ///   A task that will return a channel that is used to stream the health check messages back 
-        ///   to the caller.
+        ///   A channel that is used to stream the health check messages back to the caller.
         /// </returns>
         /// <exception cref="ArgumentException">
         ///   <paramref name="adapterId"/> is <see langword="null"/> or white space.

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
@@ -77,13 +77,17 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         /// <param name="request">
         ///   The adapter search query.
         /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
         /// <returns>
-        ///   The matching adapters.
+        ///   A channel reader that the subscriber can observe to receive the matching adapters.
         /// </returns>
-        public async Task<IEnumerable<AdapterDescriptor>> FindAdapters(FindAdaptersRequest request) {
+        public async Task<ChannelReader<AdapterDescriptor>> FindAdapters(FindAdaptersRequest request, CancellationToken cancellationToken) {
             var adapterCallContext = new SignalRAdapterCallContext(Context);
-            var adapters = await AdapterAccessor.FindAdapters(adapterCallContext, request, true, Context.ConnectionAborted).ConfigureAwait(false);
-            return adapters.Select(x => AdapterDescriptor.FromExisting(x.Descriptor)).ToArray();
+            var adapters = await AdapterAccessor.FindAdapters(adapterCallContext, request, true, cancellationToken).ConfigureAwait(false);
+
+            return adapters.Transform(x => AdapterDescriptor.FromExisting(x.Descriptor), BackgroundTaskService, cancellationToken);
         }
 
 

--- a/src/DataCore.Adapter/AdapterAccessor.cs
+++ b/src/DataCore.Adapter/AdapterAccessor.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using DataCore.Adapter.Common;
+
+using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter {
 
@@ -13,6 +16,11 @@ namespace DataCore.Adapter {
     /// </summary>
     public abstract class AdapterAccessor : IAdapterAccessor {
 
+        /// <summary>
+        /// Service for running background operations.
+        /// </summary>
+        private readonly IBackgroundTaskService _backgroundTaskService;
+
         /// <inheritdoc/>
         public IAdapterAuthorizationService AuthorizationService { get; }
 
@@ -20,13 +28,17 @@ namespace DataCore.Adapter {
         /// <summary>
         /// Creates a new <see cref="AdapterAccessor"/> object.
         /// </summary>
+        /// <param name="backgroundTaskService">
+        ///   The background task service to use.
+        /// </param>
         /// <param name="authorizationService">
         ///   The adapter authorization service to use.
         /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="authorizationService"/> is <see langword="null"/>.
         /// </exception>
-        protected AdapterAccessor(IAdapterAuthorizationService authorizationService) {
+        protected AdapterAccessor(IBackgroundTaskService backgroundTaskService, IAdapterAuthorizationService authorizationService) {
+            _backgroundTaskService = backgroundTaskService ?? throw new ArgumentNullException(nameof(backgroundTaskService));
             AuthorizationService = authorizationService ?? throw new ArgumentNullException(nameof(authorizationService));
         }
 
@@ -40,11 +52,11 @@ namespace DataCore.Adapter {
         /// <returns>
         ///   The available adapters.
         /// </returns>
-        protected abstract Task<IEnumerable<IAdapter>> GetAdapters(CancellationToken cancellationToken);
+        protected abstract Task<ChannelReader<IAdapter>> GetAdapters(CancellationToken cancellationToken);
 
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<IAdapter>> FindAdapters(
+        public Task<ChannelReader<IAdapter>> FindAdapters(
             IAdapterCallContext context, 
             FindAdaptersRequest request, 
             bool enabledOnly = true,
@@ -54,52 +66,74 @@ namespace DataCore.Adapter {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var adapters = await GetAdapters(cancellationToken).ConfigureAwait(false);
-            cancellationToken.ThrowIfCancellationRequested();
+            var result = ChannelExtensions.CreateChannel<IAdapter>(50);
+            var skipCount = (request.Page - 1) * request.PageSize;
+            var takeCount = request.PageSize;
 
-            if (enabledOnly) {
-                adapters = adapters?.Where(x => x.IsEnabled)?.ToArray();
-            }
+            result.Writer.RunBackgroundOperation(async (ch, ct) => {
+                using (var queryCtSource = CancellationTokenSource.CreateLinkedTokenSource(ct)) {
+                    try {
+                        var adapters = await GetAdapters(queryCtSource.Token).ConfigureAwait(false);
 
-            if (adapters == null || !adapters.Any()) {
-                return Array.Empty<IAdapter>();
-            }
+                        while (takeCount > 0 && await adapters.WaitToReadAsync(ct).ConfigureAwait(false)) {
+                            while (adapters.TryRead(out var item)) {
+                                if (enabledOnly && !item.IsEnabled) {
+                                    continue;
+                                }
 
-            if (!string.IsNullOrWhiteSpace(request.Id)) {
-                adapters = adapters.Where(x => x.Descriptor.Id.Like(request.Id!));
-            }
-            if (!string.IsNullOrWhiteSpace(request.Name)) {
-                adapters = adapters.Where(x => x.Descriptor.Name.Like(request.Name!));
-            }
-            if (!string.IsNullOrWhiteSpace(request.Description)) {
-                adapters = adapters.Where(x => x.Descriptor.Description!.Like(request.Description!));
-            }
-            if (request.Features != null) {
-                foreach (var item in request.Features) {
-                    if (string.IsNullOrWhiteSpace(item)) {
-                        continue;
+                                if (!string.IsNullOrWhiteSpace(request.Id) && !item.Descriptor.Id.Like(request.Id!)) {
+                                    continue;
+                                }
+
+                                if (!string.IsNullOrWhiteSpace(request.Name) && !item.Descriptor.Name.Like(request.Name!)) {
+                                    continue;
+                                }
+
+                                if (!string.IsNullOrWhiteSpace(request.Description) && !item.Descriptor.Description.Like(request.Description!)) {
+                                    continue;
+                                }
+
+                                if (request.Features != null) {
+                                    foreach (var feature in request.Features) {
+                                        if (string.IsNullOrWhiteSpace(feature)) {
+                                            continue;
+                                        }
+
+                                        if (!item.HasFeature(feature)) {
+                                            continue;
+                                        }
+                                    }
+                                }
+
+                                if (!await AuthorizationService.AuthorizeAdapter(item, context, ct).ConfigureAwait(false)) {
+                                    // Caller is not authorized to use this adapter.
+                                    continue;
+                                }
+
+                                if (skipCount > 0) {
+                                    --skipCount;
+                                    continue;
+                                }
+
+                                --takeCount;
+                                await ch.WriteAsync(item, ct).ConfigureAwait(false);
+
+                                if (takeCount < 1) {
+                                    // We can finish now.
+                                    break;
+                                }
+                            }
+                        }
                     }
-                    adapters = adapters.Where(x => x.HasFeature(item));
+                    finally {
+                        queryCtSource.Cancel();
+                    }
                 }
-            }
+            }, true, _backgroundTaskService, cancellationToken);
 
-            adapters = adapters
-                .OrderBy(x => x.Descriptor.Name)
-                .Skip((request.Page - 1) * request.PageSize)
-                .Take(request.PageSize);
-
-            var result = new List<IAdapter>();
-
-            foreach (var adapter in adapters) {
-                var authResult = await AuthorizationService.AuthorizeAdapter(adapter, context, cancellationToken).ConfigureAwait(false);
-                cancellationToken.ThrowIfCancellationRequested();
-                if (authResult) {
-                    result.Add(adapter);
-                }
-            }
-
-            return result;
+            return Task.FromResult(result.Reader);
         }
+
 
         /// <inheritdoc/>
         public async Task<IAdapter?> GetAdapter(
@@ -115,15 +149,25 @@ namespace DataCore.Adapter {
             var adapters = await GetAdapters(cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
 
-            var adapter = adapters?.FirstOrDefault(x => x.Descriptor.Id.Equals(adapterId, StringComparison.OrdinalIgnoreCase));
-            if (adapter == null || (enabledOnly && !adapter.IsEnabled)) {
-                return null;
+            while (await adapters.WaitToReadAsync(cancellationToken).ConfigureAwait(false)) {
+                while (adapters.TryRead(out var item)) {
+                    if (!item.Descriptor.Id.Equals(adapterId, StringComparison.OrdinalIgnoreCase)) {
+                        continue;
+                    }
+
+                    if (enabledOnly && !item.IsEnabled) {
+                        return null;
+                    }
+
+                    if (!await AuthorizationService.AuthorizeAdapter(item, context, cancellationToken).ConfigureAwait(false)) {
+                        return null;
+                    }
+
+                    return item;
+                }
             }
 
-            var authResult = await AuthorizationService.AuthorizeAdapter(adapter, context, cancellationToken).ConfigureAwait(false);
-            return authResult
-                ? adapter
-                : null;
+            return null;
         }
 
     }

--- a/src/Protos/datacore/adapter/AdaptersService.proto
+++ b/src/Protos/datacore/adapter/AdaptersService.proto
@@ -7,7 +7,7 @@ import "Types.proto";
 option csharp_namespace = "DataCore.Adapter.Grpc";
 
 service AdaptersService {
-    rpc FindAdapters(FindAdaptersRequest) returns (FindAdaptersResponse);
+    rpc FindAdapters(FindAdaptersRequest) returns (stream FindAdaptersResponse);
     rpc GetAdapter(GetAdapterRequest) returns (GetAdapterResponse);
     rpc CheckAdapterHealth(CheckAdapterHealthRequest) returns (CheckAdapterHealthResponse);
     rpc CreateAdapterHealthPushChannel(CreateAdapterHealthPushChannelRequest) returns (stream HealthCheckResult);
@@ -24,7 +24,7 @@ message FindAdaptersRequest {
     int32 page = 6;
 }
 message FindAdaptersResponse {
-    repeated AdapterDescriptor adapters = 1;
+    AdapterDescriptor adapter = 1;
 }
 
 

--- a/test/DataCore.Adapter.Tests/AdapterAccessorTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterAccessorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Extensions;
@@ -177,13 +178,14 @@ namespace DataCore.Adapter.Tests {
             private readonly IAdapter _adapter;
 
 
-            public AdapterAccessorImpl(IAdapter adapter, IAdapterAuthorizationService authService) : base(authService) {
+            public AdapterAccessorImpl(IAdapter adapter, IAdapterAuthorizationService authService) : base(adapter.BackgroundTaskService, authService) {
                 _adapter = adapter;
             }
 
 
-            protected override Task<IEnumerable<IAdapter>> GetAdapters(CancellationToken cancellationToken) {
-                return Task.FromResult<IEnumerable<IAdapter>>(new[] { _adapter });
+            protected override Task<ChannelReader<IAdapter>> GetAdapters(CancellationToken cancellationToken) {
+                var channel = new[] { _adapter }.PublishToChannel();
+                return Task.FromResult(channel);
             }
         }
 


### PR DESCRIPTION
IAdapterAccessor now uses a ChannelReader<T> to return adapter descriptors rather than IEnumerable<T>