### PR TITLE
net48 unit tests and refactoring of package references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ bld/
 Generated\ Files/
 
 # MSTest test Results
-[Tt]est[Rr]esult*/
+**/[Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
 # NUNIT

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(IncludeDevelopmentPackages)' == 'true' ">
-    <!-- FxCop NuGet Package -->
+    <!-- .NET Analyzers NuGet Package -->
     <PackageReference Remove="Microsoft.CodeAnalysis.NetAnalyzers" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)">
       <PrivateAssets>all</PrivateAssets>

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -13,15 +13,11 @@
   <!-- ASP.NET Core/Microsoft Extension Packages -->
   <PropertyGroup>
     <MicrosoftAspNetCoreVersion>2.2.0</MicrosoftAspNetCoreVersion>
-    <MicrosoftAspNetCoreMvcVersion>2.2.0</MicrosoftAspNetCoreMvcVersion>
     <MicrosoftAspNetCoreSignalRClientVersion>5.0.3</MicrosoftAspNetCoreSignalRClientVersion>
     <MicrosoftAspNetCoreSignalRProtocolsMessagePackVersion>5.0.3</MicrosoftAspNetCoreSignalRProtocolsMessagePackVersion>
     <MicrosoftAspNetCoreSignalRVersion>1.1.0</MicrosoftAspNetCoreSignalRVersion>
     <MicrosoftAspNetWebApiClientVersion>5.2.7</MicrosoftAspNetWebApiClientVersion>
     <MicrosoftBclAsyncInterfacesVersion>5.0.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>5.0.0</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksVersion>5.0.3</MicrosoftExtensionsDiagnosticsHealthChecksVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>5.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
   </PropertyGroup>
   
   <!-- gRPC Packages -->
@@ -47,9 +43,9 @@
   <PropertyGroup>
     <CastleCoreVersion>4.4.1</CastleCoreVersion>
     <CsvHelperVersion>22.1.2</CsvHelperVersion>
-    <IntelligentPlantBackgroundTasksVersion>4.1.0</IntelligentPlantBackgroundTasksVersion>
+    <IntelligentPlantBackgroundTasksVersion>4.2.0</IntelligentPlantBackgroundTasksVersion>
     <JaahasHttpRequestTransformerVersion>2.0.0</JaahasHttpRequestTransformerVersion>
-    <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <NSwagAspNetCoreVersion>13.10.2</NSwagAspNetCoreVersion>
     <NuGetVersioningVersion>5.8.1</NuGetVersioningVersion>
   </PropertyGroup>

--- a/examples/DataCore.Adapter.NetFxExample/DataCore.Adapter.NetFxExample.csproj
+++ b/examples/DataCore.Adapter.NetFxExample/DataCore.Adapter.NetFxExample.csproj
@@ -6,10 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DataCore.Adapter.Abstractions/IAdapterCallContext.cs
+++ b/src/DataCore.Adapter.Abstractions/IAdapterCallContext.cs
@@ -32,7 +32,7 @@ namespace DataCore.Adapter {
         /// <summary>
         /// Additional items related to the call context.
         /// </summary>
-        IDictionary<object, object> Items { get; }
+        IDictionary<object, object?> Items { get; }
 
     }
 }

--- a/src/DataCore.Adapter.AspNetCore.Common/Authorization/DefaultAdapterAuthorizationService.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/Authorization/DefaultAdapterAuthorizationService.cs
@@ -61,7 +61,7 @@ namespace DataCore.Adapter.AspNetCore.Authorization {
                 return true;
             }
 
-            var result = await _authorizationService.AuthorizeAsync(context.User, adapter, new FeatureAuthorizationRequirement(null)).ConfigureAwait(false);
+            var result = await _authorizationService.AuthorizeAsync(context.User!, adapter, new FeatureAuthorizationRequirement(null)).ConfigureAwait(false);
             return result.Succeeded;
         }
 
@@ -72,7 +72,7 @@ namespace DataCore.Adapter.AspNetCore.Authorization {
                 return true;
             }
 
-            var result = await _authorizationService.AuthorizeAsync(context.User, adapter, new FeatureAuthorizationRequirement(featureUri)).ConfigureAwait(false);
+            var result = await _authorizationService.AuthorizeAsync(context.User!, adapter, new FeatureAuthorizationRequirement(featureUri)).ConfigureAwait(false);
             return result.Succeeded;
         }
     }

--- a/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreVersion)" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">

--- a/src/DataCore.Adapter.AspNetCore.HealthChecks/DataCore.Adapter.AspNetCore.HealthChecks.csproj
+++ b/src/DataCore.Adapter.AspNetCore.HealthChecks/DataCore.Adapter.AspNetCore.HealthChecks.csproj
@@ -9,8 +9,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksVersion)" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftAspNetCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/DataCore.Adapter.AspNetCore.Mvc.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/DataCore.Adapter.AspNetCore.Mvc.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreVersion)" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
@@ -260,7 +260,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
 
 
         /// <inheritdoc/>
