### PR TITLE
Builder constructor changes and adapter IsRunning change

### DIFF
--- a/src/DataCore.Adapter.Abstractions/IAdapter.cs
+++ b/src/DataCore.Adapter.Abstractions/IAdapter.cs
@@ -61,6 +61,14 @@ namespace DataCore.Adapter {
         /// <returns>
         ///   A <see cref="Task"/> that represents the stop operation.
         /// </returns>
+        /// <remarks>
+        ///   The <see cref="StopAsync"/> method is intended to allow the same adapter to be 
+        ///   started and stopped multiple times. Therefore, only resources that are created 
+        ///   when <see cref="StartAsync"/> is called should be disposed when <see cref="StopAsync"/> 
+        ///   is called. The <see cref="IDisposable.Dispose"/> and <see cref="IAsyncDisposable.DisposeAsync"/> 
+        ///   methods should be used to dispose of all resources, including those created by 
+        ///   calls to <see cref="StartAsync"/>.
+        /// </remarks>
         Task StopAsync(CancellationToken cancellationToken);
 
     }

--- a/src/DataCore.Adapter.Abstractions/RealTimeData/IReadTagValueAnnotations.cs
+++ b/src/DataCore.Adapter.Abstractions/RealTimeData/IReadTagValueAnnotations.cs
@@ -51,7 +51,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <returns>
         ///   The requested annotation.
         /// </returns>
-        Task<TagValueAnnotationExtended> ReadAnnotation(
+        Task<TagValueAnnotationExtended?> ReadAnnotation(
             IAdapterCallContext context, 
             ReadAnnotationRequest request, 
             CancellationToken cancellationToken

--- a/src/DataCore.Adapter/RealTimeData/TagValueAnnotationBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueAnnotationBuilder.cs
@@ -50,7 +50,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <summary>
         /// Creates a new <see cref="TagValueAnnotationBuilder"/> object.
         /// </summary>
-        private TagValueAnnotationBuilder() { }
+        public TagValueAnnotationBuilder() { }
 
 
         /// <summary>
@@ -60,7 +60,14 @@ namespace DataCore.Adapter.RealTimeData {
         /// <param name="existing">
         ///   The existing annotation.
         /// </param>
-        private TagValueAnnotationBuilder(TagValueAnnotationExtended existing) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="existing"/> is <see langword="null"/>.
+        /// </exception>
+        public TagValueAnnotationBuilder(TagValueAnnotationExtended existing) {
+            if (existing == null) {
+                throw new ArgumentNullException(nameof(existing));
+            }
+
             _id = existing.Id;
             _annotationType = existing.AnnotationType;
             _utcStartTime = existing.UtcStartTime;

--- a/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
@@ -67,15 +67,13 @@ namespace DataCore.Adapter.RealTimeData {
             if (existing == null) {
                 throw new ArgumentNullException(nameof(existing));
             }
-            _utcSampleTime = existing.UtcSampleTime;
-            _value = existing.Value;
-            _status = existing.Status;
-            _units = existing.Units;
-            _notes = existing.Notes;
-            _error = existing.Error;
-            if (existing.Properties != null) {
-                _properties.AddRange(existing.Properties.Where(x => x != null));
-            }
+
+            WithUtcSampleTime(existing.UtcSampleTime);
+            WithValue(existing.Value);
+            WithStatus(existing.Status);
+            WithNotes(existing.Notes);
+            WithError(existing.Error);
+            WithProperties(existing.Properties);
         }
 
 

--- a/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
@@ -50,7 +50,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <summary>
         /// Creates a new <see cref="TagValueBuilder"/> object.
         /// </summary>
-        private TagValueBuilder() { }
+        public TagValueBuilder() { }
 
 
         /// <summary>
@@ -60,7 +60,13 @@ namespace DataCore.Adapter.RealTimeData {
         /// <param name="existing">
         ///   The existing value.
         /// </param>
-        private TagValueBuilder(TagValueExtended existing) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="existing"/> is <see langword="null"/>.
+        /// </exception>
+        public TagValueBuilder(TagValueExtended existing) {
+            if (existing == null) {
+                throw new ArgumentNullException(nameof(existing));
+            }
             _utcSampleTime = existing.UtcSampleTime;
             _value = existing.Value;
             _status = existing.Status;

--- a/src/DataCore.Adapter/Tags/TagDefinitionBuilder.cs
+++ b/src/DataCore.Adapter/Tags/TagDefinitionBuilder.cs
@@ -58,9 +58,35 @@ namespace DataCore.Adapter.Tags {
 
 
         /// <summary>
-        /// Creates a new <see cref="TagDefinitionBuilder"/> object.
+        /// Creates a new <see cref="TagDefinitionBuilder"/> object. You must call <see cref="WithId"/> 
+        /// and <see cref="WithName"/> to set the tag ID and name respectively before calling <see cref="Build"/>.
         /// </summary>
-        private TagDefinitionBuilder() { }
+        public TagDefinitionBuilder() { }
+
+
+        /// <summary>
+        /// Creates a new <see cref="TagDefinitionBuilder"/> object that is configured to use the 
+        /// specified tag ID and tag name.
+        /// </summary>
+        /// <param name="id">
+        ///   The tag ID.
+        /// </param>
+        /// <param name="name">
+        ///   The tag name.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="TagDefinitionBuilder"/> object.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="id"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="name"/> is <see langword="null"/>.
+        /// </exception>
+        public TagDefinitionBuilder (string id, string name) {
+            WithId(id);
+            WithName(name);
+        }
 
 
         /// <summary>
@@ -70,7 +96,14 @@ namespace DataCore.Adapter.Tags {
         /// <param name="existing">
         ///   The existing tag definition.
         /// </param>
-        private TagDefinitionBuilder(TagDefinition existing) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="existing"/> is <see langword="null"/>.
+        /// </exception>
+        public TagDefinitionBuilder(TagDefinition existing) {
+            if (existing == null) {
+                throw new ArgumentNullException(nameof(existing));
+            }
+
             WithId(existing.Id);
             WithName(existing.Name);
             WithDescription(existing.Description);


### PR DESCRIPTION
- Constructors for "builder" classes (e.g. `TagValueBuilder`) have been made public, so that it is not necessary to call the static `ClassName.Create` methods to construct instances.
- The implementation of `IAdapter.IsRunning` in `AdapterBase<T>` has changed, so that it will report as `false` if the adapter is stopped or if it is disposed. Previously, it was possible to dispose an adapter but still have the `IsRunning` flag set to `true`, which could lead to problems in implementations that rely on knowing if the adapter is actually running that did not also check the `IsDisposed` flag.