### PR TITLE
Namespace and URI changes for tag-related features and types

### DIFF
--- a/docs/tutorials/creating-an-adapter/01-Getting_Started.md
+++ b/docs/tutorials/creating-an-adapter/01-Getting_Started.md
@@ -91,6 +91,7 @@ using System.Threading.Tasks;
 using DataCore.Adapter;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.Hosting;
 
@@ -196,16 +197,6 @@ If you compile and run the program, you will see output similar to the following
   URI: asc:features/real-time-data/values/push/
   Description: Allows subscribers to receive snapshot tag value updates from an adapter in real-time.
 
-[Tag Information]
-  Type: DataCore.Adapter.RealTimeData.ITagInfo
-  URI: asc:features/real-time-data/tags/info/
-  Description: Allows retrieval of an adapter's tag definitions using the tag's ID or name.
-
-[Tag Search]
-  Type: DataCore.Adapter.RealTimeData.ITagSearch
-  URI: asc:features/real-time-data/tags/search/
-  Description: Allows an adapter's tag definitions to be searched.
-
 [Write Historical Tag Values]
   Type: DataCore.Adapter.RealTimeData.IWriteHistoricalTagValues
   URI: asc:features/real-time-data/values/write/history/
@@ -220,6 +211,16 @@ If you compile and run the program, you will see output similar to the following
   Type: DataCore.Adapter.RealTimeData.IWriteTagValueAnnotations
   URI: asc:features/real-time-data/annotations/write/
   Description: Allows tag value annotations on an adapter to be created, updated, and deleted.