-        public override Task OnDisconnectedAsync(Exception exception) {
+        public override Task OnDisconnectedAsync(Exception? exception) {
             return base.OnDisconnectedAsync(exception);
         }
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR/SignalRAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/SignalRAdapterCallContext.cs
@@ -39,7 +39,7 @@ namespace DataCore.Adapter.AspNetCore {
         }
 
         /// <inheritdoc/>
-        public IDictionary<object, object> Items {
+        public IDictionary<object, object?> Items {
             get { return _hubCallerContext.Items; }
         }
 

--- a/src/DataCore.Adapter.Core/Events/WriteEventMessagesRequest.cs
+++ b/src/DataCore.Adapter.Core/Events/WriteEventMessagesRequest.cs
@@ -14,7 +14,7 @@ namespace DataCore.Adapter.Events {
         /// </summary>
         [Required]
         [MinLength(1)]
-        public IEnumerable<WriteEventMessageItem> Events { get; set; } = default!;
+        public WriteEventMessageItem[] Events { get; set; } = default!;
 
     }
 }

--- a/src/DataCore.Adapter.Core/RealTimeData/WriteTagValuesRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/WriteTagValuesRequest.cs
@@ -14,7 +14,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// </summary>
         [Required]
         [MinLength(1)]
-        public IEnumerable<WriteTagValueItem> Values { get; set; } = Array.Empty<WriteTagValueItem>();
+        public WriteTagValueItem[] Values { get; set; } = Array.Empty<WriteTagValueItem>();
 
     }
 }

--- a/src/DataCore.Adapter.DependencyInjection/DataCore.Adapter.DependencyInjection.csproj
+++ b/src/DataCore.Adapter.DependencyInjection/DataCore.Adapter.DependencyInjection.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="$(IntelligentPlantBackgroundTasksVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DataCore.Adapter.Grpc.Client/DataCore.Adapter.Grpc.Client.csproj
+++ b/src/DataCore.Adapter.Grpc.Client/DataCore.Adapter.Grpc.Client.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 

--- a/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
+++ b/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.Tests</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Tests.Helpers</PackageId>
     <Description>Base MSTest test classes for testing App Store Connect adapters.</Description>
@@ -11,12 +11,19 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\DataCore.Adapter\DataCore.Adapter.csproj" />
     <ProjectReference Include="..\DataCore.Adapter.DependencyInjection\DataCore.Adapter.DependencyInjection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftAspNetCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   
 </Project>

--- a/src/DataCore.Adapter/DataCore.Adapter.csproj
+++ b/src/DataCore.Adapter/DataCore.Adapter.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>

--- a/src/DataCore.Adapter/Extensions/AdapterExtensionFeature.cs
+++ b/src/DataCore.Adapter/Extensions/AdapterExtensionFeature.cs
@@ -812,7 +812,7 @@ namespace DataCore.Adapter.Extensions {
                 throw new ArgumentNullException(nameof(json));
             }
 
-            return Newtonsoft.Json.JsonConvert.DeserializeObject(json, type);
+            return Newtonsoft.Json.JsonConvert.DeserializeObject(json, type)!;
         }
 
 

