### PR TITLE
Validation improvements

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/AssetModel/AssetModelBrowseImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/AssetModel/AssetModelBrowseImpl.cs
@@ -22,10 +22,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.AssetModel.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<AssetModelNode>> BrowseAssetModelNodes(IAdapterCallContext context, BrowseAssetModelNodesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             var hubChannel = await client.AssetModel.BrowseAssetModelNodesAsync(
@@ -45,10 +42,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.AssetModel.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<AssetModelNode>> GetAssetModelNodes(IAdapterCallContext context, GetAssetModelNodesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             var hubChannel = await client.AssetModel.GetAssetModelNodesAsync(

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/AssetModel/AssetModelSearchImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/AssetModel/AssetModelSearchImpl.cs
@@ -23,10 +23,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.AssetModel.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<AssetModelNode>> FindAssetModelNodes(IAdapterCallContext context, FindAssetModelNodesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             var hubChannel = await client.AssetModel.FindAssetModelNodesAsync(

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Diagnostics/ConfigurationChangesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Diagnostics/ConfigurationChangesImpl.cs
@@ -27,11 +27,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData {
             ConfigurationChangesSubscriptionRequest request, 
             CancellationToken cancellationToken
         ) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            SignalRAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             return client.ConfigurationChanges.CreateConfigurationChangesChannelAsync(AdapterId, request, cancellationToken);

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushImpl.cs
@@ -27,10 +27,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Events.Features {
             CreateEventMessageSubscriptionRequest request,
             CancellationToken cancellationToken
         ) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             return GetClient().Events.CreateEventMessageChannelAsync(
                 AdapterId,

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushWithTopicsImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushWithTopicsImpl.cs
@@ -29,15 +29,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Events {
             ChannelReader<EventMessageSubscriptionUpdate> channel,
             CancellationToken cancellationToken
         ) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            SignalRAdapterProxy.ValidateObject(request);
-
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, request, channel);
 
             return GetClient().Events.CreateEventMessageTopicChannelAsync(
                 AdapterId, 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
@@ -22,11 +22,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Events.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<EventMessage>> ReadEventMessagesForTimeRange(IAdapterCallContext context, ReadEventMessagesForTimeRangeRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            SignalRAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             var hubChannel = await client.Events.ReadEventMessagesAsync(

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
@@ -22,11 +22,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Events.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<EventMessageWithCursorPosition>> ReadEventMessagesUsingCursor(IAdapterCallContext context, ReadEventMessagesUsingCursorRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            SignalRAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             var hubChannel = await client.Events.ReadEventMessagesAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/WriteEventMessagesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/WriteEventMessagesImpl.cs
@@ -22,12 +22,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<WriteEventMessageResult>> WriteEventMessages(IAdapterCallContext context, ChannelReader<WriteEventMessageItem> channel, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, channel);
 
             var client = GetClient();
             var hubChannel = await client.Events.WriteEventMessagesAsync(

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
@@ -35,6 +35,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
+            Proxy.ValidateInvocation(context);
             var client = Proxy.GetClient();
             return client.Extensions.GetDescriptorAsync(Proxy.RemoteDescriptor.Id, featureUri!, cancellationToken)!;
         }
@@ -46,6 +47,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
+            Proxy.ValidateInvocation(context);
             var client = Proxy.GetClient();
             return client.Extensions.GetOperationsAsync(Proxy.RemoteDescriptor.Id, featureUri!, cancellationToken);
         }
@@ -53,6 +55,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
 
         /// <inheritdoc/>
         protected override Task<string> InvokeInternal(IAdapterCallContext context, Uri operationId, string argument, CancellationToken cancellationToken) {
+            Proxy.ValidateInvocation(context);
             var client = Proxy.GetClient();
             return client.Extensions.InvokeExtensionAsync(Proxy.RemoteDescriptor.Id, operationId, argument, cancellationToken)!;
         }
@@ -60,6 +63,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
 
         /// <inheritdoc/>
         protected override Task<ChannelReader<string>> StreamInternal(IAdapterCallContext context, Uri operationId, string argument, CancellationToken cancellationToken) {
+            Proxy.ValidateInvocation(context);
             var client = Proxy.GetClient();
             return client.Extensions.InvokeStreamingExtensionAsync(Proxy.RemoteDescriptor.Id, operationId, argument, cancellationToken)!;
         }
@@ -67,6 +71,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
 
         /// <inheritdoc/>
         protected override Task<ChannelReader<string>> DuplexStreamInternal(IAdapterCallContext context, Uri operationId, ChannelReader<string> channel, CancellationToken cancellationToken) {
+            Proxy.ValidateInvocation(context, channel);
             var client = Proxy.GetClient();
             return client.Extensions.InvokeDuplexStreamingExtensionAsync(Proxy.RemoteDescriptor.Id, operationId, channel, cancellationToken);
         }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/ProxyAdapterFeature.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/ProxyAdapterFeature.cs
@@ -26,27 +26,27 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         /// The proxy that the feature instance belongs to.
         /// </summary>
-        private readonly SignalRAdapterProxy _proxy;
+        protected SignalRAdapterProxy Proxy { get; }
 
         /// <summary>
         /// Gets the logger for the proxy.
         /// </summary>
         protected ILogger Logger {
-            get { return _proxy.Logger; }
+            get { return Proxy.Logger; }
         }
 
         /// <summary>
         /// The adapter ID for the remote adapter.
         /// </summary>
         protected string AdapterId {
-            get { return _proxy.RemoteDescriptor?.Id!; }
+            get { return Proxy.RemoteDescriptor?.Id!; }
         }
 
         /// <summary>
         /// Gets the <see cref="IBackgroundTaskService"/> for the proxy.
         /// </summary>
         public IBackgroundTaskService BackgroundTaskService {
-            get { return _proxy.BackgroundTaskService; }
+            get { return Proxy.BackgroundTaskService; }
         }
 
 
@@ -117,7 +117,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         ///   The proxy that owns the feature instance.
         /// </param>
         protected ProxyAdapterFeature(SignalRAdapterProxy proxy) {
-            _proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
+            Proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
         }
 
 
@@ -128,7 +128,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         ///   A <see cref="AdapterSignalRClient"/> object.
         /// </returns>
         protected internal AdapterSignalRClient GetClient() {
-            return _proxy.GetClient();
+            return Proxy.GetClient();
         }
 
     }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -22,10 +22,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<TagValueQueryResult>> ReadPlotTagValues(IAdapterCallContext context, ReadPlotTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             var hubChannel = await client.TagValues.ReadPlotTagValuesAsync(

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -22,9 +22,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<DataFunctionDescriptor>> GetSupportedDataFunctions(IAdapterCallContext context, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
+            Proxy.ValidateInvocation(context);
+
             var client = GetClient();
             var hubChannel = await client.TagValues.GetSupportedDataFunctionsAsync(
                 AdapterId, 
@@ -42,10 +41,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<ProcessedTagValueQueryResult>> ReadProcessedTagValues(IAdapterCallContext context, ReadProcessedTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             var hubChannel = await client.TagValues.ReadProcessedTagValuesAsync(

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -22,11 +22,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<TagValueQueryResult>> ReadRawTagValues(IAdapterCallContext context, ReadRawTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request); 
-            
+            Proxy.ValidateInvocation(context, request);
+
             var client = GetClient();
             var hubChannel = await client.TagValues.ReadRawTagValuesAsync(
                 AdapterId, 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -22,11 +22,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<TagValueQueryResult>> ReadSnapshotTagValues(IAdapterCallContext context, ReadSnapshotTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request); 
-            
+            Proxy.ValidateInvocation(context, request);
+
             var client = GetClient();
             var hubChannel = await client.TagValues.ReadSnapshotTagValuesAsync(
                 AdapterId, 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
@@ -19,11 +19,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<TagValueAnnotationQueryResult>> ReadAnnotations(IAdapterCallContext context, ReadAnnotationsRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request); 
-            
+            Proxy.ValidateInvocation(context, request);
+
             var client = GetClient();
             var hubChannel = await client.TagValueAnnotations.ReadAnnotationsAsync(
                 AdapterId, 
@@ -42,8 +39,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public async Task<TagValueAnnotationExtended> ReadAnnotation(IAdapterCallContext context, ReadAnnotationRequest request, CancellationToken cancellationToken) {
-            SignalRAdapterProxy.ValidateObject(request); 
-            
+            Proxy.ValidateInvocation(context, request);
+
             var client = GetClient();
             return await client.TagValueAnnotations.ReadAnnotationAsync(
                 AdapterId, 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -22,11 +22,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<TagValueQueryResult>> ReadTagValuesAtTimes(IAdapterCallContext context, ReadTagValuesAtTimesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            SignalRAdapterProxy.ValidateObject(request); 
-            
+            Proxy.ValidateInvocation(context, request);
+
             var client = GetClient();
             var hubChannel = await client.TagValues.ReadTagValuesAtTimesAsync(
                 AdapterId, 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
@@ -34,15 +34,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             ChannelReader<TagValueSubscriptionUpdate> channel,
             CancellationToken cancellationToken
         ) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            SignalRAdapterProxy.ValidateObject(request);
-
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, request, channel);
 
             return GetClient().TagValues.CreateSnapshotTagValueChannelAsync(
                 AdapterId,

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/TagSearchImpl.cs
@@ -24,12 +24,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<TagDefinition>> FindTags(IAdapterCallContext context, FindTagsRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
+            Proxy.ValidateInvocation(context, request);
 
-            SignalRAdapterProxy.ValidateObject(request); 
-            
             var client = GetClient();
             var hubChannel = await client.TagSearch.FindTagsAsync(
                 AdapterId, 
@@ -49,12 +45,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<TagDefinition>> GetTags(IAdapterCallContext context, GetTagsRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
+            Proxy.ValidateInvocation(context, request);
 
-            SignalRAdapterProxy.ValidateObject(request); 
-            
             var client = GetClient();
             var hubChannel = await client.TagSearch.GetTagsAsync(
                 AdapterId, 
@@ -74,12 +66,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<AdapterProperty>> GetTagProperties(IAdapterCallContext context, GetTagPropertiesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            
-            SignalRAdapterProxy.ValidateObject(request); 
-            
+            Proxy.ValidateInvocation(context, request);
+
             var client = GetClient();
             var hubChannel = await client.TagSearch.GetTagPropertiesAsync(
                 AdapterId, 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
@@ -22,12 +22,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<WriteTagValueResult>> WriteHistoricalTagValues(IAdapterCallContext context, ChannelReader<WriteTagValueItem> channel, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, channel);
 
             var client = GetClient();
             var hubChannel = await client.TagValues.WriteHistoricalTagValuesAsync(

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
@@ -22,12 +22,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<WriteTagValueResult>> WriteSnapshotTagValues(IAdapterCallContext context, ChannelReader<WriteTagValueItem> channel, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, channel);
 
             var client = GetClient();
             var hubChannel = await client.TagValues.WriteSnapshotTagValuesAsync(

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
@@ -20,36 +20,24 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> CreateAnnotation(IAdapterCallContext context, CreateAnnotationRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
+            Proxy.ValidateInvocation(context, request);
 
-            SignalRAdapterProxy.ValidateObject(request); 
-            
             var client = GetClient();
             return await client.TagValueAnnotations.CreateAnnotationAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> UpdateAnnotation(IAdapterCallContext context, UpdateAnnotationRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
+            Proxy.ValidateInvocation(context, request);
 
-            SignalRAdapterProxy.ValidateObject(request); 
-            
             var client = GetClient();
             return await client.TagValueAnnotations.UpdateAnnotationAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> DeleteAnnotation(IAdapterCallContext context, DeleteAnnotationRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
+            Proxy.ValidateInvocation(context, request);
 
-            SignalRAdapterProxy.ValidateObject(request); 
-            
             var client = GetClient();
             return await client.TagValueAnnotations.DeleteAnnotationAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
@@ -272,29 +272,6 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
 
 
         /// <summary>
-        /// Validates an object. This should be called on all adapter request objects prior to 
-        /// invoking a remote endpoint.
-        /// </summary>
-        /// <param name="o">
-        ///   The object.
-        /// </param>
-        /// <param name="canBeNull">
-        ///   When <see langword="true"/>, validation will succeed if <paramref name="o"/> is 
-        ///   <see langword="null"/>.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="o"/> is <see langword="null"/> and <paramref name="canBeNull"/> is 
-        ///   <see langword="false"/>.
-        /// </exception>
-        /// <exception cref="ValidationException">
-        ///   <paramref name="o"/> fails validation.
-        /// </exception>
-        public static void ValidateObject(object o, bool canBeNull = false) {
-            AdapterSignalRClient.ValidateObject(o, canBeNull);
-        }
-
-
-        /// <summary>
         /// Long-running task that tells the adapter to recompute the overall health status of the 
         /// adapter when the remote adapter health status changes.
         /// </summary>

--- a/src/DataCore.Adapter.Csv/CsvAdapter.cs
+++ b/src/DataCore.Adapter.Csv/CsvAdapter.cs
@@ -512,9 +512,7 @@ namespace DataCore.Adapter.Csv {
 
         /// <inheritdoc/>
         public Task<ChannelReader<TagDefinition>> FindTags(IAdapterCallContext context, FindTagsRequest request, CancellationToken cancellationToken) {
-            CheckDisposed();
-            CheckStarted(true);
-            ValidationExtensions.ValidateObject(request);
+            ValidateInvocation(context, request);
             var result = ChannelExtensions.CreateTagDefinitionChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
@@ -530,9 +528,7 @@ namespace DataCore.Adapter.Csv {
 
         /// <inheritdoc/>
         public Task<ChannelReader<TagDefinition>> GetTags(IAdapterCallContext context, GetTagsRequest request, CancellationToken cancellationToken) {
-            CheckDisposed();
-            CheckStarted(true);
-            ValidationExtensions.ValidateObject(request);
+            ValidateInvocation(context, request);
             var result = ChannelExtensions.CreateTagDefinitionChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
@@ -551,10 +547,7 @@ namespace DataCore.Adapter.Csv {
 
         /// <inheritdoc/>
         public Task<ChannelReader<AdapterProperty>> GetTagProperties(IAdapterCallContext context, GetTagPropertiesRequest request, CancellationToken cancellationToken) {
-            CheckDisposed();
-            CheckStarted(true);
-            ValidationExtensions.ValidateObject(request);
-
+            ValidateInvocation(context, request);
             return Task.FromResult(Array.Empty<AdapterProperty>().PublishToChannel());
         }
 
@@ -582,9 +575,7 @@ namespace DataCore.Adapter.Csv {
 
         /// <inheritdoc/>
         public Task<ChannelReader<TagValueQueryResult>> ReadSnapshotTagValues(IAdapterCallContext context, ReadSnapshotTagValuesRequest request, CancellationToken cancellationToken) {
-            CheckDisposed();
-            CheckStarted();
-            ValidationExtensions.ValidateObject(request);
+            ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateTagValueChannel();
 
@@ -758,10 +749,7 @@ namespace DataCore.Adapter.Csv {
 
         /// <inheritdoc/>
         public Task<ChannelReader<TagValueQueryResult>> ReadRawTagValues(IAdapterCallContext context, ReadRawTagValuesRequest request, CancellationToken cancellationToken) {
-            CheckDisposed();
-            CheckStarted();
-            ValidationExtensions.ValidateObject(request);
-
+            ValidateInvocation(context, request);
             var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {

--- a/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelBrowseImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelBrowseImpl.cs
@@ -23,10 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.AssetModel.AssetModelNode>> BrowseAssetModelNodes(IAdapterCallContext context, Adapter.AssetModel.BrowseAssetModelNodesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
             
             var client = CreateClient<AssetModelBrowserService.AssetModelBrowserServiceClient>();
             var grpcRequest = new BrowseAssetModelNodesRequest() {
@@ -64,10 +61,7 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.AssetModel.AssetModelNode>> GetAssetModelNodes(IAdapterCallContext context, Adapter.AssetModel.GetAssetModelNodesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<AssetModelBrowserService.AssetModelBrowserServiceClient>();
             var grpcRequest = new GetAssetModelNodesRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelSearchImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelSearchImpl.cs
@@ -23,10 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.AssetModel.AssetModelNode>> FindAssetModelNodes(IAdapterCallContext context, Adapter.AssetModel.FindAssetModelNodesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<AssetModelBrowserService.AssetModelBrowserServiceClient>();
             var grpcRequest = new FindAssetModelNodesRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/Diagnostics/ConfigurationChangesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Diagnostics/ConfigurationChangesImpl.cs
@@ -26,11 +26,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData {
             ConfigurationChangesSubscriptionRequest request, 
             CancellationToken cancellationToken
         ) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateChannel<Adapter.Diagnostics.ConfigurationChange>(0);
 

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushImpl.cs
@@ -26,10 +26,7 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
             CreateEventMessageSubscriptionRequest request,
             CancellationToken cancellationToken
         ) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateEventMessageChannel<Adapter.Events.EventMessage>(0);
 

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.cs
@@ -30,15 +30,7 @@ namespace DataCore.Adapter.Grpc.Proxy.Events {
             ChannelReader<EventMessageSubscriptionUpdate> channel,
             CancellationToken cancellationToken
         ) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
-
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, request, channel);
 
             var client = CreateClient<EventsService.EventsServiceClient>();
             var grpcStream = client.CreateEventTopicPushChannel(GetCallOptions(context, cancellationToken));

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
@@ -23,11 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.Events.EventMessage>> ReadEventMessagesForTimeRange(IAdapterCallContext context, Adapter.Events.ReadEventMessagesForTimeRangeRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<EventsService.EventsServiceClient>();
             var grpcRequest = new GetEventMessagesForTimeRangeRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
@@ -23,11 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.Events.EventMessageWithCursorPosition>> ReadEventMessagesUsingCursor(IAdapterCallContext context, Adapter.Events.ReadEventMessagesUsingCursorRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<EventsService.EventsServiceClient>();
             var grpcRequest = new GetEventMessagesUsingCursorPositionRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.cs
@@ -23,12 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
 
         /// <inheritdoc/>
         public async Task<ChannelReader<Adapter.Events.WriteEventMessageResult>> WriteEventMessages(IAdapterCallContext context, ChannelReader<Adapter.Events.WriteEventMessageItem> channel, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, channel);
 
             var client = CreateClient<EventsService.EventsServiceClient>();
             var grpcStream = client.WriteEventMessages(GetCallOptions(context, cancellationToken));

--- a/src/DataCore.Adapter.Grpc.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
@@ -33,6 +33,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
+            Proxy.ValidateInvocation(context);
+
             var client = Proxy.CreateClient<ExtensionFeaturesService.ExtensionFeaturesServiceClient>();
             var response = client.GetDescriptorAsync(new GetExtensionDescriptorRequest() {
                 AdapterId = Proxy.RemoteDescriptor.Id,
@@ -51,6 +53,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
+            Proxy.ValidateInvocation(context);
+
             var client = Proxy.CreateClient<ExtensionFeaturesService.ExtensionFeaturesServiceClient>();
             var response = client.GetOperationsAsync(new GetExtensionOperationsRequest() {
                 AdapterId = Proxy.RemoteDescriptor.Id,
@@ -65,6 +69,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions {
 
         /// <inheritdoc/>
         protected override async Task<string> InvokeInternal(IAdapterCallContext context, Uri operationId, string argument, CancellationToken cancellationToken) {
+            Proxy.ValidateInvocation(context);
+
             var client = Proxy.CreateClient<ExtensionFeaturesService.ExtensionFeaturesServiceClient>();
             var response = client.InvokeExtensionAsync(new InvokeExtensionRequest() {
                 AdapterId = Proxy.RemoteDescriptor.Id,
@@ -79,6 +85,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions {
 
         /// <inheritdoc/>
         protected override Task<ChannelReader<string>> StreamInternal(IAdapterCallContext context, Uri operationId, string argument, CancellationToken cancellationToken) {
+            Proxy.ValidateInvocation(context);
+
             var result = Channel.CreateUnbounded<string>();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
@@ -100,6 +108,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions {
 
         /// <inheritdoc/>
         protected override Task<ChannelReader<string>> DuplexStreamInternal(IAdapterCallContext context, Uri operationId, ChannelReader<string> channel, CancellationToken cancellationToken) {
+            Proxy.ValidateInvocation(context, channel);
+
             var result = Channel.CreateUnbounded<string>();
 
             var client = Proxy.CreateClient<ExtensionFeaturesService.ExtensionFeaturesServiceClient>();

--- a/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.cs
@@ -323,35 +323,10 @@ namespace DataCore.Adapter.Grpc.Proxy {
                 try {
                     await _channel.ShutdownAsync().ConfigureAwait(false);
                 }
-#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception e) {
-#pragma warning restore CA1031 // Do not catch general exception types
                     Logger.LogError(e, Resources.Log_ChannelShutdownError);
                 }
             }
-        }
-
-
-        /// <summary>
-        /// Validates an object. This should be called on all adapter request objects prior to 
-        /// invoking a remote endpoint.
-        /// </summary>
-        /// <param name="o">
-        ///   The object.
-        /// </param>
-        /// <param name="canBeNull">
-        ///   When <see langword="true"/>, validation will succeed if <paramref name="o"/> is 
-        ///   <see langword="null"/>.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="o"/> is <see langword="null"/> and <paramref name="canBeNull"/> is 
-        ///   <see langword="false"/>.
-        /// </exception>
-        /// <exception cref="ValidationException">
-        ///   <paramref name="o"/> fails validation.
-        /// </exception>
-        public static void ValidateObject(object o, bool canBeNull = false) {
-            ValidationExtensions.ValidateObject(o, canBeNull);
         }
 
 
@@ -373,9 +348,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
             if (!string.IsNullOrWhiteSpace(context?.CorrelationId)) {
                 // We have a correlation ID for the context; use it on the outgoing call as 
                 // well.
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
                 headers.Add("Request-Id", context.CorrelationId);
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
             }
 
             return new GrpcCore.CallOptions(

--- a/src/DataCore.Adapter.Grpc.Proxy/ProxyAdapterFeature.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/ProxyAdapterFeature.cs
@@ -27,34 +27,33 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         /// The proxy that the feature instance belongs to.
         /// </summary>
-        private readonly GrpcAdapterProxy _proxy;
+        protected GrpcAdapterProxy Proxy { get; }
 
         /// <summary>
         /// Gets the logger for the proxy.
         /// </summary>
         protected ILogger Logger {
-            get { return _proxy.Logger; }
+            get { return Proxy.Logger; }
         }
 
         /// <summary>
         /// The adapter ID for the remote adapter.
         /// </summary>
         protected string AdapterId {
-            get { return _proxy.RemoteDescriptor?.Id!; }
+            get { return Proxy.RemoteDescriptor?.Id!; }
         }
 
         /// <summary>
         /// Gets the <see cref="IBackgroundTaskService"/> for the proxy.
         /// </summary>
         public IBackgroundTaskService BackgroundTaskService {
-            get { return _proxy.BackgroundTaskService; }
+            get { return Proxy.BackgroundTaskService; }
         }
 
 
         /// <summary>
         /// Static constructor.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline", Justification = "Initialisation is non-trivial")]
         static ProxyAdapterFeature() {
             _featureImplementations = new ConcurrentDictionary<Type, Type>();
 
@@ -118,7 +117,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         ///   The proxy that owns the feature instance.
         /// </param>
         protected ProxyAdapterFeature(GrpcAdapterProxy proxy) {
-            _proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
+            Proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
         }
 
 
@@ -132,7 +131,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         ///   A new gRPC client instance.
         /// </returns>
         protected internal TClient CreateClient<TClient>() where TClient : GrpcCore.ClientBase<TClient> {
-            return _proxy.CreateClient<TClient>();
+            return Proxy.CreateClient<TClient>();
         }
 
 
@@ -150,7 +149,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         ///   A new <see cref="GrpcCore.CallOptions"/> object.
         /// </returns>
         protected internal GrpcCore.CallOptions GetCallOptions(IAdapterCallContext context, CancellationToken cancellationToken) {
-            return _proxy.GetCallOptions(context, cancellationToken);
+            return Proxy.GetCallOptions(context, cancellationToken);
         }
 
     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -23,11 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.RealTimeData.TagValueQueryResult>> ReadPlotTagValues(IAdapterCallContext context, Adapter.RealTimeData.ReadPlotTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadPlotTagValuesRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -23,9 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.RealTimeData.DataFunctionDescriptor>> GetSupportedDataFunctions(IAdapterCallContext context, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
+            Proxy.ValidateInvocation(context);
 
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new GetSupportedDataFunctionsRequest() {
@@ -56,11 +54,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.RealTimeData.ProcessedTagValueQueryResult>> ReadProcessedTagValues(IAdapterCallContext context, Adapter.RealTimeData.ReadProcessedTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadProcessedTagValuesRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -23,11 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.RealTimeData.TagValueQueryResult>> ReadRawTagValues(IAdapterCallContext context, Adapter.RealTimeData.ReadRawTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadRawTagValuesRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -23,11 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.RealTimeData.TagValueQueryResult>> ReadSnapshotTagValues(IAdapterCallContext context, Adapter.RealTimeData.ReadSnapshotTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadSnapshotTagValuesRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
@@ -22,11 +22,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.RealTimeData.TagValueAnnotationQueryResult>> ReadAnnotations(IAdapterCallContext context, Adapter.RealTimeData.ReadAnnotationsRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new ReadAnnotationsRequest() {
@@ -66,7 +62,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public async Task<TagValueAnnotationExtended> ReadAnnotation(IAdapterCallContext context, Adapter.RealTimeData.ReadAnnotationRequest request, CancellationToken cancellationToken) {
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new ReadAnnotationRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -24,11 +24,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public Task<ChannelReader<Adapter.RealTimeData.TagValueQueryResult>> ReadTagValuesAtTimes(IAdapterCallContext context, Adapter.RealTimeData.ReadTagValuesAtTimesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadTagValuesAtTimesRequest() {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
@@ -36,15 +36,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             ChannelReader<TagValueSubscriptionUpdate> channel,
             CancellationToken cancellationToken
         ) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
-
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, request, channel);
 
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcStream = client.CreateSnapshotPushChannel(GetCallOptions(context, cancellationToken));

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/TagSearchImpl.cs
@@ -23,11 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public Task<ChannelReader<Adapter.Tags.TagDefinition>> FindTags(IAdapterCallContext context, Adapter.Tags.FindTagsRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagSearchService.TagSearchServiceClient>();
             var grpcRequest = new FindTagsRequest() {
@@ -75,8 +71,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public Task<ChannelReader<Adapter.Tags.TagDefinition>> GetTags(IAdapterCallContext context, Adapter.Tags.GetTagsRequest request, CancellationToken cancellationToken) {
-            GrpcAdapterProxy.ValidateObject(request); 
-            
+            Proxy.ValidateInvocation(context, request);
+
             var client = CreateClient<TagSearchService.TagSearchServiceClient>();
             var grpcRequest = new GetTagsRequest() {
                 AdapterId = AdapterId
@@ -107,8 +103,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public Task<ChannelReader<Common.AdapterProperty>> GetTagProperties(IAdapterCallContext context, Adapter.Tags.GetTagPropertiesRequest request, CancellationToken cancellationToken) {
-            GrpcAdapterProxy.ValidateObject(request); 
-            
+            Proxy.ValidateInvocation(context, request);
+
             var client = CreateClient<TagSearchService.TagSearchServiceClient>();
             var grpcRequest = new GetTagPropertiesRequest() {
                 AdapterId = AdapterId,

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
@@ -23,13 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<Adapter.RealTimeData.WriteTagValueResult>> WriteHistoricalTagValues(IAdapterCallContext context, ChannelReader<Adapter.RealTimeData.WriteTagValueItem> channel, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, channel);
 
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcStream = client.WriteHistoricalTagValues(GetCallOptions(context, cancellationToken));

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
@@ -23,12 +23,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<ChannelReader<Adapter.RealTimeData.WriteTagValueResult>> WriteSnapshotTagValues(IAdapterCallContext context, ChannelReader<Adapter.RealTimeData.WriteTagValueItem> channel, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, channel);
 
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcStream = client.WriteSnapshotTagValues(GetCallOptions(context, cancellationToken));

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
@@ -21,10 +21,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<Adapter.RealTimeData.WriteTagValueAnnotationResult> CreateAnnotation(IAdapterCallContext context, Adapter.RealTimeData.CreateAnnotationRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new CreateAnnotationRequest() {
@@ -48,7 +45,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<Adapter.RealTimeData.WriteTagValueAnnotationResult> UpdateAnnotation(IAdapterCallContext context, Adapter.RealTimeData.UpdateAnnotationRequest request, CancellationToken cancellationToken) {
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new UpdateAnnotationRequest() {
@@ -73,7 +70,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<Adapter.RealTimeData.WriteTagValueAnnotationResult> DeleteAnnotation(IAdapterCallContext context, Adapter.RealTimeData.DeleteAnnotationRequest request, CancellationToken cancellationToken) {
-            GrpcAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new DeleteAnnotationRequest() {

--- a/src/DataCore.Adapter.Http.Proxy/AssetModel/AssetModelBrowseImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/AssetModel/AssetModelBrowseImpl.cs
@@ -21,11 +21,8 @@ namespace DataCore.Adapter.Http.Proxy.AssetModel {
 
         /// <inheritdoc />
         public Task<ChannelReader<AssetModelNode>> BrowseAssetModelNodes(IAdapterCallContext context, BrowseAssetModelNodesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
-            
+            Proxy.ValidateInvocation(context, request);
+
             var result = ChannelExtensions.CreateAssetModelNodeChannel(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
@@ -43,10 +40,7 @@ namespace DataCore.Adapter.Http.Proxy.AssetModel {
 
         /// <inheritdoc />
         public Task<ChannelReader<AssetModelNode>> GetAssetModelNodes(IAdapterCallContext context, GetAssetModelNodesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateAssetModelNodeChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/AssetModel/AssetModelSearchImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/AssetModel/AssetModelSearchImpl.cs
@@ -22,11 +22,7 @@ namespace DataCore.Adapter.Http.Proxy.AssetModel {
 
         /// <inheritdoc />
         public Task<ChannelReader<AssetModelNode>> FindAssetModelNodes(IAdapterCallContext context, FindAssetModelNodesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateAssetModelNodeChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
@@ -21,11 +21,7 @@ namespace DataCore.Adapter.Http.Proxy.Events {
 
         /// <inheritdoc />
         public Task<ChannelReader<EventMessage>> ReadEventMessagesForTimeRange(IAdapterCallContext context, ReadEventMessagesForTimeRangeRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateEventMessageChannel<EventMessage>(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
@@ -21,11 +21,7 @@ namespace DataCore.Adapter.Http.Proxy.Events {
 
         /// <inheritdoc />
         public Task<ChannelReader<EventMessageWithCursorPosition>> ReadEventMessagesUsingCursor(IAdapterCallContext context, ReadEventMessagesUsingCursorRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateEventMessageChannel<EventMessageWithCursorPosition>(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/Events/WriteEventMessagesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/WriteEventMessagesImpl.cs
@@ -24,12 +24,7 @@ namespace DataCore.Adapter.Http.Proxy.Events {
 
         /// <inheritdoc />
         public Task<ChannelReader<WriteEventMessageResult>> WriteEventMessages(IAdapterCallContext context, ChannelReader<WriteEventMessageItem> channel, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, channel);
 
             var result = ChannelExtensions.CreateEventMessageWriteResultChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
@@ -32,6 +32,8 @@ namespace DataCore.Adapter.Http.Proxy.Extensions {
             Uri? featureUri, 
             CancellationToken cancellationToken
         ) {
+            Proxy.ValidateInvocation(context);
+
             var client = Proxy.GetClient();
             return client.Extensions.GetDescriptorAsync(
                 Proxy.RemoteDescriptor.Id,
@@ -48,6 +50,8 @@ namespace DataCore.Adapter.Http.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
+            Proxy.ValidateInvocation(context);
+
             var client = Proxy.GetClient();
             return client.Extensions.GetOperationsAsync(
                 Proxy.RemoteDescriptor.Id, 
@@ -60,6 +64,8 @@ namespace DataCore.Adapter.Http.Proxy.Extensions {
 
         /// <inheritdoc/>
         protected override Task<string> InvokeInternal(IAdapterCallContext context, Uri operationId, string argument, CancellationToken cancellationToken) {
+            Proxy.ValidateInvocation(context);
+
             var client = Proxy.GetClient();
             return client.Extensions.InvokeExtensionAsync(
                 Proxy.RemoteDescriptor.Id, 

--- a/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
+++ b/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
@@ -236,29 +236,6 @@ namespace DataCore.Adapter.Http.Proxy {
 
 
         /// <summary>
-        /// Validates an object. This should be called on all adapter request objects prior to 
-        /// invoking a remote endpoint.
-        /// </summary>
-        /// <param name="o">
-        ///   The object.
-        /// </param>
-        /// <param name="canBeNull">
-        ///   When <see langword="true"/>, validation will succeed if <paramref name="o"/> is 
-        ///   <see langword="null"/>.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="o"/> is <see langword="null"/> and <paramref name="canBeNull"/> is 
-        ///   <see langword="false"/>.
-        /// </exception>
-        /// <exception cref="ValidationException">
-        ///   <paramref name="o"/> fails validation.
-        /// </exception>
-        public static void ValidateObject(object o, bool canBeNull = false) {
-            AdapterHttpClient.ValidateObject(o, canBeNull);
-        }
-
-
-        /// <summary>
         /// Checks the health of the remote adapter.
         /// </summary>
         /// <param name="context">

--- a/src/DataCore.Adapter.Http.Proxy/ProxyAdapterFeature.cs
+++ b/src/DataCore.Adapter.Http.Proxy/ProxyAdapterFeature.cs
@@ -26,27 +26,27 @@ namespace DataCore.Adapter.Http.Proxy {
         /// <summary>
         /// The proxy that the feature instance belongs to.
         /// </summary>
-        private readonly HttpAdapterProxy _proxy;
+        protected HttpAdapterProxy Proxy { get; }
 
         /// <summary>
         /// Gets the proxy's logger.
         /// </summary>
         protected ILogger Logger {
-            get { return _proxy.Logger; }
+            get { return Proxy.Logger; }
         }
 
         /// <summary>
         /// The adapter ID for the remote adapter.
         /// </summary>
         protected string AdapterId {
-            get { return _proxy.RemoteDescriptor?.Id!; }
+            get { return Proxy.RemoteDescriptor?.Id!; }
         }
 
         /// <summary>
         /// Gets the <see cref="IBackgroundTaskService"/> for the proxy.
         /// </summary>
         public IBackgroundTaskService BackgroundTaskService {
-            get { return _proxy.BackgroundTaskService; }
+            get { return Proxy.BackgroundTaskService; }
         }
 
 
@@ -118,7 +118,7 @@ namespace DataCore.Adapter.Http.Proxy {
         ///   The proxy that owns the feature instance.
         /// </param>
         protected ProxyAdapterFeature(HttpAdapterProxy proxy) {
-            _proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
+            Proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
         }
 
 
@@ -129,7 +129,7 @@ namespace DataCore.Adapter.Http.Proxy {
         ///   A <see cref="AdapterHttpClient"/> object.
         /// </returns>
         protected internal AdapterHttpClient GetClient() {
-            return _proxy.GetClient();
+            return Proxy.GetClient();
         }
 
     }

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -22,10 +22,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<TagValueQueryResult>> ReadPlotTagValues(IAdapterCallContext context, ReadPlotTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateTagValueChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -22,9 +22,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<DataFunctionDescriptor>> GetSupportedDataFunctions(IAdapterCallContext context, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
+            Proxy.ValidateInvocation(context);
             var result = ChannelExtensions.CreateChannel<DataFunctionDescriptor>(-1);
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
@@ -42,10 +40,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<ProcessedTagValueQueryResult>> ReadProcessedTagValues(IAdapterCallContext context, ReadProcessedTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateProcessedTagValueChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -22,10 +22,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<TagValueQueryResult>> ReadRawTagValues(IAdapterCallContext context, ReadRawTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateTagValueChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -22,10 +22,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<TagValueQueryResult>> ReadSnapshotTagValues(IAdapterCallContext context, ReadSnapshotTagValuesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateTagValueChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
@@ -18,10 +18,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<TagValueAnnotationQueryResult>> ReadAnnotations(IAdapterCallContext context, ReadAnnotationsRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateTagValueAnnotationChannel(-1);
 
@@ -40,7 +37,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc/>
         public async Task<TagValueAnnotationExtended> ReadAnnotation(IAdapterCallContext context, ReadAnnotationRequest request, CancellationToken cancellationToken) {
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             return await client.TagValueAnnotations.ReadAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false);

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -22,10 +22,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<TagValueQueryResult>> ReadTagValuesAtTimes(IAdapterCallContext context, ReadTagValuesAtTimesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateTagValueChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/TagSearchImpl.cs
@@ -23,10 +23,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<TagDefinition>> FindTags(IAdapterCallContext context, FindTagsRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateTagDefinitionChannel(-1);
 
@@ -46,10 +43,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<TagDefinition>> GetTags(IAdapterCallContext context, GetTagsRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateTagDefinitionChannel(-1);
 
@@ -69,10 +63,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<AdapterProperty>> GetTagProperties(IAdapterCallContext context, GetTagPropertiesRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var result = ChannelExtensions.CreateChannel<AdapterProperty>(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
@@ -23,12 +23,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<WriteTagValueResult>> WriteHistoricalTagValues(IAdapterCallContext context, ChannelReader<WriteTagValueItem> channel, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, channel);
 
             var result = ChannelExtensions.CreateTagValueWriteResultChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
@@ -23,12 +23,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public Task<ChannelReader<WriteTagValueResult>> WriteSnapshotTagValues(IAdapterCallContext context, ChannelReader<WriteTagValueItem> channel, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (channel == null) {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            Proxy.ValidateInvocation(context, channel);
 
             var result = ChannelExtensions.CreateTagValueWriteResultChannel(-1);
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
@@ -19,10 +19,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> CreateAnnotation(IAdapterCallContext context, CreateAnnotationRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             return await client.TagValueAnnotations.CreateAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false);
@@ -30,10 +27,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> UpdateAnnotation(IAdapterCallContext context, UpdateAnnotationRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             return await client.TagValueAnnotations.UpdateAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false);
@@ -41,10 +35,7 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> DeleteAnnotation(IAdapterCallContext context, DeleteAnnotationRequest request, CancellationToken cancellationToken) {
-            if (context == null) {
-                throw new ArgumentNullException(nameof(context));
-            }
-            HttpAdapterProxy.ValidateObject(request);
+            Proxy.ValidateInvocation(context, request);
 
             var client = GetClient();
             return await client.TagValueAnnotations.DeleteAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false);

--- a/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
+++ b/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
@@ -509,18 +509,14 @@ namespace DataCore.Adapter.WaveGenerator {
 
         /// <inheritdoc/>
         public Task<ChannelReader<AdapterProperty>> GetTagProperties(IAdapterCallContext context, GetTagPropertiesRequest request, CancellationToken cancellationToken) {
-            ValidateContext(context);
-            ValidateRequest(request);
-
+            ValidateInvocation(context, request);
             return Task.FromResult(s_tagPropertyDefinitions.PublishToChannel());
         }
 
 
         /// <inheritdoc/>
         public Task<ChannelReader<TagDefinition>> GetTags(IAdapterCallContext context, GetTagsRequest request, CancellationToken cancellationToken) {
-            ValidateContext(context);
-            ValidateRequest(request);
-
+            ValidateInvocation(context, request);
             var result = ChannelExtensions.CreateTagDefinitionChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => { 
@@ -538,9 +534,7 @@ namespace DataCore.Adapter.WaveGenerator {
 
         /// <inheritdoc/>
         public Task<ChannelReader<TagDefinition>> FindTags(IAdapterCallContext context, FindTagsRequest request, CancellationToken cancellationToken) {
-            ValidateContext(context);
-            ValidateRequest(request);
-
+            ValidateInvocation(context, request);
             var result = ChannelExtensions.CreateTagDefinitionChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
@@ -572,9 +566,7 @@ namespace DataCore.Adapter.WaveGenerator {
 
         /// <inheritdoc/>
         public Task<ChannelReader<TagValueQueryResult>> ReadSnapshotTagValues(IAdapterCallContext context, ReadSnapshotTagValuesRequest request, CancellationToken cancellationToken) {
-            ValidateContext(context);
-            ValidateRequest(request);
-
+            ValidateInvocation(context, request);
             var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
@@ -602,9 +594,7 @@ namespace DataCore.Adapter.WaveGenerator {
 
         /// <inheritdoc/>
         public Task<ChannelReader<TagValueQueryResult>> ReadRawTagValues(IAdapterCallContext context, ReadRawTagValuesRequest request, CancellationToken cancellationToken) {
-            ValidateContext(context);
-            ValidateRequest(request);
-
+            ValidateInvocation(context, request);
             var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {
@@ -655,9 +645,7 @@ namespace DataCore.Adapter.WaveGenerator {
 
         /// <inheritdoc/>
         public Task<ChannelReader<TagValueQueryResult>> ReadTagValuesAtTimes(IAdapterCallContext context, ReadTagValuesAtTimesRequest request, CancellationToken cancellationToken) {
-            ValidateContext(context);
-            ValidateRequest(request);
-
+            ValidateInvocation(context, request);
             var result = ChannelExtensions.CreateTagValueChannel();
 
             result.Writer.RunBackgroundOperation(async (ch, ct) => {

--- a/src/DataCore.Adapter/AdapterBaseT.cs
+++ b/src/DataCore.Adapter/AdapterBaseT.cs
@@ -522,7 +522,7 @@ namespace DataCore.Adapter {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
-        public virtual void ValidateContext(IAdapterCallContext context) {
+        protected virtual void ValidateContext(IAdapterCallContext context) {
             if (context == null) {
                 throw new ArgumentNullException(nameof(context));
             }
@@ -536,7 +536,7 @@ namespace DataCore.Adapter {
         ///   The request type.
         /// </typeparam>
         /// <param name="request">
-        ///   The request object.
+        ///   The request object for the invocation.
         /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="request"/> is <see langword="null"/>.
@@ -544,11 +544,67 @@ namespace DataCore.Adapter {
         /// <exception cref="ValidationException">
         ///   <paramref name="request"/> fails validation.
         /// </exception>
-        public virtual void ValidateRequest<TRequest>(TRequest request) {
+        protected virtual void ValidateRequest(object request) {
             if (request == null) {
                 throw new ArgumentNullException(nameof(request));
             }
             Validator.ValidateObject(request, new ValidationContext(request), true);
+        }
+
+
+        /// <summary>
+        /// Validates the invocation of an adapter feature method that does not use a request 
+        /// object.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="context"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The adapter has been disposed.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The adapter is not running.
+        /// </exception>
+        /// <seealso cref="ValidateInvocation(IAdapterCallContext, object)"/>
+        public void ValidateInvocation(IAdapterCallContext context) {
+            CheckDisposed();
+            CheckStarted();
+            ValidateContext(context);
+        }
+
+
+        /// <summary>
+        /// Validates the invocation of an adapter feature method.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/> for the invocation.
+        /// </param>
+        /// <param name="invocationParameters">
+        ///   The invocation parameters to validate (such as request DTOs).
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="context"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   Any item in <paramref name="invocationParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ValidationException">
+        ///   Any item in <paramref name="invocationParameters"/> fails validation.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The adapter has been disposed.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The adapter is not running.
+        /// </exception>
+        public void ValidateInvocation(IAdapterCallContext context, params object[] invocationParameters) {
+            ValidateInvocation(context);
+            foreach (var item in invocationParameters) {
+                ValidateRequest(item);
+            }
         }
 
 


### PR DESCRIPTION
- Adds `ValidateInvocation` method to `AdapterBase<T>` that can be used to validate the `IAdapterCallContext` and any parameters passed to a feature invocation, and also ensure that the adapter has not been disposed and is currently running.
- Updates the built-in adapter types (including proxies) to ensure that all feature invocations are validated correctly.