### PR TITLE
Miscellaneous changes

### DIFF
--- a/src/DataCore.Adapter.Core/RealTimeData/DataFunctionDescriptorExtensions.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/DataFunctionDescriptorExtensions.cs
@@ -39,6 +39,33 @@ namespace DataCore.Adapter.RealTimeData {
 
 
         /// <summary>
+        /// Tests if the specified descriptor matches the <see cref="DataFunctionDescriptor.Id"/>, 
+        /// <see cref="DataFunctionDescriptor.Name"/> or any of the <see cref="DataFunctionDescriptor.Aliases"/> 
+        /// for this function descriptor.
+        /// </summary>
+        /// <param name="descriptor">
+        ///   The data function descriptor.
+        /// </param>
+        /// <param name="other">
+        ///   The other descriptor to match against..
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the other descriptor matches this descriptor, or 
+        ///   <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool IsMatch(this DataFunctionDescriptor descriptor, DataFunctionDescriptor other) {
+            if (descriptor == null) {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+            if (other == null) {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            return descriptor.GetIdentifiers().Any(x => other.GetIdentifiers().Contains(x, StringComparer.OrdinalIgnoreCase));
+        }
+
+
+        /// <summary>
         /// Gets all identifiers for the data function descriptor (ID, name, and aliases).
         /// </summary>
         /// <param name="descriptor">

--- a/src/DataCore.Adapter/AdapterBaseT.cs
+++ b/src/DataCore.Adapter/AdapterBaseT.cs
@@ -519,6 +519,7 @@ namespace DataCore.Adapter {
 
 
         /// <summary>
+        /// <strong>[INFRASTRUCTURE METHOD]</strong> 
         /// Validates the <see cref="IAdapterCallContext"/> passed to an adapter feature method.
         /// </summary>
         /// <param name="context">
@@ -527,6 +528,22 @@ namespace DataCore.Adapter {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   This method is not intended to be called directly from your adapter implementation; 
+        ///   you should call <see cref="ValidateInvocation(IAdapterCallContext, object[])"/> 
+        ///   instead when validating a call to your adapter.
+        /// </para>
+        /// 
+        /// <para>
+        ///   Override this method to customise the validation of <see cref="IAdapterCallContext"/> 
+        ///   objects passed into your adapter. The default behaviour in <see cref="AdapterBase{TAdapterOptions}"/>
+        ///   is to ensure that the <paramref name="context"/> is not <see langword="null"/>.
+        /// </para>
+        /// 
+        /// </remarks>
+        /// <seealso cref="ValidateInvocation(IAdapterCallContext, object[])"/>
         protected virtual void ValidateContext(IAdapterCallContext context) {
             if (context == null) {
                 throw new ArgumentNullException(nameof(context));
@@ -535,6 +552,7 @@ namespace DataCore.Adapter {
 
 
         /// <summary>
+        /// <strong>[INFRASTRUCTURE METHOD]</strong> 
         /// Validates a parameter passed to an adapter feature method.
         /// </summary>
         /// <param name="parameter">
@@ -546,6 +564,24 @@ namespace DataCore.Adapter {
         /// <exception cref="ValidationException">
         ///   <paramref name="parameter"/> fails validation.
         /// </exception>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   This method is not intended to be called directly from your adapter implementation; 
+        ///   you should call <see cref="ValidateInvocation(IAdapterCallContext, object[])"/> 
+        ///   instead when validating a call to your adapter.
+        /// </para>
+        /// 
+        /// <para>
+        ///   Override this method to customise the validation of parameters passed to an adapter 
+        ///   feature invocation. The default behaviour in <see cref="AdapterBase{TAdapterOptions}"/>
+        ///   is to ensure that the <paramref name="parameter"/> is not <see langword="null"/>, and 
+        ///   to validate the <paramref name="parameter"/> by calling 
+        ///   <see cref="Validator.ValidateObject(object, ValidationContext, bool)"/>.
+        /// </para>
+        /// 
+        /// </remarks>
+        /// <seealso cref="ValidateInvocation(IAdapterCallContext, object[])"/>
         protected virtual void ValidateInvocationParameter(object parameter) {
             if (parameter == null) {
                 throw new ArgumentNullException(nameof(parameter));
@@ -579,7 +615,25 @@ namespace DataCore.Adapter {
         ///   The adapter is not running.
         /// </exception>
         /// <remarks>
-        ///   Override this method to perform any additional invocation checks required by your adapter.
+        /// 
+        /// <para>
+        ///   Call this method at the start of every adapter feature implementation method to 
+        ///   validate the feature method's parameters.
+        /// </para>
+        /// 
+        /// <para>
+        ///   Override this method to perform any additional invocation checks required by your 
+        ///   adapter.  
+        /// </para>
+        /// 
+        /// <para>
+        ///   The default behaviour in <see cref="AdapterBase{TAdapterOptions}"/> is to ensure that 
+        ///   the adapter has not been disposed and that it is currently running, and to validate 
+        ///   the <paramref name="context"/> and <paramref name="invocationParameters"/> by calling 
+        ///   <see cref="ValidateContext(IAdapterCallContext)"/> and <see cref="ValidateInvocationParameter(object)"/> 
+        ///   respectively.
+        /// </para>
+        /// 
         /// </remarks>
         public virtual void ValidateInvocation(IAdapterCallContext context, params object[] invocationParameters) {
             CheckDisposed();

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -654,6 +654,8 @@ namespace DataCore.Adapter.Tests {
                 )
                 .WithSupportedFeature<IReadSnapshotTagValues>()
                 .WithSupportedFeature<IReadRawTagValues>()
+                .WithSupportedFeature<IReadProcessedTagValues>(DefaultDataFunctions.Average.Id)
+                .WithSupportedFeature<IReadProcessedTagValues>(DefaultDataFunctions.Interpolate.Id)
                 .WithProperties(
                     AdapterProperty.Create("Prop1", 100),
                     AdapterProperty.Create("Prop2", "Value")


### PR DESCRIPTION
- Adds `DataFunctionDescriptorExtensions.IsMatch` overload that allows matching one descriptor against another if any of their identifiers (ID, name, aliases) match.
- Improves documentation around the usage of `ValidateContext`, `ValidateInvocationParameter` and `ValidateInvocation` methods in `AdapterBase<T>`.
- When adding supported features to a `TagDefinitionBuilder`, a hash can now be specified to append to the feature URI when calling `WithSupportedFeature<TFeature>`. This is to allow for situations where e.g. an adapter supports `IReadProcessedTagValues`, but only certain data functions are allowed on the tag (for example, a digital tag might not allow an average value aggregation to be calculated). In these circumstances, the feature can be added multiple times to the `TagDefinitionBuilder`, but the data function ID can be specified as the hash on each occasion.