--- a/test/DataCore.Adapter.Tests/AssemblyInitializer.cs
+++ b/test/DataCore.Adapter.Tests/AssemblyInitializer.cs
@@ -3,10 +3,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-using IntelligentPlant.BackgroundTasks;
-
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DataCore.Adapter.Tests {

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -1,37 +1,77 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRProtocolsMessagePackVersion)" />
+    <Compile Remove="TestResults\**" />
+    <EmbeddedResource Remove="TestResults\**" />
+    <None Remove="TestResults\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <!-- Since we are using v5.0.x of the SignalR MessagePack library, we need to include a 
-         reference to v5.0.0 of System.Text.Encodings.Web when running on netcoreapp3.1 or the 
-         ASP.NET Core web server will throw a runtime error. -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.0" />
-  </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.Grpc\DataCore.Adapter.AspNetCore.Grpc.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.HealthChecks\DataCore.Adapter.AspNetCore.HealthChecks.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.Mvc\DataCore.Adapter.AspNetCore.Mvc.csproj" />
-    <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.SignalR.Proxy\DataCore.Adapter.AspNetCore.SignalR.Proxy.csproj" />
-    <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.SignalR\DataCore.Adapter.AspNetCore.SignalR.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.Csv\DataCore.Adapter.Csv.csproj" />
-    <ProjectReference Include="..\..\src\DataCore.Adapter.Grpc.Proxy\DataCore.Adapter.Grpc.Proxy.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.Http.Proxy\DataCore.Adapter.Http.Proxy.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.Tests.Helpers\DataCore.Adapter.Tests.Helpers.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.WaveGenerator\DataCore.Adapter.WaveGenerator.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter\DataCore.Adapter.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.Json\DataCore.Adapter.Json.csproj" />
+  </ItemGroup>
+
+  <!-- 
+  Some references depend on the target framework for the tests.
+  
+  For .NET Framework 4.8, we do not include any gRPC or SignalR-related projects. Hosting of gRPC 
+  services is only possible in ASP.NET Core 3.x and higher. Hosting of adapter SignalR hubs is 
+  possible in ASP.NET Cpre 2.x, but we do not test that here because the web server and the tests 
+  run in the same process, and references to newer versions of e.g. Microsoft.Extensions.Logging 
+  in the SignalR client library can cause us problems when running an ASP.NET Core 2.x web server, 
+  due to breaking changes between the 2.x versions of various libraries expected by ASP.NET Core 
+  and the latest versions referenced by the client or proxy adapter projects.
+  
+  -->
+  <Choose>
+    <!-- .NET Core 3.1/.NET 5.0 references -->
+    <When Condition=" '$(TargetFramework)' != 'net48' ">
+      <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+      </ItemGroup>
+      <ItemGroup>
+        <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRProtocolsMessagePackVersion)" />
+      </ItemGroup>
+      <ItemGroup>
+        <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.Grpc\DataCore.Adapter.AspNetCore.Grpc.csproj" />
+        <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.SignalR\DataCore.Adapter.AspNetCore.SignalR.csproj" />
+        <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.SignalR.Proxy\DataCore.Adapter.AspNetCore.SignalR.Proxy.csproj" />
+        <ProjectReference Include="..\..\src\DataCore.Adapter.Grpc.Proxy\DataCore.Adapter.Grpc.Proxy.csproj" />
+      </ItemGroup>
+    </When>
+    <!-- .NET Framework 4.8 references -->
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCoreVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftAspNetCoreVersion)" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  
+  <!-- 
+  Since we are using v5.0.x of the SignalR MessagePack library, we need to include a reference to 
+  v5.0.0 of System.Text.Encodings.Web when running on netcoreapp3.1 or the ASP.NET Core web server 
+  will throw a runtime error. 
+  -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DataCore.Adapter.Tests/GrpcProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/GrpcProxyTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+#if NETCOREAPP
 using DataCore.Adapter.Grpc.Proxy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -10,6 +10,7 @@ namespace DataCore.Adapter.Tests {
     public class GrpcProxyTests : ProxyAdapterTests<GrpcAdapterProxy> {
 
         protected override GrpcAdapterProxy CreateProxy(string remoteAdapterId, IServiceProvider serviceProvider) {
+
             return ActivatorUtilities.CreateInstance<GrpcAdapterProxy>(serviceProvider, nameof(GrpcProxyTests), new GrpcAdapterProxyOptions() {
                 RemoteId = remoteAdapterId
             });
@@ -17,3 +18,4 @@ namespace DataCore.Adapter.Tests {
 
     }
 }
+#endif

--- a/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NETCOREAPP
+
+using System;
 
 using DataCore.Adapter.AspNetCore.SignalR.Proxy;
 
@@ -55,3 +57,5 @@ namespace DataCore.Adapter.Tests {
 
     }
 }
+
+#endif

--- a/test/DataCore.Adapter.Tests/WaveGeneratorAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/WaveGeneratorAdapterTests.cs
@@ -271,7 +271,13 @@ namespace DataCore.Adapter.Tests {
 
                 var baseFuncChannel = await feature.ReadTagValuesAtTimes(context, new ReadTagValuesAtTimesRequest() {
                     Tags = new[] { baseFunc },
-                    UtcSampleTimes = new[] { DateTime.UnixEpoch.AddSeconds(defaultPeriod) }
+                    UtcSampleTimes = new[] {
+#if NETCOREAPP
+                        DateTime.UnixEpoch.AddSeconds(defaultPeriod) 
+#else
+                        new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(defaultPeriod)
+#endif
+                    }
                 }, ct).ConfigureAwait(false);
 
                 var baseFuncValues = await baseFuncChannel.ToEnumerable(cancellationToken: ct).ConfigureAwait(false);
@@ -279,7 +285,13 @@ namespace DataCore.Adapter.Tests {
 
                 var offsetFuncChannel = await feature.ReadTagValuesAtTimes(context, new ReadTagValuesAtTimesRequest() {
                     Tags = new[] { offsetFunc },
-                    UtcSampleTimes = new[] { DateTime.UnixEpoch.AddSeconds(period) }
+                    UtcSampleTimes = new[] { 
+#if NETCOREAPP
+                        DateTime.UnixEpoch.AddSeconds(period) 
+#else
+                        new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(period)
+#endif
+                    }
                 }, ct).ConfigureAwait(false);
 
                 var offsetFuncValues = await offsetFuncChannel.ToEnumerable(cancellationToken: ct).ConfigureAwait(false);

--- a/test/DataCore.Adapter.Tests/WebHostConfiguration.cs
+++ b/test/DataCore.Adapter.Tests/WebHostConfiguration.cs
@@ -26,10 +26,13 @@ namespace DataCore.Adapter.Tests {
 
         internal static void AllowUntrustedCertificates(HttpMessageHandler handler) {
             // For unit test purposes, allow all SSL certificates.
+#if NETCOREAPP
             if (handler is SocketsHttpHandler socketsHandler) {
                 socketsHandler.SslOptions.RemoteCertificateValidationCallback = (message, cert, chain, sslPolicyErrors) => true;
+                return;
             }
-            else if (handler is HttpClientHandler clientHandler) {
+#endif
+            if (handler is HttpClientHandler clientHandler) {
                 clientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) => true;
             }
         }
@@ -49,11 +52,13 @@ namespace DataCore.Adapter.Tests {
             });
             services.AddHttpClient<Http.Client.AdapterHttpClient>(HttpClientName);
 
+#if NETCOREAPP
             services.AddTransient(sp => {
                 return GrpcNet.Client.GrpcChannel.ForAddress(DefaultUrl, new GrpcNet.Client.GrpcChannelOptions() {
                     HttpClient = sp.GetService<IHttpClientFactory>().CreateClient(HttpClientName)
                 });
             });
+#endif
         }
 
     }

--- a/test/DataCore.Adapter.Tests/WebHostStartup.cs
+++ b/test/DataCore.Adapter.Tests/WebHostStartup.cs
@@ -1,6 +1,4 @@
-﻿#if NETCOREAPP
-
-using System;
+﻿using System;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -67,7 +65,7 @@ namespace DataCore.Adapter.Tests {
 
                     // Add configuration change notifier.
                     adapter.AddStandardFeatures(
-                        ActivatorUtilities.CreateInstance<Diagnostics.ConfigurationChanges>(sp, sp.GetService<ILogger<Csv.CsvAdapter>>())    
+                        ActivatorUtilities.CreateInstance<Diagnostics.ConfigurationChanges>(sp, sp.GetService<ILogger<Csv.CsvAdapter>>())
                     );
 
                     // Add ping-pong extension
@@ -81,16 +79,21 @@ namespace DataCore.Adapter.Tests {
             // the FeatureAuthorizationHandler class and call AddAdapterFeatureAuthorization
             // above to register your handler.
 
+#if NETCOREAPP
             services.AddGrpc();
+#endif
 
             services.AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
+                .SetCompatibilityVersion(CompatibilityVersion.Latest)
+#if NETCOREAPP
                 .AddJsonOptions(options => {
                     options.JsonSerializerOptions.WriteIndented = true;
                     options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
                 })
+#endif
                 .AddDataCoreAdapterMvc();
 
+#if NETCOREAPP
             services
                 .AddSignalR()
                 .AddDataCoreAdapterSignalR()
@@ -98,19 +101,26 @@ namespace DataCore.Adapter.Tests {
                     options.PayloadSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
                 })
                 .AddMessagePackProtocol();
+#endif
 
             services
                 .AddHealthChecks()
                 .AddAdapterHeathChecks();
         }
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+
+#if NETCOREAPP
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
+#else
+        public void Configure(IApplicationBuilder app, Microsoft.AspNetCore.Hosting.IHostingEnvironment env) {
+#endif
             if (env.IsDevelopment()) {
                 app.UseDeveloperExceptionPage();
             }
 
             app.UseRequestLocalization();
+
+#if NETCOREAPP
             app.UseRouting();
 
             app.UseEndpoints(endpoints => {
@@ -119,8 +129,10 @@ namespace DataCore.Adapter.Tests {
                 endpoints.MapDataCoreAdapterHubs();
                 endpoints.MapHealthChecks("/health");
             });
+#else
+            app.UseMvc();
+#endif
         }
+    
     }
 }
-
-#endif


### PR DESCRIPTION
Refactor package references so that .NET Standard 2.0 targets use Microsoft.Extensions.* packages that are compatible with ASP.NET Core 2.x.

For .NET Core targets, add ASP.NET Core framework references where required instead of explicit Microsoft.Extensions.* package references.

Add .NET Framework 4.8 unit test targets (with some caveats/restrictions)