### PR TITLE
Bump dependencies and deprecate TagDefinition.Create

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -47,7 +47,7 @@
     <CastleCoreVersion>4.4.1</CastleCoreVersion>
     <CsvHelperVersion>15.0.10</CsvHelperVersion>
     <IntelligentPlantBackgroundTasksVersion>4.1.0</IntelligentPlantBackgroundTasksVersion>
-    <JaahasHttpRequestTransformerVersion>1.0.1</JaahasHttpRequestTransformerVersion>
+    <JaahasHttpRequestTransformerVersion>2.0.0</JaahasHttpRequestTransformerVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
     <NSwagAspNetCoreVersion>13.9.0</NSwagAspNetCoreVersion>
     <NuGetVersioningVersion>5.8.0</NuGetVersioningVersion>

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
@@ -1533,7 +1533,7 @@ namespace DataCore.Adapter {
                 throw new ArgumentNullException(nameof(tagDefinition));
             }
 
-            return RealTimeData.TagDefinition.Create(
+            return new RealTimeData.TagDefinition(
                 tagDefinition.Id,
                 tagDefinition.Name,
                 tagDefinition.Description,

--- a/src/DataCore.Adapter.Core/RealTimeData/TagDefinition.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagDefinition.cs
@@ -127,6 +127,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="name"/> is <see langword="null"/>.
         /// </exception>
+        [Obsolete("This method will be removed in a future version. Use the constructor directly or use TagDefinitionBuilder in DataCore.Adapter.dll.", false)]
         public static TagDefinition Create(string id, string name, string? description, string? units, VariantType dataType, IEnumerable<DigitalState>? states, IEnumerable<Uri>? supportedFeatures, IEnumerable<AdapterProperty>? properties, IEnumerable<string>? labels) {
             return new TagDefinition(id, name, description, units, dataType, states, supportedFeatures, properties, labels);
         }
@@ -149,7 +150,7 @@ namespace DataCore.Adapter.RealTimeData {
                 throw new ArgumentNullException(nameof(tag));
             }
 
-            return Create(
+            return new TagDefinition(
                 tag.Id,
                 tag.Name,
                 tag.Description,

--- a/src/DataCore.Adapter.Csv/CsvAdapter.cs
+++ b/src/DataCore.Adapter.Csv/CsvAdapter.cs
@@ -178,20 +178,14 @@ namespace DataCore.Adapter.Csv {
                 return null!;
             }
 
-            if (!definition.StartsWith("[", StringComparison.Ordinal) || !definition.EndsWith("]", StringComparison.Ordinal)) { 
+            if (!definition.StartsWith("[", StringComparison.Ordinal) || !definition.EndsWith("]", StringComparison.Ordinal)) {
                 // Assume that the entire item is the tag name; set the ID to be the same 
                 // as the name.
-                return TagDefinition.Create(
-                    definition, 
-                    definition, 
-                    null, 
-                    null, 
-                    Common.VariantType.Double, 
-                    null, 
-                    null,
-                    new[] { new AdapterProperty(nameof(definition), definition) }, 
-                    new[] { "CSV" }
-                );
+                return TagDefinitionBuilder.Create(definition, definition)
+                    .WithDataType(VariantType.Double)
+                    .WithProperty(nameof(definition), definition)
+                    .WithLabels("CSV")
+                    .Build();
             }
 
             var definitionOriginal = definition;
@@ -232,27 +226,26 @@ namespace DataCore.Adapter.Csv {
                 }
             }
 
-            return TagDefinition.Create(
-                id ?? name!,
-                name ?? id!,
-                props.TryGetValue(nameof(description), out description!) 
-                    ? description 
-                    : string.Empty,
-                props.TryGetValue(nameof(units), out units!)
+            return TagDefinitionBuilder.Create()
+                .WithId(id ?? name!)
+                .WithName(name ?? id!)
+                .WithDescription(props.TryGetValue(nameof(description), out description!)
+                    ? description
+                    : string.Empty)
+                .WithUnits(props.TryGetValue(nameof(units), out units!)
                     ? units
-                    : string.Empty,
-                states.Count > 0
-                    ? Common.VariantType.Int32
-                    : props.TryGetValue(nameof(dataType), out dataType!) && Enum.TryParse<Common.VariantType>(dataType, out var dataTypeActual)
+                    : string.Empty)
+                .WithDataType(states.Count > 0
+                    ? VariantType.Int32
+                    : props.TryGetValue(nameof(dataType), out dataType!) && Enum.TryParse<VariantType>(dataType, out var dataTypeActual)
                         ? dataTypeActual
-                        : Common.VariantType.Double,
-                states.Count > 0
+                        : VariantType.Double)
+                .WithDigitalStates(states.Count > 0
                     ? states.Select(x => DigitalState.Create(x.Key, x.Value))
-                    : null,
-                null,
-                new[] { new AdapterProperty(nameof(definition), definitionOriginal) },
-                new[] { "CSV" }
-            );
+                    : null)
+                .WithProperty(nameof(definition), definitionOriginal)
+                .WithLabels("CSV")
+                .Build();
         }
 
 

--- a/src/DataCore.Adapter.Http.Client/AdapterHttpClient.cs
+++ b/src/DataCore.Adapter.Http.Client/AdapterHttpClient.cs
@@ -110,8 +110,9 @@ namespace DataCore.Adapter.Http.Client {
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            return new Jaahas.Http.HttpRequestTransformHandler(async (request, cancellationToken) => {
+            return new Jaahas.Http.HttpRequestPipelineHandler(async (request, next, cancellationToken) => {
                 await callback(request, request.GetStateProperty<RequestMetadata>(), cancellationToken).ConfigureAwait(false);
+                return await next(request, cancellationToken).ConfigureAwait(false);
             });
         }
 

--- a/src/DataCore.Adapter.Json/TagDefinitionConverter.cs
+++ b/src/DataCore.Adapter.Json/TagDefinitionConverter.cs
@@ -69,7 +69,7 @@ namespace DataCore.Adapter.Json {
                 }
             }
 
-            return TagDefinition.Create(id, name, description, units, dataType, states, supportedFeatures, properties, labels);
+            return new TagDefinition(id, name, description, units, dataType, states, supportedFeatures, properties, labels);
         }
 
 

--- a/src/DataCore.Adapter/RealTimeData/TagDefinitionBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagDefinitionBuilder.cs
@@ -264,7 +264,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <returns>
         ///   The updated <see cref="TagDefinitionBuilder"/>.
         /// </returns>
-        public TagDefinitionBuilder WithDigitalStates(IEnumerable<DigitalState> states) {
+        public TagDefinitionBuilder WithDigitalStates(IEnumerable<DigitalState>? states) {
             if (states != null) {
                 _states.AddRange(states.Where(x => x != null).Select(x => new DigitalState(x.Name, x.Value)));
             }
@@ -281,8 +281,8 @@ namespace DataCore.Adapter.RealTimeData {
         /// <returns>
         ///   The updated <see cref="TagDefinitionBuilder"/>.
         /// </returns>
-        public TagDefinitionBuilder WithDigitalStates(DigitalStateSet stateSet) {
-            return WithDigitalStates(stateSet?.States!);
+        public TagDefinitionBuilder WithDigitalStates(DigitalStateSet? stateSet) {
+            return WithDigitalStates(stateSet?.States);
         }
 
 
@@ -321,7 +321,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <returns>
         ///   The updated <see cref="TagDefinitionBuilder"/>.
         /// </returns>
-        public TagDefinitionBuilder WithSupportedFeatures(IEnumerable<Uri> uris) {
+        public TagDefinitionBuilder WithSupportedFeatures(IEnumerable<Uri>? uris) {
             if (uris != null) {
                 foreach (var uri in uris) {
                     if (uri != null && (uri.IsStandardFeatureUri() || uri.IsExtensionFeatureUri())) {
@@ -357,7 +357,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <returns>
         ///   The updated <see cref="TagDefinitionBuilder"/>.
         /// </returns>
-        public TagDefinitionBuilder WithSupportedFeatures(IEnumerable<string> uriStrings) {
+        public TagDefinitionBuilder WithSupportedFeatures(IEnumerable<string>? uriStrings) {
             if (uriStrings != null) {
                 foreach (var uriString in uriStrings) {
                     if (Uri.TryCreate(uriString, UriKind.Absolute, out var uri)) {
@@ -423,7 +423,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <returns>
         ///   The updated <see cref="TagDefinitionBuilder"/>.
         /// </returns>
-        public TagDefinitionBuilder WithProperties(IEnumerable<AdapterProperty> properties) {
+        public TagDefinitionBuilder WithProperties(IEnumerable<AdapterProperty>? properties) {
             if (properties != null) {
                 _properties.AddRange(properties.Where(x => x != null).Select(x => new AdapterProperty(x.Name, x.Value, x.Description)));
             }
@@ -449,7 +449,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="name"/> is <see langword="null"/>.
         /// </exception>
-        public TagDefinitionBuilder WithProperty(string name, object value, string? description = null) {
+        public TagDefinitionBuilder WithProperty(string name, object? value, string? description = null) {
             if (name == null) {
                 throw new ArgumentNullException(nameof(name));
             }
@@ -493,7 +493,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <returns>
         ///   The updated <see cref="TagDefinitionBuilder"/>.
         /// </returns>
-        public TagDefinitionBuilder WithLabels(IEnumerable<string> labels) {
+        public TagDefinitionBuilder WithLabels(IEnumerable<string>? labels) {
             if (labels != null) {
                 _labels.AddRange(labels.Where(x => !string.IsNullOrWhiteSpace(x)));
             }

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -96,7 +96,7 @@ namespace DataCore.Adapter.Tests {
 
             var result = Channel.CreateUnbounded<TagDefinition>();
             foreach (var item in request.Tags) {
-                result.Writer.TryWrite(TagDefinition.Create(item, item, null, null, VariantType.Double, null, null, null, null));
+                result.Writer.TryWrite(new TagDefinition(item, item, null, null, VariantType.Double, null, null, null, null));
             }
             result.Writer.TryComplete();
             return Task.FromResult(result.Reader);


### PR DESCRIPTION
- Bump Jaahas.HttpRequestTransformer to v2.0.0.
- Deprecate use of TagDefinition.Create in favour of TagDefinitionBuilder.