+
+[Tag Information]
+  Type: DataCore.Adapter.RealTimeData.ITagInfo
+  URI: asc:features/tags/info/
+  Description: Allows retrieval of an adapter's tag definitions using the tag's ID or name.
+
+[Tag Search]
+  Type: DataCore.Adapter.RealTimeData.ITagSearch
+  URI: asc:features/tags/search/
+  Description: Allows an adapter's tag definitions to be searched.
 ```
 
 > Note: adapters are not required to implement every standard feature! You can pick and choose which of the features are appropriate for your adapter.

--- a/examples/DataCore.Adapter.ExampleAdapter/ExampleAdapter.cs
+++ b/examples/DataCore.Adapter.ExampleAdapter/ExampleAdapter.cs
@@ -56,7 +56,7 @@ namespace DataCore.Adapter.Example {
             var startup = DateTime.UtcNow;
             await base.StartAsync(cancellationToken).ConfigureAwait(false);
             var adapter = (IAdapter) this;
-            await _assetModelBrowser.Init(adapter.Descriptor.Id, adapter.Features.Get<RealTimeData.ITagSearch>(), cancellationToken).ConfigureAwait(false);
+            await _assetModelBrowser.Init(adapter.Descriptor.Id, adapter.Features.Get<Tags.ITagSearch>(), cancellationToken).ConfigureAwait(false);
 
             _ = Task.Run(async () => {
                 try {

--- a/examples/DataCore.Adapter.ExampleAdapter/Features/AssetModelBrowser.cs
+++ b/examples/DataCore.Adapter.ExampleAdapter/Features/AssetModelBrowser.cs
@@ -24,7 +24,7 @@ namespace DataCore.Adapter.Example.Features {
         }
 
 
-        internal async Task Init(string adapterId, RealTimeData.ITagSearch tagSearch, CancellationToken cancellationToken) {
+        internal async Task Init(string adapterId, Tags.ITagSearch tagSearch, CancellationToken cancellationToken) {
             using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream(typeof(ExampleAdapter), AssetModelJson))
             using (var reader = new System.IO.StreamReader(stream)) {
                 var json = reader.ReadToEnd();
@@ -32,7 +32,7 @@ namespace DataCore.Adapter.Example.Features {
 
                 var dataReferences = nodeDefinitions.Where(x => !string.IsNullOrWhiteSpace(x.DataReference)).Select(x => x.DataReference).ToArray();
 
-                var dataReferencesChannel = await tagSearch.GetTags(null, new RealTimeData.GetTagsRequest() { 
+                var dataReferencesChannel = await tagSearch.GetTags(null, new Tags.GetTagsRequest() { 
                     Tags = dataReferences
                 }, cancellationToken).ConfigureAwait(false);
 

--- a/examples/tutorials/Directory.Build.props
+++ b/examples/tutorials/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <AdapterPackageVersion>2.0.0-beta.408</AdapterPackageVersion>
+    <AdapterPackageVersion></AdapterPackageVersion>
     <MicrosoftExtensionsHostingVersion>5.0.0</MicrosoftExtensionsHostingVersion>
   </PropertyGroup>
 </Project>

--- a/examples/tutorials/creating-an-adapter/chapter-01/Runner.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-01/Runner.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DataCore.Adapter;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.Hosting;
 

--- a/examples/tutorials/creating-an-adapter/chapter-02/Runner.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-02/Runner.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DataCore.Adapter;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.Hosting;
 

--- a/examples/tutorials/creating-an-adapter/chapter-03/Adapter.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-03/Adapter.cs
@@ -9,6 +9,8 @@ using DataCore.Adapter;
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
+
 using IntelligentPlant.BackgroundTasks;
 using Microsoft.Extensions.Logging;
 

--- a/examples/tutorials/creating-an-adapter/chapter-03/Runner.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-03/Runner.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DataCore.Adapter;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.Hosting;
 

--- a/examples/tutorials/creating-an-adapter/chapter-04/Adapter.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-04/Adapter.cs
@@ -9,6 +9,7 @@ using DataCore.Adapter;
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 using IntelligentPlant.BackgroundTasks;
 using Microsoft.Extensions.Logging;
 

--- a/examples/tutorials/creating-an-adapter/chapter-04/Runner.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-04/Runner.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DataCore.Adapter;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.Hosting;
 

--- a/examples/tutorials/creating-an-adapter/chapter-05/Adapter.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-05/Adapter.cs
@@ -9,6 +9,7 @@ using DataCore.Adapter;
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 using IntelligentPlant.BackgroundTasks;
 using Microsoft.Extensions.Logging;
 

--- a/examples/tutorials/creating-an-adapter/chapter-05/Runner.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-05/Runner.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DataCore.Adapter;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.Hosting;
 

--- a/examples/tutorials/creating-an-adapter/chapter-06/Adapter.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-06/Adapter.cs
@@ -9,6 +9,7 @@ using DataCore.Adapter;
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 using IntelligentPlant.BackgroundTasks;
 using Microsoft.Extensions.Logging;
 

--- a/examples/tutorials/creating-an-adapter/chapter-06/Runner.cs
+++ b/examples/tutorials/creating-an-adapter/chapter-06/Runner.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DataCore.Adapter;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.Hosting;
 

--- a/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Reflection;
 
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Extensions;
@@ -10,7 +9,6 @@ namespace DataCore.Adapter {
     /// <summary>
     /// Extensions for <see cref="IAdapter"/> and <see cref="AdapterDescriptorExtended"/>.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:Uri parameters should not be strings", Justification = "String parameter might not always be a URI")]
     public static class AdapterExtensions {
 
         /// <summary>

--- a/src/DataCore.Adapter.Abstractions/README.md
+++ b/src/DataCore.Adapter.Abstractions/README.md
@@ -26,6 +26,9 @@ Adapters can implement any number of the following standard feature interfaces:
     - [IAssetModelSearch](./AssetModel/IAssetModelSearch.cs)
 - Diagnostics:
     - [IHealthCheck](./Diagostics/IHealthCheck.cs)
+- Tags:
+    - [ITagInfo](./Tags/ITagInfo.cs)
+    - [ITagSearch](./Tags/ITagSearch.cs)
 - Events:
     - [IEventMessagePush](./Events/IEventMessagePush.cs)
     - [IEventMessagePushWithTopics](./Events/IEventMessagePushWithTopics.cs)
@@ -40,8 +43,6 @@ Adapters can implement any number of the following standard feature interfaces:
     - [IReadTagValueAnnotations](./RealTimeData/IReadTagValueAnnotations.cs)
     - [IReadTagValuesAtTimes](./RealTimeData/IReadTagValuesAtTimes.cs)
     - [ISnapshotTagValuePush](./RealTimeData/ISnapshotTagValuePush.cs)
-    - [ITagInfo](./RealTimeData/ITagInfo.cs)
-    - [ITagSearch](./RealTimeData/ITagSearch.cs)
     - [IWriteHistoricalTagValues](./RealTimeData/IWriteHistoricalTagValues.cs)
     - [IWriteSnapshotTagValues](./RealTimeData/IWriteSnapshotTagValues.cs)
     - [IWriteTagValueAnnotations](./RealTimeData/IWriteTagValueAnnotations.cs)

--- a/src/DataCore.Adapter.Abstractions/Tags/ITagInfo.cs
+++ b/src/DataCore.Adapter.Abstractions/Tags/ITagInfo.cs
@@ -4,13 +4,13 @@ using System.Threading.Tasks;
 
 using DataCore.Adapter.Common;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Feature for requesting information about tags.
     /// </summary>
     [AdapterFeature(
-        WellKnownFeatures.RealTimeData.TagInfo,
+        WellKnownFeatures.Tags.TagInfo,
         ResourceType = typeof(AbstractionsResources),
         Name = nameof(AbstractionsResources.DisplayName_TagInfo),
         Description = nameof(AbstractionsResources.Description_TagInfo)

--- a/src/DataCore.Adapter.Abstractions/Tags/ITagSearch.cs
+++ b/src/DataCore.Adapter.Abstractions/Tags/ITagSearch.cs
@@ -2,13 +2,13 @@
 using System.Threading.Channels;
 using System.Threading.Tasks;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Feature for performing tag searches on an adapter.
     /// </summary>
     [AdapterFeature(
-        WellKnownFeatures.RealTimeData.TagSearch,
+        WellKnownFeatures.Tags.TagSearch,
         ResourceType = typeof(AbstractionsResources),
         Name = nameof(AbstractionsResources.DisplayName_TagSearch),
         Description = nameof(AbstractionsResources.Description_TagSearch)

--- a/src/DataCore.Adapter.Abstractions/WellKnownFeatures.cs
+++ b/src/DataCore.Adapter.Abstractions/WellKnownFeatures.cs
@@ -9,6 +9,7 @@ using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.Events;
 using DataCore.Adapter.Extensions;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter {
 
@@ -49,11 +50,11 @@ namespace DataCore.Adapter {
             [RealTimeData.ReadSnapshotTagValues] = typeof(IReadSnapshotTagValues),
             [RealTimeData.ReadTagValuesAtTimes] = typeof(IReadTagValuesAtTimes),
             [RealTimeData.SnapshotTagValuePush] = typeof(ISnapshotTagValuePush),
-            [RealTimeData.TagInfo] = typeof(ITagInfo),
-            [RealTimeData.TagSearch] = typeof(ITagSearch),
             [RealTimeData.WriteAnnotations] = typeof(IWriteTagValueAnnotations),
             [RealTimeData.WriteHistoricalTagValues] = typeof(IWriteHistoricalTagValues),
-            [RealTimeData.WriteSnapshotTagValues] = typeof(IWriteSnapshotTagValues)
+            [RealTimeData.WriteSnapshotTagValues] = typeof(IWriteSnapshotTagValues),
+            [Tags.TagInfo] = typeof(ITagInfo),
+            [Tags.TagSearch] = typeof(ITagSearch),
         });
 
 
@@ -286,16 +287,6 @@ namespace DataCore.Adapter {
             public const string SnapshotTagValuePush = BaseUri + "values/push/";
 
             /// <summary>
-            /// URI for <see cref="ITagInfo"/>.
-            /// </summary>
-            public const string TagInfo = BaseUri + "tags/info/";
-
-            /// <summary>
-            /// URI for <see cref="ITagSearch"/>.
-            /// </summary>
-            public const string TagSearch = BaseUri + "tags/search/";
-
-            /// <summary>
             /// URI for <see cref="IWriteTagValueAnnotations"/>.
             /// </summary>
             public const string WriteAnnotations = BaseUri + "annotations/write/";
@@ -309,6 +300,29 @@ namespace DataCore.Adapter {
             /// URI for <see cref="IWriteSnapshotTagValues"/>.
             /// </summary>
             public const string WriteSnapshotTagValues = BaseUri + "values/write/snapshot/";
+
+        }
+
+
+        /// <summary>
+        /// Defines URIs for well-known tag-related adapter features.
+        /// </summary>
+        public static class Tags {
+
+            /// <summary>
+            /// Base URI for tag-related adapter features.
+            /// </summary>
+            public const string BaseUri = "asc:features/tags/";
+
+            /// <summary>
+            /// URI for <see cref="ITagInfo"/>.
+            /// </summary>
+            public const string TagInfo = BaseUri + "info/";
+
+            /// <summary>
+            /// URI for <see cref="ITagSearch"/>.
+            /// </summary>
+            public const string TagSearch = BaseUri + "search/";
 
         }
 

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
@@ -104,7 +104,7 @@ namespace DataCore.Adapter {
                 node.HasDataReference
                     ? new AssetModel.DataReference(
                         node.DataReference.AdapterId, 
-                        new RealTimeData.TagIdentifier(
+                        new Tags.TagIdentifier(
                             node.DataReference.Tag.Id, 
                             node.DataReference.Tag.Name
                         )
@@ -1528,12 +1528,12 @@ namespace DataCore.Adapter {
         /// <returns>
         ///   The adapter tag definition.
         /// </returns>
-        public static RealTimeData.TagDefinition ToAdapterTagDefinition(this Grpc.TagDefinition tagDefinition) {
+        public static Tags.TagDefinition ToAdapterTagDefinition(this Grpc.TagDefinition tagDefinition) {
             if (tagDefinition == null) {
                 throw new ArgumentNullException(nameof(tagDefinition));
             }
 
-            return new RealTimeData.TagDefinition(
+            return new Tags.TagDefinition(
                 tagDefinition.Id,
                 tagDefinition.Name,
                 tagDefinition.Description,
@@ -1556,7 +1556,7 @@ namespace DataCore.Adapter {
         /// <returns>
         ///   The gRPC tag definition.
         /// </returns>
-        public static Grpc.TagDefinition ToGrpcTagDefinition(this RealTimeData.TagDefinition tag) {
+        public static Grpc.TagDefinition ToGrpcTagDefinition(this Tags.TagDefinition tag) {
             if (tag == null) {
                 throw new ArgumentNullException(nameof(tag));
             }
@@ -1618,12 +1618,12 @@ namespace DataCore.Adapter {
         /// <returns>
         ///   The adapter digital state.
         /// </returns>
-        public static RealTimeData.DigitalState ToAdapterDigitalState(this Grpc.DigitalState state) {
+        public static Tags.DigitalState ToAdapterDigitalState(this Grpc.DigitalState state) {
             if (state == null) {
                 throw new ArgumentNullException(nameof(state));
             }
 
-            return RealTimeData.DigitalState.Create(state.Name, state.Value);
+            return Tags.DigitalState.Create(state.Name, state.Value);
         }
 
 
@@ -1636,7 +1636,7 @@ namespace DataCore.Adapter {
         /// <returns>
         ///   The gRPC digital state.
         /// </returns>
-        public static Grpc.DigitalState ToGrpcDigitalState(this RealTimeData.DigitalState state) {
+        public static Grpc.DigitalState ToGrpcDigitalState(this Tags.DigitalState state) {
             if (state == null) {
                 throw new ArgumentNullException(nameof(state));
             }
@@ -1657,12 +1657,12 @@ namespace DataCore.Adapter {
         /// <returns>
         ///   The adapter digital state set.
         /// </returns>
-        public static RealTimeData.DigitalStateSet ToAdapterDigitalStateSet(this Grpc.DigitalStateSet set) {
+        public static Tags.DigitalStateSet ToAdapterDigitalStateSet(this Grpc.DigitalStateSet set) {
             if (set == null) {
                 throw new ArgumentNullException(nameof(set));
             }
 
-            return RealTimeData.DigitalStateSet.Create(set.Id, set.Name, set.States.Select(x => x.ToAdapterDigitalState()));
+            return Tags.DigitalStateSet.Create(set.Id, set.Name, set.States.Select(x => x.ToAdapterDigitalState()));
         }
 
 
@@ -1675,7 +1675,7 @@ namespace DataCore.Adapter {
         /// <returns>
         ///   The gRPC digital state set.
         /// </returns>
-        public static Grpc.DigitalStateSet ToGrpcDigitalStateSet(this RealTimeData.DigitalStateSet set) {
+        public static Grpc.DigitalStateSet ToGrpcDigitalStateSet(this Tags.DigitalStateSet set) {
             if (set == null) {
                 throw new ArgumentNullException(nameof(set));
             }

--- a/src/DataCore.Adapter.AspNetCore.Grpc/Services/TagSearchServiceImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/Services/TagSearchServiceImpl.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using DataCore.Adapter.AspNetCore.Grpc;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
+
 using Grpc.Core;
 
 namespace DataCore.Adapter.Grpc.Server.Services {
@@ -37,7 +39,7 @@ namespace DataCore.Adapter.Grpc.Server.Services {
             var cancellationToken = context.CancellationToken;
             var adapter = await Util.ResolveAdapterAndFeature<ITagInfo>(adapterCallContext, _adapterAccessor, adapterId, cancellationToken).ConfigureAwait(false);
 
-            var adapterRequest = new Adapter.RealTimeData.GetTagPropertiesRequest() {
+            var adapterRequest = new Adapter.Tags.GetTagPropertiesRequest() {
                 PageSize = request.PageSize,
                 Page = request.Page,
                 Properties = new Dictionary<string, string>(request.Properties)
@@ -63,7 +65,7 @@ namespace DataCore.Adapter.Grpc.Server.Services {
             var cancellationToken = context.CancellationToken;
             var adapter = await Util.ResolveAdapterAndFeature<ITagSearch>(adapterCallContext, _adapterAccessor, adapterId, cancellationToken).ConfigureAwait(false);
 
-            var adapterRequest = new Adapter.RealTimeData.FindTagsRequest() {
+            var adapterRequest = new Adapter.Tags.FindTagsRequest() {
                 Name = request.Name,
                 Description = request.Description,
                 Units = request.Units,
@@ -95,7 +97,7 @@ namespace DataCore.Adapter.Grpc.Server.Services {
             var cancellationToken = context.CancellationToken;
             var adapter = await Util.ResolveAdapterAndFeature<ITagInfo>(adapterCallContext, _adapterAccessor, adapterId, cancellationToken).ConfigureAwait(false);
 
-            var adapterRequest = new Adapter.RealTimeData.GetTagsRequest() {
+            var adapterRequest = new Adapter.Tags.GetTagsRequest() {
                 Tags = request.Tags.ToArray(),
                 Properties = new Dictionary<string, string>(request.Properties)
             };

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+
 using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace DataCore.Adapter.AspNetCore.Controllers {

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagSearchClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagSearchClient.cs
@@ -2,8 +2,10 @@
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+
 using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
+
 using Microsoft.AspNetCore.SignalR.Client;
 
 namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/TagSearchImpl.cs
@@ -4,7 +4,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagSearchHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagSearchHub.cs
@@ -3,7 +3,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.AspNetCore.Hubs {
 

--- a/src/DataCore.Adapter.Core/AssetModel/DataReference.cs
+++ b/src/DataCore.Adapter.Core/AssetModel/DataReference.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.AssetModel {
 

--- a/src/DataCore.Adapter.Core/Tags/DigitalState.cs
+++ b/src/DataCore.Adapter.Core/Tags/DigitalState.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Describes a digital state associated with a tag.

--- a/src/DataCore.Adapter.Core/Tags/DigitalStateSet.cs
+++ b/src/DataCore.Adapter.Core/Tags/DigitalStateSet.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Describes a collection of discrete states.

--- a/src/DataCore.Adapter.Core/Tags/FindTagsRequest.cs
+++ b/src/DataCore.Adapter.Core/Tags/FindTagsRequest.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 
 using DataCore.Adapter.Common;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Describes a tag search query.

--- a/src/DataCore.Adapter.Core/Tags/GetTagPropertiesRequest.cs
+++ b/src/DataCore.Adapter.Core/Tags/GetTagPropertiesRequest.cs
@@ -1,6 +1,6 @@
 ﻿using DataCore.Adapter.Common;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Describes a request to retrieve tag property definitions.

--- a/src/DataCore.Adapter.Core/Tags/GetTagsRequest.cs
+++ b/src/DataCore.Adapter.Core/Tags/GetTagsRequest.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 using DataCore.Adapter.Common;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Describes a request to get tag definitions by tag ID or name.

--- a/src/DataCore.Adapter.Core/Tags/TagDefinition.cs
+++ b/src/DataCore.Adapter.Core/Tags/TagDefinition.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using DataCore.Adapter.Common;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Describes a tag definition.

--- a/src/DataCore.Adapter.Core/Tags/TagDefinitionExtensions.cs
+++ b/src/DataCore.Adapter.Core/Tags/TagDefinitionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Extensions for <see cref="TagDefinition"/>.

--- a/src/DataCore.Adapter.Core/Tags/TagDefinitionFields.cs
+++ b/src/DataCore.Adapter.Core/Tags/TagDefinitionFields.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Indicates which parts of a <see cref="TagDefinition"/> to populate when returning the 

--- a/src/DataCore.Adapter.Core/Tags/TagIdentifier.cs
+++ b/src/DataCore.Adapter.Core/Tags/TagIdentifier.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Defines basic information for identifying a real-time data tag.

--- a/src/DataCore.Adapter.Core/Tags/TagSummary.cs
+++ b/src/DataCore.Adapter.Core/Tags/TagSummary.cs
@@ -2,7 +2,7 @@
 
 using DataCore.Adapter.Common;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Describes summary information about a tag.

--- a/src/DataCore.Adapter.Csv/CsvAdapter.cs
+++ b/src/DataCore.Adapter.Csv/CsvAdapter.cs
@@ -12,6 +12,8 @@ using CsvHelper;
 
 using DataCore.Adapter.Common;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
+
 using IntelligentPlant.BackgroundTasks;
 using Microsoft.Extensions.Logging;
 

--- a/src/DataCore.Adapter.Csv/CsvDataSet.cs
+++ b/src/DataCore.Adapter.Csv/CsvDataSet.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Csv {
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/TagSearchImpl.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
@@ -22,7 +22,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
 
         /// <inheritdoc />
-        public Task<ChannelReader<Adapter.RealTimeData.TagDefinition>> FindTags(IAdapterCallContext context, Adapter.RealTimeData.FindTagsRequest request, CancellationToken cancellationToken) {
+        public Task<ChannelReader<Adapter.Tags.TagDefinition>> FindTags(IAdapterCallContext context, Adapter.Tags.FindTagsRequest request, CancellationToken cancellationToken) {
             if (context == null) {
                 throw new ArgumentNullException(nameof(context));
             }
@@ -74,7 +74,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
 
         /// <inheritdoc />
-        public Task<ChannelReader<Adapter.RealTimeData.TagDefinition>> GetTags(IAdapterCallContext context, Adapter.RealTimeData.GetTagsRequest request, CancellationToken cancellationToken) {
+        public Task<ChannelReader<Adapter.Tags.TagDefinition>> GetTags(IAdapterCallContext context, Adapter.Tags.GetTagsRequest request, CancellationToken cancellationToken) {
             GrpcAdapterProxy.ValidateObject(request); 
             
             var client = CreateClient<TagSearchService.TagSearchServiceClient>();
@@ -106,7 +106,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
 
         /// <inheritdoc />
-        public Task<ChannelReader<Common.AdapterProperty>> GetTagProperties(IAdapterCallContext context, Adapter.RealTimeData.GetTagPropertiesRequest request, CancellationToken cancellationToken) {
+        public Task<ChannelReader<Common.AdapterProperty>> GetTagProperties(IAdapterCallContext context, Adapter.Tags.GetTagPropertiesRequest request, CancellationToken cancellationToken) {
             GrpcAdapterProxy.ValidateObject(request); 
             
             var client = CreateClient<TagSearchService.TagSearchServiceClient>();

--- a/src/DataCore.Adapter.Http.Client/Clients/TagSearchClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagSearchClient.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Http.Client.Clients {
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/TagSearchImpl.cs
@@ -4,7 +4,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Http.Proxy.RealTimeData {
     /// <summary>

--- a/src/DataCore.Adapter.Json/DataReferenceConverter.cs
+++ b/src/DataCore.Adapter.Json/DataReferenceConverter.cs
@@ -2,7 +2,7 @@
 using System.Text.Json;
 
 using DataCore.Adapter.AssetModel;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Json {
 

--- a/src/DataCore.Adapter.Json/DigitalStateConverter.cs
+++ b/src/DataCore.Adapter.Json/DigitalStateConverter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.Json;
-using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Json {
 

--- a/src/DataCore.Adapter.Json/DigitalStateSetConverter.cs
+++ b/src/DataCore.Adapter.Json/DigitalStateSetConverter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Text.Json;
-using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Json {
 

--- a/src/DataCore.Adapter.Json/TagDefinitionConverter.cs
+++ b/src/DataCore.Adapter.Json/TagDefinitionConverter.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Text.Json;
+
 using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Json {
 

--- a/src/DataCore.Adapter.Json/TagIdentifierConverter.cs
+++ b/src/DataCore.Adapter.Json/TagIdentifierConverter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.Json;
-using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Json {
 

--- a/src/DataCore.Adapter.Json/TagSummaryConverter.cs
+++ b/src/DataCore.Adapter.Json/TagSummaryConverter.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Text.Json;
+
 using DataCore.Adapter.Common;
-using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.Json {
 

--- a/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
+++ b/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
@@ -12,6 +12,7 @@ using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.Events;
 using DataCore.Adapter.Extensions;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
+++ b/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 
 using DataCore.Adapter.Common;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using IntelligentPlant.BackgroundTasks;
 

--- a/src/DataCore.Adapter/AssetModel/AssetModelNodeBuilder.cs
+++ b/src/DataCore.Adapter/AssetModel/AssetModelNodeBuilder.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using DataCore.Adapter.Common;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.AssetModel {
 

--- a/src/DataCore.Adapter/ChannelExtensions.cs
+++ b/src/DataCore.Adapter/ChannelExtensions.cs
@@ -107,12 +107,12 @@ namespace DataCore.Adapter {
         /// <remarks>
         ///   The default capacity of the created channel is set to <see cref="TagDefinitionChannelCapacity"/>.
         /// </remarks>
-        public static Channel<RealTimeData.TagDefinition> CreateTagDefinitionChannel(
+        public static Channel<Tags.TagDefinition> CreateTagDefinitionChannel(
             int capacity = TagDefinitionChannelCapacity,
             bool singleReader = true,
             bool singleWriter = true
         ) {
-            return CreateChannel<RealTimeData.TagDefinition>(capacity, singleReader, singleWriter);
+            return CreateChannel<Tags.TagDefinition>(capacity, singleReader, singleWriter);
         }
 
 
@@ -135,12 +135,12 @@ namespace DataCore.Adapter {
         /// <remarks>
         ///   The default capacity of the created channel is set to <see cref="TagDefinitionChannelCapacity"/>.
         /// </remarks>
-        public static Channel<RealTimeData.TagIdentifier> CreateTagIdentifierChannel(
+        public static Channel<Tags.TagIdentifier> CreateTagIdentifierChannel(
             int capacity = TagDefinitionChannelCapacity,
             bool singleReader = true,
             bool singleWriter = true
         ) {
-            return CreateChannel<RealTimeData.TagIdentifier>(capacity, singleReader, singleWriter);
+            return CreateChannel<Tags.TagIdentifier>(capacity, singleReader, singleWriter);
         }
 
 

--- a/src/DataCore.Adapter/RealTimeData/PollingSnapshotTagValuePush.cs
+++ b/src/DataCore.Adapter/RealTimeData/PollingSnapshotTagValuePush.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 
+using DataCore.Adapter.Tags;
+
 using IntelligentPlant.BackgroundTasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/DataCore.Adapter/RealTimeData/ReadHistoricalTagValues.cs
+++ b/src/DataCore.Adapter/RealTimeData/ReadHistoricalTagValues.cs
@@ -5,6 +5,8 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.RealTimeData.Utilities;
+using DataCore.Adapter.Tags;
+
 using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.RealTimeData {

--- a/src/DataCore.Adapter/RealTimeData/SnapshotTagValuePush.cs
+++ b/src/DataCore.Adapter/RealTimeData/SnapshotTagValuePush.cs
@@ -7,6 +7,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Common;
+using DataCore.Adapter.Tags;
 
 using IntelligentPlant.BackgroundTasks;
 

--- a/src/DataCore.Adapter/RealTimeData/TagValueSubscriptionChannel.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueSubscriptionChannel.cs
@@ -1,7 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
+
+using DataCore.Adapter.Tags;
 
 using IntelligentPlant.BackgroundTasks;
 

--- a/src/DataCore.Adapter/RealTimeData/Utilities/AggregationHelper.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/AggregationHelper.cs
@@ -7,6 +7,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Common;
+using DataCore.Adapter.Tags;
 
 using IntelligentPlant.BackgroundTasks;
 

--- a/src/DataCore.Adapter/RealTimeData/Utilities/InterpolationHelper.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/InterpolationHelper.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using DataCore.Adapter.Common;
+using DataCore.Adapter.Tags;
+
 using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.RealTimeData.Utilities {

--- a/src/DataCore.Adapter/RealTimeData/Utilities/PlotHelper.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/PlotHelper.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using DataCore.Adapter.Common;
+using DataCore.Adapter.Tags;
+
 using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.RealTimeData.Utilities {

--- a/src/DataCore.Adapter/Tags/TagDefinitionBuilder.cs
+++ b/src/DataCore.Adapter/Tags/TagDefinitionBuilder.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 using DataCore.Adapter.Common;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Helper class for constructing <see cref="TagDefinition"/> objects using a fluent interface.

--- a/src/DataCore.Adapter/Tags/TagDefinitionExtensions.cs
+++ b/src/DataCore.Adapter/Tags/TagDefinitionExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
-namespace DataCore.Adapter.RealTimeData {
+namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Extension methods for <see cref="TagDefinition"/>.

--- a/test/DataCore.Adapter.Benchmarks/SnapshotPush.cs
+++ b/test/DataCore.Adapter.Benchmarks/SnapshotPush.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
+
 using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.Benchmarks {

--- a/test/DataCore.Adapter.Tests/AggregationTests.cs
+++ b/test/DataCore.Adapter.Tests/AggregationTests.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using DataCore.Adapter.Common;
 using DataCore.Adapter.RealTimeData;
 using DataCore.Adapter.RealTimeData.Utilities;
+using DataCore.Adapter.Tags;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DataCore.Adapter.Tests {

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Events;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using IntelligentPlant.BackgroundTasks;
 

--- a/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Events;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -8,6 +8,8 @@ using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.Events;
 using DataCore.Adapter.Json;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DataCore.Adapter.Tests {

--- a/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -10,6 +9,7 @@ using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.Events;
 using DataCore.Adapter.Http.Client;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/DataCore.Adapter.Tests/SubscriptionTests.cs
+++ b/test/DataCore.Adapter.Tests/SubscriptionTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using DataCore.Adapter.Events;
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/test/DataCore.Adapter.Tests/WaveGeneratorAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/WaveGeneratorAdapterTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.RealTimeData;
+using DataCore.Adapter.Tags;
 using DataCore.Adapter.WaveGenerator;
 
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
**Breaking Changes:**
- `ITagInfo`, `ITagSearch` and associated request and response types (`TagDefinition` etc.) have been moved to the `DataCore.Adapter.Tags` namespace.
- URIs for `ITagInfo` and `ITagSearch` have been changed.