### PR TITLE
Simplify asset model node data references

### DIFF
--- a/examples/DataCore.Adapter.ExampleAdapter/Features/AssetModelBrowser.cs
+++ b/examples/DataCore.Adapter.ExampleAdapter/Features/AssetModelBrowser.cs
@@ -32,7 +32,7 @@ namespace DataCore.Adapter.Example.Features {
 
                 var dataReferences = nodeDefinitions.Where(x => !string.IsNullOrWhiteSpace(x.DataReference)).Select(x => x.DataReference).ToArray();
 
-                var dataReferencesChannel = await tagSearch.GetTags(null, new Tags.GetTagsRequest() { 
+                var dataReferencesChannel = await tagSearch.GetTags(new DefaultAdapterCallContext(), new Tags.GetTagsRequest() { 
                     Tags = dataReferences
                 }, cancellationToken).ConfigureAwait(false);
 
@@ -51,7 +51,7 @@ namespace DataCore.Adapter.Example.Features {
                             ? null
                             : new DataReference(
                                 adapterId, 
-                                tags.First(t => t.Id.Equals(x.DataReference, StringComparison.Ordinal) || t.Name.Equals(x.DataReference, StringComparison.Ordinal))
+                                tags.First(t => t.Id.Equals(x.DataReference, StringComparison.Ordinal) || t.Name.Equals(x.DataReference, StringComparison.Ordinal)).Name
                             )
                         )
                         .Build()

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
@@ -104,10 +104,7 @@ namespace DataCore.Adapter {
                 node.HasDataReference
                     ? new AssetModel.DataReference(
                         node.DataReference.AdapterId, 
-                        new Tags.TagIdentifier(
-                            node.DataReference.Tag.Id, 
-                            node.DataReference.Tag.Name
-                        )
+                        node.DataReference.TagNameOrId
                     )
                     : null,
                 node.Properties.Select(x => x.ToAdapterProperty()).ToArray()
@@ -140,10 +137,7 @@ namespace DataCore.Adapter {
                 HasDataReference = node.DataReference != null,
                 DataReference = new Grpc.AssetModelDataReference() {
                     AdapterId = node.DataReference?.AdapterId ?? string.Empty,
-                    Tag = new Grpc.TagIdentifier() {
-                        Id = node.DataReference?.Tag?.Id ?? string.Empty,
-                        Name = node.DataReference?.Tag?.Name ?? string.Empty
-                    }
+                    TagNameOrId = node.DataReference?.Tag ?? string.Empty
                 }
             };
 

--- a/src/DataCore.Adapter.Core/AssetModel/DataReference.cs
+++ b/src/DataCore.Adapter.Core/AssetModel/DataReference.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using DataCore.Adapter.Tags;
-
 namespace DataCore.Adapter.AssetModel {
 
     /// <summary>
@@ -16,9 +14,9 @@ namespace DataCore.Adapter.AssetModel {
         public string AdapterId { get; }
 
         /// <summary>
-        /// The tag identifier for the reference.
+        /// The tag name or ID for the reference.
         /// </summary>
-        public TagIdentifier Tag { get; }
+        public string Tag { get; }
 
 
         /// <summary>
@@ -28,9 +26,9 @@ namespace DataCore.Adapter.AssetModel {
         ///   The adapter ID for the data reference.
         /// </param>
         /// <param name="tag">
-        ///   The tag identifier for the data reference.
+        ///   The tag name or ID for the data reference.
         /// </param>
-        public DataReference(string adapterId, TagIdentifier tag) {
+        public DataReference(string adapterId, string tag) {
             AdapterId = adapterId ?? throw new ArgumentNullException(nameof(adapterId));
             Tag = tag ?? throw new ArgumentNullException(nameof(tag));
         }

--- a/src/DataCore.Adapter.Json/DataReferenceConverter.cs
+++ b/src/DataCore.Adapter.Json/DataReferenceConverter.cs
@@ -18,7 +18,7 @@ namespace DataCore.Adapter.Json {
             }
 
             string adapterId = null!;
-            TagIdentifier tag = null!;
+            string tag = null!;
 
             while (reader.Read() && reader.TokenType != JsonTokenType.EndObject) {
                 if (reader.TokenType != JsonTokenType.PropertyName) {
@@ -34,7 +34,7 @@ namespace DataCore.Adapter.Json {
                     adapterId = reader.GetString()!;
                 }
                 else if (string.Equals(propertyName, nameof(DataReference.Tag), StringComparison.OrdinalIgnoreCase)) {
-                    tag = JsonSerializer.Deserialize<TagIdentifier>(ref reader, options)!;
+                    tag = JsonSerializer.Deserialize<string>(ref reader, options)!;
                 }
                 else {
                     reader.Skip();

--- a/src/DataCore.Adapter/AssetModel/AssetModelNodeBuilder.cs
+++ b/src/DataCore.Adapter/AssetModel/AssetModelNodeBuilder.cs
@@ -263,7 +263,7 @@ namespace DataCore.Adapter.AssetModel {
         ///   <paramref name="tag"/> is <see langword="null"/>.
         /// </exception>
         public AssetModelNodeBuilder WithDataReference(string adapterId, TagSummary tag) {
-            _dataReference = new DataReference(adapterId, tag);
+            _dataReference = new DataReference(adapterId, tag?.Name!);
             return this;
         }
 
@@ -274,11 +274,8 @@ namespace DataCore.Adapter.AssetModel {
         /// <param name="adapterId">
         ///   The adapter ID for the data reference.
         /// </param>
-        /// <param name="tagId">
-        ///   The tag ID for the data reference.
-        /// </param>
-        /// <param name="tagName">
-        ///   The tag display name.
+        /// <param name="tag">
+        ///   The tag ID or name for the data reference.
         /// </param>
         /// <returns>
         ///   The updated <see cref="AssetModelNodeBuilder"/>.
@@ -287,17 +284,13 @@ namespace DataCore.Adapter.AssetModel {
         ///   <paramref name="adapterId"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="ArgumentNullException">
-        ///   <paramref name="tagId"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="tagName"/> is <see langword="null"/>.
+        ///   <paramref name="tag"/> is <see langword="null"/>.
         /// </exception>
         public AssetModelNodeBuilder WithDataReference(
             string adapterId, 
-            string tagId, 
-            string tagName
+            string tag
         ) {
-            _dataReference = new DataReference(adapterId, new TagIdentifier(tagId, tagName));
+            _dataReference = new DataReference(adapterId, tag);
             return this;
         }
 

--- a/src/Protos/datacore/adapter/Types.proto
+++ b/src/Protos/datacore/adapter/Types.proto
@@ -162,7 +162,7 @@ enum AssetModelNodeType {
 
 message AssetModelDataReference {
     string adapter_id = 1;
-    TagIdentifier tag = 2;
+    string tag_name_or_id = 3;
 }
 
 

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -299,7 +299,7 @@ namespace DataCore.Adapter.Tests {
                 "Description",
                 "Parent",
                 true,
-                new DataReference("AdapterId1", new TagSummary("Id1", "Name1", "Description1", "Units1", VariantType.Double)),
+                new DataReference("AdapterId1", "Id1"),
                 new [] {
                     AdapterProperty.Create("Prop1", 100),
                     AdapterProperty.Create("Prop2", "Value")
@@ -319,8 +319,7 @@ namespace DataCore.Adapter.Tests {
             Assert.IsNotNull(actual.DataReference);
             Assert.AreEqual(expected.DataReference.AdapterId, actual.DataReference.AdapterId);
             Assert.IsNotNull(actual.DataReference.Tag);
-            Assert.AreEqual(expected.DataReference.Tag.Id, actual.DataReference.Tag.Id);
-            Assert.AreEqual(expected.DataReference.Tag.Name, actual.DataReference.Tag.Name);
+            Assert.AreEqual(expected.DataReference.Tag, actual.DataReference.Tag);
 
             Assert.AreEqual(expected.Properties.Count(), actual.Properties.Count());
             for (var i = 0; i < expected.Properties.Count(); i++) {


### PR DESCRIPTION
The `DataReference` type used by `AssetModelNode` no longer requires a `TagIdentifier` defining both tag ID and tag name. Instead, a string specifying either the tag name or the tag ID is supplied.