### PR TITLE
Allow tag values to have multiple values

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
@@ -1751,9 +1751,10 @@ namespace DataCore.Adapter {
                 throw new ArgumentNullException(nameof(tagValue));
             }
 
-            return RealTimeData.TagValueExtended.Create(
+            return new RealTimeData.TagValueExtended(
                 tagValue.UtcSampleTime.ToDateTime(),
                 tagValue.Value.ToAdapterVariant(),
+                tagValue.AdditionalValues.Select(x => x.ToAdapterVariant()),
                 tagValue.Status.ToAdapterTagValueStatus(),
                 tagValue.Units,
                 tagValue.Notes,
@@ -1785,6 +1786,12 @@ namespace DataCore.Adapter {
                 UtcSampleTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(tagValue.UtcSampleTime),
                 Value = tagValue.Value.ToGrpcVariant()
             };
+
+            if (tagValue.AdditionalValues != null) {
+                foreach (var item in tagValue.AdditionalValues) {
+                    result.AdditionalValues.Add(item.ToGrpcVariant());
+                }
+            }
 
             if (tagValue.Properties != null) {
                 foreach (var item in tagValue.Properties) {
@@ -2149,9 +2156,10 @@ namespace DataCore.Adapter {
             return new RealTimeData.WriteTagValueItem() {
                 CorrelationId = writeRequest.CorrelationId,
                 TagId = writeRequest.TagId,
-                Value = RealTimeData.TagValue.Create(
+                Value = new RealTimeData.TagValue (
                     writeRequest.UtcSampleTime.ToDateTime(),
                     writeRequest.Value.ToAdapterVariant(),
+                    null,
                     writeRequest.Status.ToAdapterTagValueStatus(),
                     writeRequest.Units
                 )

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValue.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValue.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
 using DataCore.Adapter.Common;
 
 namespace DataCore.Adapter.RealTimeData {
@@ -14,9 +17,18 @@ namespace DataCore.Adapter.RealTimeData {
         public DateTime UtcSampleTime { get; }
 
         /// <summary>
-        /// The tag value.
+        /// The primary tag value.
         /// </summary>
+        /// <seealso cref="AdditionalValues"/>
         public Variant Value { get; }
+
+        /// <summary>
+        /// Additional tag values. For example, if the value represents a digital state, it is 
+        /// possible to supply both the numeric and text values of the state in a single 
+        /// <see cref="TagValue"/> instance.
+        /// </summary>
+        /// <seealso cref="Value"/>
+        public IEnumerable<Variant> AdditionalValues { get; }
 
         /// <summary>
         /// The quality status for the value.
@@ -38,15 +50,20 @@ namespace DataCore.Adapter.RealTimeData {
         /// <param name="value">
         ///   The tag value.
         /// </param>
+        /// <param name="additionalValues">
+        ///   Additional tag values e.g. if <paramref name="value"/> is the value of a digital 
+        ///   state, the name of the state can be specified by passing in an additional value.
+        /// </param>
         /// <param name="status">
         ///   The quality status for the value.
         /// </param>
         /// <param name="units">
         ///   The value units.
         /// </param>
-        public TagValue(DateTime utcSampleTime, Variant value, TagValueStatus status, string? units) {
+        public TagValue(DateTime utcSampleTime, Variant value, IEnumerable<Variant>? additionalValues, TagValueStatus status, string? units) {
             UtcSampleTime = utcSampleTime;
             Value = value;
+            AdditionalValues = additionalValues?.ToArray() ?? Array.Empty<Variant>();
             Status = status;
             Units = units;
         }
@@ -67,8 +84,9 @@ namespace DataCore.Adapter.RealTimeData {
         /// <param name="units">
         ///   The value units.
         /// </param>
+        [Obsolete("Use constructor directly.", true)]
         public static TagValue Create(DateTime utcSampleTime, Variant value, TagValueStatus status, string? units) {
-            return new TagValue(utcSampleTime, value, status, units);
+            return new TagValue(utcSampleTime, value, null, status, units);
         }
 
 

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValueExtended.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValueExtended.cs
@@ -36,6 +36,10 @@ namespace DataCore.Adapter.RealTimeData {
         /// <param name="value">
         ///   The tag value.
         /// </param>
+        /// <param name="additionalValues">
+        ///   Additional tag values e.g. if <paramref name="value"/> is the value of a digital 
+        ///   state, the name of the state can be specified by passing in an additional value.
+        /// </param>
         /// <param name="status">
         ///   The quality status for the value.
         /// </param>
@@ -54,12 +58,13 @@ namespace DataCore.Adapter.RealTimeData {
         public TagValueExtended(
             DateTime utcSampleTime, 
             Variant value, 
+            IEnumerable<Variant>? additionalValues,
             TagValueStatus status, 
             string? units, 
             string? notes, 
             string? error, 
             IEnumerable<AdapterProperty>? properties
-        ) : base(utcSampleTime, value, status, units) {
+        ) : base(utcSampleTime, value, additionalValues, status, units) {
             Notes = notes;
             Error = error;
             Properties = properties?.ToArray() ?? Array.Empty<AdapterProperty>();
@@ -74,6 +79,10 @@ namespace DataCore.Adapter.RealTimeData {
         /// </param>
         /// <param name="value">
         ///   The tag value.
+        /// </param>
+        /// <param name="additionalValues">
+        ///   Additional tag values e.g. if <paramref name="value"/> is the value of a digital 
+        ///   state, the name of the state can be specified by passing in an additional value.
         /// </param>
         /// <param name="status">
         ///   The quality status for the value.
@@ -90,8 +99,9 @@ namespace DataCore.Adapter.RealTimeData {
         /// <param name="properties">
         ///   Custom properties associated with the value.
         /// </param>
-        public static TagValueExtended Create(DateTime utcSampleTime, Variant value, TagValueStatus status, string? units, string? notes, string? error, IEnumerable<AdapterProperty>? properties) {
-            return new TagValueExtended(utcSampleTime, value, status, units, notes, error, properties);
+        [Obsolete("Use constructor directly", true)]
+        public static TagValueExtended Create(DateTime utcSampleTime, Variant value, IEnumerable<Variant>? additionalValues, TagValueStatus status, string? units, string? notes, string? error, IEnumerable<AdapterProperty>? properties) {
+            return new TagValueExtended(utcSampleTime, value, additionalValues, status, units, notes, error, properties);
         }
 
     }

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValueExtensions.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValueExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+
 using DataCore.Adapter.Common;
 
 namespace DataCore.Adapter.RealTimeData {
@@ -50,6 +52,30 @@ namespace DataCore.Adapter.RealTimeData {
                 throw new ArgumentNullException(nameof(value));
             }
             return value.Value.GetValueOrDefault<T>(defaultValue);
+        }
+
+
+        /// <summary>
+        /// Gets a collection containing both the <see cref="TagValue.Value"/> and <see cref="TagValue.AdditionalValues"/> 
+        /// defined on the <see cref="TagValue"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   The <see cref="TagValue"/>.
+        /// </param>
+        /// <returns>
+        ///   An enumerable of <see cref="Variant"/> instances representing all of the values of 
+        ///   the <see cref="TagValue"/>.
+        /// </returns>
+        public static IEnumerable<Variant> GetAllValues(this TagValue value) {
+            if (value == null) {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            yield return value.Value;
+
+            foreach (var item in value.AdditionalValues) {
+                yield return item;
+            }
         }
 
     }

--- a/src/DataCore.Adapter.Csv/CsvAdapter.cs
+++ b/src/DataCore.Adapter.Csv/CsvAdapter.cs
@@ -449,8 +449,7 @@ namespace DataCore.Adapter.Csv {
 
                         valuesForTag.Add(
                             sampleTime,
-                            TagValueBuilder
-                                .Create()
+                            new TagValueBuilder()
                                 .WithUtcSampleTime(sampleTime)
                                 .WithValue(double.TryParse(unparsedValue, NumberStyles.Any, csvConfig.CultureInfo, out var numericValue) ? (object) numericValue : unparsedValue)
                                 .WithStatus(TagValueStatus.Good)
@@ -740,7 +739,7 @@ namespace DataCore.Adapter.Csv {
                 var snapshot = valuesForTag.Values.LastOrDefault(x => x.UtcSampleTime.Add(offset) <= now);
 
                 if (snapshot != null && await resultChannel.WaitToWriteAsync(cancellationToken).ConfigureAwait(false)) {
-                    resultChannel.TryWrite(TagValueQueryResult.Create(tag.Id, tag.Name, TagValueBuilder.CreateFromExisting(snapshot).WithUtcSampleTime(snapshot.UtcSampleTime.Add(offset)).Build()));
+                    resultChannel.TryWrite(TagValueQueryResult.Create(tag.Id, tag.Name, new TagValueBuilder(snapshot).WithUtcSampleTime(snapshot.UtcSampleTime.Add(offset)).Build()));
                 }
             }
 
@@ -973,7 +972,7 @@ namespace DataCore.Adapter.Csv {
                         // sample, to prevent us from creating unnecessary instances of DataCoreTagValue.
                         var sample = offset.Equals(TimeSpan.Zero)
                             ? unmodifiedSample
-                            : TagValueBuilder.CreateFromExisting(unmodifiedSample).WithUtcSampleTime(sampleTimeThisIteration).Build();
+                            : new TagValueBuilder(unmodifiedSample).WithUtcSampleTime(sampleTimeThisIteration).Build();
 
                         if (await writer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false)) {
                             writer.TryWrite(TagValueQueryResult.Create(tag.Id, tag.Name, sample));

--- a/src/DataCore.Adapter.Json/TagValueConverter.cs
+++ b/src/DataCore.Adapter.Json/TagValueConverter.cs
@@ -10,7 +10,6 @@ namespace DataCore.Adapter.Json {
     /// </summary>
     public class TagValueConverter : AdapterJsonConverter<TagValue> {
 
-
         /// <inheritdoc/>
         public override TagValue Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
             if (reader.TokenType != JsonTokenType.StartObject) {
@@ -19,6 +18,7 @@ namespace DataCore.Adapter.Json {
 
             DateTime utcSampleTime = default;
             Variant value = Variant.Null;
+            Variant[]? additionalValues = null;
             TagValueStatus status = TagValueStatus.Uncertain;
             string units = null!;
 
@@ -38,6 +38,9 @@ namespace DataCore.Adapter.Json {
                 else if (string.Equals(propertyName, nameof(TagValue.Value), StringComparison.OrdinalIgnoreCase)) {
                     value = JsonSerializer.Deserialize<Variant>(ref reader, options);
                 }
+                else if (string.Equals(propertyName, nameof(TagValue.AdditionalValues), StringComparison.OrdinalIgnoreCase)) {
+                    additionalValues = JsonSerializer.Deserialize<Variant[]>(ref reader, options);
+                }
                 else if (string.Equals(propertyName, nameof(TagValue.Status), StringComparison.OrdinalIgnoreCase)) {
                     status = JsonSerializer.Deserialize<TagValueStatus>(ref reader, options);
                 }
@@ -49,7 +52,7 @@ namespace DataCore.Adapter.Json {
                 }
             }
 
-            return TagValue.Create(utcSampleTime, value, status, units);
+            return new TagValue(utcSampleTime, value, additionalValues, status, units);
         }
 
 
@@ -63,6 +66,7 @@ namespace DataCore.Adapter.Json {
             writer.WriteStartObject();
             WritePropertyValue(writer, nameof(TagValue.UtcSampleTime), value.UtcSampleTime, options);
             WritePropertyValue(writer, nameof(TagValue.Value), value.Value, options);
+            WritePropertyValue(writer, nameof(TagValue.AdditionalValues), value.AdditionalValues, options);
             WritePropertyValue(writer, nameof(TagValue.Status), value.Status, options);
             WritePropertyValue(writer, nameof(TagValue.Units), value.Units, options);
             writer.WriteEndObject();

--- a/src/DataCore.Adapter.Json/TagValueExtendedConverter.cs
+++ b/src/DataCore.Adapter.Json/TagValueExtendedConverter.cs
@@ -19,6 +19,7 @@ namespace DataCore.Adapter.Json {
 
             DateTime utcSampleTime = default;
             Variant value = Variant.Null;
+            Variant[]? additionalValues = null;
             TagValueStatus status = TagValueStatus.Uncertain;
             string units = null!;
             string notes = null!;
@@ -41,6 +42,9 @@ namespace DataCore.Adapter.Json {
                 else if (string.Equals(propertyName, nameof(TagValueExtended.Value), StringComparison.OrdinalIgnoreCase)) {
                     value = JsonSerializer.Deserialize<Variant>(ref reader, options);
                 }
+                else if (string.Equals(propertyName, nameof(TagValueExtended.AdditionalValues), StringComparison.OrdinalIgnoreCase)) {
+                    additionalValues = JsonSerializer.Deserialize<Variant[]>(ref reader, options);
+                }
                 else if (string.Equals(propertyName, nameof(TagValueExtended.Status), StringComparison.OrdinalIgnoreCase)) {
                     status = JsonSerializer.Deserialize<TagValueStatus>(ref reader, options);
                 }
@@ -61,7 +65,7 @@ namespace DataCore.Adapter.Json {
                 }
             }
 
-            return TagValueExtended.Create(utcSampleTime, value, status, units, notes, error, properties);
+            return new TagValueExtended(utcSampleTime, value, additionalValues, status, units, notes, error, properties);
         }
 
 
@@ -75,6 +79,7 @@ namespace DataCore.Adapter.Json {
             writer.WriteStartObject();
             WritePropertyValue(writer, nameof(TagValueExtended.UtcSampleTime), value.UtcSampleTime, options);
             WritePropertyValue(writer, nameof(TagValueExtended.Value), value.Value, options);
+            WritePropertyValue(writer, nameof(TagValueExtended.AdditionalValues), value.AdditionalValues, options);
             WritePropertyValue(writer, nameof(TagValueExtended.Status), value.Status, options);
             WritePropertyValue(writer, nameof(TagValueExtended.Units), value.Units, options);
             WritePropertyValue(writer, nameof(TagValueExtended.Notes), value.Notes, options);

--- a/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
+++ b/src/DataCore.Adapter.WaveGenerator/WaveGeneratorAdapter.cs
@@ -578,8 +578,7 @@ namespace DataCore.Adapter.WaveGenerator {
 
                     var tagId = tagOptions?.Name ?? tag;
 
-                    var val = TagValueBuilder
-                        .Create()
+                    var val = new TagValueBuilder()
                         .WithUtcSampleTime(sampleTime)
                         .WithValue(CalculateValue(sampleTime, tagOptions!))
                         .Build();
@@ -624,8 +623,7 @@ namespace DataCore.Adapter.WaveGenerator {
                             continue;
                         }
 
-                        var val = TagValueBuilder
-                            .Create()
+                        var val = new TagValueBuilder()
                             .WithUtcSampleTime(sampleTime)
                             .WithValue(CalculateValue(sampleTime, tagOptions!))
                             .Build();
@@ -657,8 +655,7 @@ namespace DataCore.Adapter.WaveGenerator {
                     var tagId = tagOptions?.Name ?? tag;
 
                     foreach (var sampleTime in request.UtcSampleTimes) {
-                        var val = TagValueBuilder
-                            .Create()
+                        var val = new TagValueBuilder()
                             .WithUtcSampleTime(sampleTime)
                             .WithValue(CalculateValue(sampleTime, tagOptions!))
                             .Build();

--- a/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
@@ -22,6 +22,12 @@ namespace DataCore.Adapter.RealTimeData {
         private Variant _value = Variant.Null;
 
         /// <summary>
+        /// Additional values (e.g. the name of a digital state if <see cref="_value"/> represents 
+        /// the state's value).
+        /// </summary>
+        private readonly List<Variant> _additionalValues = new List<Variant>();
+
+        /// <summary>
         /// The quality status.
         /// </summary>
         private TagValueStatus _status = TagValueStatus.Good;
@@ -70,6 +76,7 @@ namespace DataCore.Adapter.RealTimeData {
 
             WithUtcSampleTime(existing.UtcSampleTime);
             WithValue(existing.Value);
+            WithAdditionalValues(existing.AdditionalValues);
             WithStatus(existing.Status);
             WithNotes(existing.Notes);
             WithError(existing.Error);
@@ -83,6 +90,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <returns>
         ///   A new <see cref="TagValueBuilder"/> object.
         /// </returns>
+        [Obsolete("Use TagValueBuilder() constructor", false)]
         public static TagValueBuilder Create() {
             return new TagValueBuilder();
         }
@@ -101,6 +109,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="other"/> is <see langword="null"/>.
         /// </exception>
+        [Obsolete("Use TagValueBuilder(TagValueExtended) constructor", false)]
         public static TagValueBuilder CreateFromExisting(TagValueExtended other) {
             if (other == null) {
                 throw new ArgumentNullException(nameof(other));
@@ -117,7 +126,7 @@ namespace DataCore.Adapter.RealTimeData {
         ///   A new <see cref="TagValueExtended"/> object.
         /// </returns>
         public TagValueExtended Build() {
-            return TagValueExtended.Create(_utcSampleTime, _value, _status, _units, _notes, _error, _properties);
+            return new TagValueExtended(_utcSampleTime, _value, _additionalValues, _status, _units, _notes, _error, _properties);
         }
 
 
@@ -163,6 +172,67 @@ namespace DataCore.Adapter.RealTimeData {
         /// </returns>
         public TagValueBuilder WithValue<T>(T value) {
             _value = Variant.FromValue(value);
+            return this;
+        }
+
+
+        /// <summary>
+        /// Adds secondary values.
+        /// </summary>
+        /// <param name="values">
+        ///   The additional values.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TagValueBuilder"/>.
+        /// </returns>
+        /// <remarks>
+        ///   Secondary values can be used when e.g. the primary value is the name of a digital 
+        ///   state, but you also want to provide the state's numeric value.
+        /// </remarks>
+        public TagValueBuilder WithAdditionalValues(params Variant[] values) {
+            return WithAdditionalValues((IEnumerable<Variant>) values);
+        }
+
+
+        /// <summary>
+        /// Adds secondary values.
+        /// </summary>
+        /// <param name="values">
+        ///   The additional values.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TagValueBuilder"/>.
+        /// </returns>
+        /// <remarks>
+        ///   Secondary values can be used when e.g. the primary value is the name of a digital 
+        ///   state, but you also want to provide the state's numeric value.
+        /// </remarks>
+        public TagValueBuilder WithAdditionalValues(IEnumerable<Variant> values) {
+            if (values != null) {
+                _additionalValues.AddRange(values);
+            }
+            return this;
+        }
+
+
+        /// <summary>
+        /// Adds a secondary value.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The type of the value.
+        /// </typeparam>
+        /// <param name="value">
+        ///   The additional value.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TagValueBuilder"/>.
+        /// </returns>
+        /// <remarks>
+        ///   Secondary values can be used when e.g. the primary value is the name of a digital 
+        ///   state, but you also want to provide the state's numeric value.
+        /// </remarks>
+        public TagValueBuilder WithAdditionalValue<T>(T value) {
+            _additionalValues.Add(Variant.FromValue(value));
             return this;
         }
 

--- a/src/DataCore.Adapter/RealTimeData/Utilities/AggregationHelper.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/AggregationHelper.cs
@@ -193,7 +193,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             var numericValue = CalculateAverage(goodQualitySamples);
 
             return new[] {
-                TagValueBuilder.Create()
+                new TagValueBuilder()
                     .WithUtcSampleTime(bucket.UtcBucketStart)
                     .WithValue(numericValue)
                     .WithStatus(status)
@@ -241,7 +241,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                 .First();
 
             return new[] {
-                TagValueBuilder.CreateFromExisting(minValue)
+                new TagValueBuilder(minValue)
                     .WithStatus(status)
                     .WithBucketProperties(bucket)
                     .WithProperties(CreateXPoweredByProperty())
@@ -286,7 +286,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                 .First();
 
             return new[] {
-                TagValueBuilder.CreateFromExisting(maxValue)
+                new TagValueBuilder(maxValue)
                     .WithStatus(status)
                     .WithBucketProperties(bucket)
                     .WithProperties(CreateXPoweredByProperty())
@@ -322,7 +322,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
 
             if (goodQualitySamples.Length == 0) {
                 return new[] {
-                    TagValueBuilder.Create()
+                    new TagValueBuilder()
                         .WithUtcSampleTime(bucket.UtcBucketStart)
                         .WithValue(0d)
                         .WithStatus(status)
@@ -333,7 +333,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             }
 
             return new[] {
-                TagValueBuilder.Create()
+                new TagValueBuilder()
                     .WithUtcSampleTime(bucket.UtcBucketStart)
                     .WithValue(goodQualitySamples.Length)
                     .WithStatus(status)
@@ -386,7 +386,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             var numericValue = Math.Abs(maxValue.Value.GetValueOrDefault(double.NaN) - minValue.Value.GetValueOrDefault(double.NaN));
 
             return new[] {
-                TagValueBuilder.Create()
+                new TagValueBuilder()
                     .WithUtcSampleTime(bucket.UtcBucketStart)
                     .WithValue(numericValue)
                     .WithStatus(status)
@@ -435,7 +435,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             var numericValue = firstValue.Value.GetValueOrDefault(double.NaN) - lastValue.Value.GetValueOrDefault(double.NaN);
 
             return new[] {
-                TagValueBuilder.Create()
+                new TagValueBuilder()
                     .WithUtcSampleTime(bucket.UtcBucketStart)
                     .WithValue(numericValue)
                     .WithStatus(status)
@@ -466,7 +466,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         private static IEnumerable<TagValueExtended> CalculatePercentGood(TagSummary tag, TagValueBucket bucket) {
             if (bucket.RawSampleCount == 0) {
                 return new[] {
-                    TagValueBuilder.Create()
+                    new TagValueBuilder()
                         .WithUtcSampleTime(bucket.UtcBucketStart)
                         .WithValue(0d)
                         .WithUnits("%")
@@ -480,7 +480,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             var percentGoodCount = bucket.RawSamples.Count(x => x.Status == TagValueStatus.Good);
 
             return new[] {
-                TagValueBuilder.Create()
+                new TagValueBuilder()
                     .WithUtcSampleTime(bucket.UtcBucketStart)
                     .WithValue((double) percentGoodCount / bucket.RawSampleCount * 100)
                     .WithUnits("%")
@@ -511,7 +511,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         private static IEnumerable<TagValueExtended> CalculatePercentBad(TagSummary tag, TagValueBucket bucket) {
             if (bucket.RawSampleCount == 0) {
                 return new[] {
-                    TagValueBuilder.Create()
+                    new TagValueBuilder()
                         .WithUtcSampleTime(bucket.UtcBucketStart)
                         .WithValue(0d)
                         .WithUnits("%")
@@ -525,7 +525,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             var percentBadCount = bucket.RawSamples.Count(x => x.Status == TagValueStatus.Bad);
 
             return new[] {
-                TagValueBuilder.Create()
+                new TagValueBuilder()
                     .WithUtcSampleTime(bucket.UtcBucketStart)
                     .WithValue((double) percentBadCount / bucket.RawSampleCount * 100)
                     .WithUnits("%")
@@ -594,7 +594,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
 
             if (goodQualitySamples.Length == 1) {
                 return new[] {
-                    TagValueBuilder.Create()
+                    new TagValueBuilder()
                         .WithUtcSampleTime(bucket.UtcBucketStart)
                         .WithValue(0d)
                         .WithStatus(status)
@@ -610,7 +610,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             var variance = CalculateVariance(goodQualitySamples, out var avg);
 
             return new[] {
-                TagValueBuilder.Create()
+                new TagValueBuilder()
                     .WithUtcSampleTime(bucket.UtcBucketStart)
                     .WithValue(variance)
                     .WithStatus(status)
@@ -657,7 +657,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             
             if (goodQualitySamples.Length == 1) {
                 return new[] {
-                    TagValueBuilder.Create()
+                    new TagValueBuilder()
                         .WithUtcSampleTime(bucket.UtcBucketStart)
                         .WithValue(0d)
                         .WithStatus(status)
@@ -679,7 +679,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             var upperBound = avg + (sigma * stdDev);
 
             return new[] {
-                TagValueBuilder.Create()
+                new TagValueBuilder()
                     .WithUtcSampleTime(bucket.UtcBucketStart)
                     .WithValue(stdDev)
                     .WithStatus(status)
@@ -1315,7 +1315,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         ///   The tag value.
         /// </returns>
         private static TagValueExtended CreateErrorTagValue(TagValueBucket bucket, DateTime sampleTime, string error) {
-            return TagValueBuilder.Create()
+            return new TagValueBuilder()
                 .WithUtcSampleTime(sampleTime)
                 .WithValue(Resources.TagValue_ProcessedValue_Error)
                 .WithStatus(TagValueStatus.Bad)

--- a/src/DataCore.Adapter/RealTimeData/Utilities/InterpolationHelper.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/InterpolationHelper.cs
@@ -96,7 +96,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             ) {
                 return valueBefore == null 
                     ? null 
-                    : TagValueBuilder.CreateFromExisting(valueBefore)
+                    : new TagValueBuilder(valueBefore)
                         .WithUtcSampleTime(utcSampleTime)
                         .WithStatus(
                             valueBefore.Status == TagValueStatus.Good && !forceUncertainStatus 
@@ -116,7 +116,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                 ? TagValueStatus.Good
                 : TagValueStatus.Uncertain;
 
-            return TagValueBuilder.Create()
+            return new TagValueBuilder()
                 .WithUtcSampleTime(utcSampleTime)
                 .WithValue(nextNumericValue)
                 .WithStatus(nextStatusValue)
@@ -185,8 +185,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                         ? TagValueStatus.Uncertain 
                         : valueBefore.Status;
 
-                    return TagValueBuilder
-                        .CreateFromExisting(valueBefore)
+                    return new TagValueBuilder(valueBefore)
                         .WithUtcSampleTime(utcSampleTime)
                         .WithStatus(status)
                         .WithProperties(AggregationHelper.CreateXPoweredByProperty())
@@ -197,8 +196,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                         ? TagValueStatus.Uncertain
                         : valueAfter.Status;
 
-                    return TagValueBuilder
-                        .CreateFromExisting(valueAfter)
+                    return new TagValueBuilder(valueAfter)
                         .WithUtcSampleTime(utcSampleTime)
                         .WithStatus(status)
                         .WithProperties(AggregationHelper.CreateXPoweredByProperty())
@@ -353,8 +351,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
 
             var exactValue = values.FirstOrDefault(x => x != null && x.UtcSampleTime == utcSampleTime);
             if (exactValue != null) {
-                return TagValueBuilder
-                    .CreateFromExisting(exactValue)
+                return new TagValueBuilder(exactValue)
                     .WithProperties(AggregationHelper.CreateXPoweredByProperty())
                     .Build();
             }

--- a/src/DataCore.Adapter/RealTimeData/Utilities/PlotHelper.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/PlotHelper.cs
@@ -466,8 +466,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                 resultsChannel.TryWrite(TagValueQueryResult.Create(
                     tag.Id, 
                     tag.Name, 
-                    TagValueBuilder
-                        .CreateFromExisting(value)
+                    new TagValueBuilder(value)
                         .WithBucketProperties(bucket)
                         .WithProperties(AggregationHelper.CreateXPoweredByProperty())
                         .Build()

--- a/src/Protos/datacore/adapter/Types.proto
+++ b/src/Protos/datacore/adapter/Types.proto
@@ -318,7 +318,8 @@ message TagValue {
     string units = 4;
     string notes = 5;
     string error = 6;
-    repeated AdapterProperty properties = 7; 
+    repeated AdapterProperty properties = 7;
+    repeated Variant additional_values = 8;
 }
 
 

--- a/test/DataCore.Adapter.Benchmarks/SnapshotPush.cs
+++ b/test/DataCore.Adapter.Benchmarks/SnapshotPush.cs
@@ -39,7 +39,7 @@ namespace DataCore.Adapter.Benchmarks {
                             new TagValueQueryResult(
                                 tag.Id,
                                 tag.Name,
-                                TagValueBuilder.Create().WithValue(i).Build()
+                                new TagValueBuilder().WithValue(i).Build()
                             ),
                             ct
                         );
@@ -59,7 +59,7 @@ namespace DataCore.Adapter.Benchmarks {
                     new TagValueQueryResult(
                         tag.Id,
                         tag.Name,
-                        TagValueBuilder.Create().WithValue(i).Build()
+                        new TagValueBuilder().WithValue(i).Build()
                     ),
                     cancellationToken
                 );

--- a/test/DataCore.Adapter.Tests/AdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterTests.cs
@@ -98,7 +98,7 @@ namespace DataCore.Adapter.Tests {
                     values.Add(new WriteTagValueItem() {  
                         CorrelationId = Guid.NewGuid().ToString(),
                         TagId = TestContext.TestName,
-                        Value = TagValueBuilder.Create().WithUtcSampleTime(now.AddMinutes(-1 * (5 - i))).WithValue(i).Build()
+                        Value = new TagValueBuilder().WithUtcSampleTime(now.AddMinutes(-1 * (5 - i))).WithValue(i).Build()
                     });
                 }
 
@@ -137,7 +137,7 @@ namespace DataCore.Adapter.Tests {
                     values.Add(new WriteTagValueItem() {
                         CorrelationId = Guid.NewGuid().ToString(),
                         TagId = TestContext.TestName,
-                        Value = TagValueBuilder.Create().WithUtcSampleTime(now.AddMinutes(-1 * (5 - i))).WithValue(i).Build()
+                        Value = new TagValueBuilder().WithUtcSampleTime(now.AddMinutes(-1 * (5 - i))).WithValue(i).Build()
                     });
                 }
 
@@ -173,7 +173,7 @@ namespace DataCore.Adapter.Tests {
                     values.Add(new WriteTagValueItem() {
                         CorrelationId = Guid.NewGuid().ToString(),
                         TagId = TestContext.TestName,
-                        Value = TagValueBuilder.Create().WithUtcSampleTime(now.AddDays(-1).AddMinutes(-1 * (5 - i))).WithValue(i).Build()
+                        Value = new TagValueBuilder().WithUtcSampleTime(now.AddDays(-1).AddMinutes(-1 * (5 - i))).WithValue(i).Build()
                     });
                 }
 
@@ -212,7 +212,7 @@ namespace DataCore.Adapter.Tests {
                     values.Add(new WriteTagValueItem() {
                         CorrelationId = Guid.NewGuid().ToString(),
                         TagId = TestContext.TestName,
-                        Value = TagValueBuilder.Create().WithUtcSampleTime(now.AddDays(-1).AddMinutes(-1 * (5 - i))).WithValue(i).Build()
+                        Value = new TagValueBuilder().WithUtcSampleTime(now.AddDays(-1).AddMinutes(-1 * (5 - i))).WithValue(i).Build()
                     });
                 }
 

--- a/test/DataCore.Adapter.Tests/AggregationTests.cs
+++ b/test/DataCore.Adapter.Tests/AggregationTests.cs
@@ -173,9 +173,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -243,9 +243,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -308,9 +308,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -371,9 +371,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).WithStatus(TagValueStatus.Bad).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).WithStatus(TagValueStatus.Bad).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -429,9 +429,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -488,9 +488,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).WithStatus(TagValueStatus.Bad).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).WithStatus(TagValueStatus.Bad).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -601,9 +601,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -650,9 +650,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -703,10 +703,10 @@ namespace DataCore.Adapter.Tests {
             // good value.
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-69)).WithValue(70).WithStatus(TagValueStatus.Bad).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-69)).WithValue(70).WithStatus(TagValueStatus.Bad).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -753,9 +753,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-69)).WithValue(70).WithStatus(TagValueStatus.Bad).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-69)).WithValue(70).WithStatus(TagValueStatus.Bad).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -806,10 +806,10 @@ namespace DataCore.Adapter.Tests {
             // good value.
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).WithStatus(TagValueStatus.Bad).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-57)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-75)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).WithStatus(TagValueStatus.Bad).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-57)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -856,9 +856,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-69)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).WithStatus(TagValueStatus.Bad).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-69)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-59)).WithValue(100).WithStatus(TagValueStatus.Bad).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).WithStatus(TagValueStatus.Bad).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -905,9 +905,9 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-57)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-51)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-57)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-51)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-2)).WithValue(0).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -955,8 +955,8 @@ namespace DataCore.Adapter.Tests {
             var interval = TimeSpan.FromSeconds(60);
 
             var rawValues = new[] {
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-57)).WithValue(70).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(end.AddSeconds(-50)).WithValue(100).Build()
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-57)).WithValue(70).Build(),
+                new TagValueBuilder().WithUtcSampleTime(end.AddSeconds(-50)).WithValue(100).Build()
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).ToArray();
@@ -1136,7 +1136,7 @@ namespace DataCore.Adapter.Tests {
                     : bucket.RawSamples.Sum(x => x.Value.GetValueOrDefault(0f));
 
                 return new[] { 
-                    TagValueBuilder.Create()
+                    new TagValueBuilder()
                         .WithUtcSampleTime(bucket.UtcBucketStart)
                         .WithValue(val)
                         .Build()
@@ -1158,16 +1158,16 @@ namespace DataCore.Adapter.Tests {
 
             var rawValues = new[] {
                 // Bucket 1
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-57)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-50)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-46)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-57)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-50)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-46)).WithValue(1).Build(),
 
                 // Bucket 2: no values
 
                 // Bucket 3
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-30)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-20)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-16)).WithValue(1).Build()
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-30)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-20)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-16)).WithValue(1).Build()
 
                 // Bucket 4: no values
             };
@@ -1221,7 +1221,7 @@ namespace DataCore.Adapter.Tests {
                     : bucket.RawSamples.Sum(x => x.Value.GetValueOrDefault(0f));
 
                 return new[] {
-                    TagValueBuilder.Create()
+                    new TagValueBuilder()
                         .WithUtcSampleTime(bucket.UtcBucketStart)
                         .WithValue(val)
                         .Build()
@@ -1243,16 +1243,16 @@ namespace DataCore.Adapter.Tests {
 
             var rawValues = new[] {
                 // Bucket 1
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-57)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-50)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-46)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-57)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-50)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-46)).WithValue(1).Build(),
 
                 // Bucket 2: no values
 
                 // Bucket 3
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-30)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-20)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-16)).WithValue(1).Build()
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-30)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-20)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-16)).WithValue(1).Build()
 
                 // Bucket 4: no values
             };
@@ -1311,7 +1311,7 @@ namespace DataCore.Adapter.Tests {
                     : bucket.RawSamples.Sum(x => x.Value.GetValueOrDefault(0f));
 
                 return new[] {
-                    TagValueBuilder.Create()
+                    new TagValueBuilder()
                         .WithUtcSampleTime(bucket.UtcBucketStart)
                         .WithValue(val)
                         .Build()
@@ -1333,16 +1333,16 @@ namespace DataCore.Adapter.Tests {
 
             var rawValues = new[] {
                 // Bucket 1
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-57)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-50)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-46)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-57)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-50)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-46)).WithValue(1).Build(),
 
                 // Bucket 2: no values
 
                 // Bucket 3
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-30)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-20)).WithValue(1).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(-16)).WithValue(1).Build()
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-30)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-20)).WithValue(1).Build(),
+                new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(-16)).WithValue(1).Build()
 
                 // Bucket 4: no values
             };
@@ -1404,24 +1404,24 @@ namespace DataCore.Adapter.Tests {
 
             var rawValues = new[] {
                 // Bucket 1: 0-20s
-                TagValueBuilder.Create().WithUtcSampleTime(start).WithValue(70).Build(), // earliest
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(7)).WithValue(100).Build(), // max
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(14)).WithValue(0).Build(), // min
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(15)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(19)).WithValue(100).Build(), // latest
+                new TagValueBuilder().WithUtcSampleTime(start).WithValue(70).Build(), // earliest
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(7)).WithValue(100).Build(), // max
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(14)).WithValue(0).Build(), // min
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(15)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(19)).WithValue(100).Build(), // latest
                 // Bucket 2: 20-40s
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(21)).WithValue(1.883).Build(), // earliest + min
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(27)).WithValue(77.765).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(39)).WithValue(77.766).Build(), // latest + max
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(21)).WithValue(1.883).Build(), // earliest + min
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(27)).WithValue(77.765).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(39)).WithValue(77.766).Build(), // latest + max
                 // Bucket 3: 40-60s
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(41)).WithValue(88).Build(), // earliest
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(47)).WithValue(13).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(49)).WithValue(35).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(53)).WithValue(116).Build(), // max
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(55)).WithValue(0.8867).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(56)).WithValue(23).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(58)).WithValue(44.444).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(59)).WithValue(0.556).Build(), // latest + min
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(41)).WithValue(88).Build(), // earliest
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(47)).WithValue(13).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(49)).WithValue(35).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(53)).WithValue(116).Build(), // max
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(55)).WithValue(0.8867).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(56)).WithValue(23).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(58)).WithValue(44.444).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(59)).WithValue(0.556).Build(), // latest + min
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).PublishToChannel();
@@ -1454,21 +1454,21 @@ namespace DataCore.Adapter.Tests {
 
             var rawValues = new[] {
                 // Bucket 1: 0-20s
-                TagValueBuilder.Create().WithUtcSampleTime(start).WithValue(70).Build(), // earliest
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(7)).WithValue(100).Build(), // max
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(14)).WithValue(0).Build(), // min
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(15)).WithValue(100).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(19)).WithValue(100).Build(), // latest
+                new TagValueBuilder().WithUtcSampleTime(start).WithValue(70).Build(), // earliest
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(7)).WithValue(100).Build(), // max
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(14)).WithValue(0).Build(), // min
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(15)).WithValue(100).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(19)).WithValue(100).Build(), // latest
                 // Bucket 2: 20-40s
                 // Bucket 3: 40-60s
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(41)).WithValue(88).Build(), // earliest
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(47)).WithValue(13).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(49)).WithValue(35).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(53)).WithValue(116).Build(), // max
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(55)).WithValue(0.8867).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(56)).WithValue(23).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(58)).WithValue(44.444).Build(),
-                TagValueBuilder.Create().WithUtcSampleTime(start.AddSeconds(59)).WithValue(0.556).Build(), // latest + min
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(41)).WithValue(88).Build(), // earliest
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(47)).WithValue(13).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(49)).WithValue(35).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(53)).WithValue(116).Build(), // max
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(55)).WithValue(0.8867).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(56)).WithValue(23).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(58)).WithValue(44.444).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(59)).WithValue(0.556).Build(), // latest + min
             };
 
             var rawData = rawValues.Select(x => TagValueQueryResult.Create(tag.Id, tag.Name, x)).PublishToChannel();

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -108,7 +108,7 @@ namespace DataCore.Adapter.Tests {
             var result = request.Tags.Select(t => new TagValueQueryResult(
                 t,
                 t,
-                TagValueBuilder.Create()
+                new TagValueBuilder()
                     .WithUtcSampleTime(DateTime.MinValue)
                     .WithValue(0)
                     .Build()
@@ -153,7 +153,7 @@ namespace DataCore.Adapter.Tests {
                     ValueReceived(new TagValueQueryResult(
                         tag.Id,
                         tag.Name,
-                        TagValueBuilder.Create()
+                        new TagValueBuilder()
                             .WithUtcSampleTime(DateTime.MinValue)
                             .WithValue(0)
                             .Build()

--- a/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
@@ -129,8 +129,7 @@ namespace DataCore.Adapter.Tests {
                     TagValueQueryResult.Create(
                         TestContext.TestName,
                         TestContext.TestName,
-                        TagValueBuilder
-                            .Create()
+                        new TagValueBuilder()
                             .WithUtcSampleTime(now.AddSeconds(-5))
                             .WithValue(100)
                             .Build()
@@ -140,8 +139,7 @@ namespace DataCore.Adapter.Tests {
                     TagValueQueryResult.Create(
                         TestContext.TestName,
                         TestContext.TestName,
-                        TagValueBuilder
-                            .Create()
+                        new TagValueBuilder()
                             .WithUtcSampleTime(now.AddSeconds(-1))
                             .WithValue(99)
                             .Build()

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -601,7 +601,8 @@ namespace DataCore.Adapter.Tests {
                "Name",
                new TagValueExtended(
                    DateTime.UtcNow, 
-                   Variant.FromValue(100), 
+                   Variant.FromValue(100),
+                   new[] { Variant.FromValue("OPEN") },
                    TagValueStatus.Good, 
                    "Units", 
                    "Notes", 
@@ -625,6 +626,14 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expected.Value.Status, actual.Value.Status);
             Assert.AreEqual(expected.Value.Units, actual.Value.Units);
             Assert.AreEqual(expected.Value.Notes, actual.Value.Notes);
+
+            Assert.AreEqual(expected.Value.AdditionalValues.Count(), actual.Value.AdditionalValues.Count());
+            for (var i = 0; i < expected.Value.AdditionalValues.Count(); i++) {
+                var expectedValue = expected.Value.AdditionalValues.ElementAt(i);
+                var actualValue = actual.Value.AdditionalValues.ElementAt(i);
+
+                Assert.AreEqual(expectedValue, actualValue);
+            }
 
             Assert.AreEqual(expected.Value.Properties.Count(), actual.Value.Properties.Count());
             for (var i = 0; i < expected.Value.Properties.Count(); i++) {
@@ -1010,6 +1019,7 @@ namespace DataCore.Adapter.Tests {
             new TagValue(
                 DateTime.UtcNow,
                 Variant.FromValue(100),
+                new[] { Variant.FromValue("OPEN") },
                 TagValueStatus.Good,
                 "Units"
             );
@@ -1021,6 +1031,14 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expected.Value, actual.Value);
             Assert.AreEqual(expected.Status, actual.Status);
             Assert.AreEqual(expected.Units, actual.Units);
+
+            Assert.AreEqual(expected.AdditionalValues.Count(), actual.AdditionalValues.Count());
+            for (var i = 0; i < expected.AdditionalValues.Count(); i++) {
+                var expectedValue = expected.AdditionalValues.ElementAt(i);
+                var actualValue = actual.AdditionalValues.ElementAt(i);
+
+                Assert.AreEqual(expectedValue, actualValue);
+            }
         }
 
 
@@ -1031,6 +1049,7 @@ namespace DataCore.Adapter.Tests {
             new TagValueExtended(
                 DateTime.UtcNow,
                 Variant.FromValue(100),
+                new[] { Variant.FromValue("OPEN") },
                 TagValueStatus.Good,
                 "Units",
                 "Notes",
@@ -1049,6 +1068,14 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expected.Status, actual.Status);
             Assert.AreEqual(expected.Units, actual.Units);
             Assert.AreEqual(expected.Notes, actual.Notes);
+
+            Assert.AreEqual(expected.AdditionalValues.Count(), actual.AdditionalValues.Count());
+            for (var i = 0; i < expected.AdditionalValues.Count(); i++) {
+                var expectedValue = expected.AdditionalValues.ElementAt(i);
+                var actualValue = actual.AdditionalValues.ElementAt(i);
+
+                Assert.AreEqual(expectedValue, actualValue);
+            }
 
             Assert.AreEqual(expected.Properties.Count(), actual.Properties.Count());
             for (var i = 0; i < expected.Properties.Count(); i++) {
@@ -1070,6 +1097,7 @@ namespace DataCore.Adapter.Tests {
                new TagValueExtended(
                    DateTime.UtcNow,
                    Variant.FromValue(100),
+                   new[] { Variant.FromValue("OPEN") },
                    TagValueStatus.Good,
                    "Units",
                    "Notes",
@@ -1091,6 +1119,14 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expected.Value.Status, actual.Value.Status);
             Assert.AreEqual(expected.Value.Units, actual.Value.Units);
             Assert.AreEqual(expected.Value.Notes, actual.Value.Notes);
+
+            Assert.AreEqual(expected.Value.AdditionalValues.Count(), actual.Value.AdditionalValues.Count());
+            for (var i = 0; i < expected.Value.AdditionalValues.Count(); i++) {
+                var expectedValue = expected.Value.AdditionalValues.ElementAt(i);
+                var actualValue = actual.Value.AdditionalValues.ElementAt(i);
+
+                Assert.AreEqual(expectedValue, actualValue);
+            }
 
             Assert.AreEqual(expected.Value.Properties.Count(), actual.Value.Properties.Count());
             for (var i = 0; i < expected.Value.Properties.Count(); i++) {

--- a/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
@@ -159,7 +159,7 @@ namespace DataCore.Adapter.Tests {
                 values.Add(new WriteTagValueItem() {
                     CorrelationId = Guid.NewGuid().ToString(),
                     TagId = context.TestName,
-                    Value = TagValueBuilder.Create().WithUtcSampleTime(now.AddDays(-1).AddMinutes(-1 * (5 - i))).WithValue(i).Build()
+                    Value = new TagValueBuilder().WithUtcSampleTime(now.AddDays(-1).AddMinutes(-1 * (5 - i))).WithValue(i).Build()
                 });
             }
             return values;
@@ -173,7 +173,7 @@ namespace DataCore.Adapter.Tests {
                 values.Add(new WriteTagValueItem() {
                     CorrelationId = Guid.NewGuid().ToString(),
                     TagId = context.TestName,
-                    Value = TagValueBuilder.Create().WithUtcSampleTime(now.AddDays(-1).AddMinutes(-1 * (5 - i))).WithValue(i).Build()
+                    Value = new TagValueBuilder().WithUtcSampleTime(now.AddDays(-1).AddMinutes(-1 * (5 - i))).WithValue(i).Build()
                 });
             }
             return values;

--- a/test/DataCore.Adapter.Tests/SubscriptionTests.cs
+++ b/test/DataCore.Adapter.Tests/SubscriptionTests.cs
@@ -85,7 +85,7 @@ namespace DataCore.Adapter.Tests {
                     CancellationToken
                 );
 
-                var val = TagValueBuilder.Create().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
+                var val = new TagValueBuilder().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
                 await feature.ValueReceived(TagValueQueryResult.Create(TestContext.TestName, TestContext.TestName, val));
 
                 CancelAfter(TimeSpan.FromSeconds(1));
@@ -118,7 +118,7 @@ namespace DataCore.Adapter.Tests {
                     CancellationToken
                 );
 
-                var val1 = TagValueBuilder.Create().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
+                var val1 = new TagValueBuilder().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
                 await feature.ValueReceived(TagValueQueryResult.Create(TestContext.TestName, TestContext.TestName, val1));
 
                 channel.Writer.TryWrite(new TagValueSubscriptionUpdate() { 
@@ -126,7 +126,7 @@ namespace DataCore.Adapter.Tests {
                     Tags = new [] { TestContext.TestName }
                 });
 
-                var val2 = TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(1)).WithValue(now.Ticks + TimeSpan.TicksPerSecond).Build();
+                var val2 = new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(1)).WithValue(now.Ticks + TimeSpan.TicksPerSecond).Build();
                 await feature.ValueReceived(TagValueQueryResult.Create(TestContext.TestName, TestContext.TestName, val2));
 
                 CancelAfter(TimeSpan.FromSeconds(1));
@@ -172,7 +172,7 @@ namespace DataCore.Adapter.Tests {
                     CancellationToken
                 );
 
-                var val1 = TagValueBuilder.Create().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
+                var val1 = new TagValueBuilder().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
                 await feature.ValueReceived(TagValueQueryResult.Create(TestContext.TestName, TestContext.TestName, val1));
 
                 channel.Writer.TryWrite(new TagValueSubscriptionUpdate() {
@@ -182,7 +182,7 @@ namespace DataCore.Adapter.Tests {
 
                 await Task.Delay(1000, CancellationToken);
 
-                var val2 = TagValueBuilder.Create().WithUtcSampleTime(now.AddSeconds(1)).WithValue(now.Ticks + TimeSpan.TicksPerSecond).Build();
+                var val2 = new TagValueBuilder().WithUtcSampleTime(now.AddSeconds(1)).WithValue(now.Ticks + TimeSpan.TicksPerSecond).Build();
                 await feature.ValueReceived(TagValueQueryResult.Create(TestContext.TestName, TestContext.TestName, val2));
 
                 CancelAfter(TimeSpan.FromSeconds(1));
@@ -233,7 +233,7 @@ namespace DataCore.Adapter.Tests {
                     try {
                         while (!CancellationToken.IsCancellationRequested) {
                             await Task.Delay(50, CancellationToken).ConfigureAwait(false);
-                            var val = TagValueBuilder.Create().WithValue(DateTime.UtcNow.Ticks).Build();
+                            var val = new TagValueBuilder().WithValue(DateTime.UtcNow.Ticks).Build();
                             await feature.ValueReceived(TagValueQueryResult.Create(TestContext.TestName, TestContext.TestName, val));
                         }
                     }
@@ -307,17 +307,17 @@ namespace DataCore.Adapter.Tests {
                 );
 
                 // We should receive this value due to our IsTopicMatch delegate
-                var val1 = TagValueBuilder.Create().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
+                var val1 = new TagValueBuilder().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
                 var tagId1 = TestContext.TestName + "/SubTag";
                 Assert.IsTrue(await feature.ValueReceived(TagValueQueryResult.Create(tagId1, tagId1, val1)), "Sub-tag value write failed.");
 
                 // We should not receive this value
-                var val2 = TagValueBuilder.Create().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
+                var val2 = new TagValueBuilder().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
                 var tagId2 = "Should_Not_Match";
                 Assert.IsTrue(await feature.ValueReceived(TagValueQueryResult.Create(tagId2, tagId2, val2)), "Non-matching value write failed.");
 
                 // We should receive this value because it is an exact match for the tag we subscribed to.
-                var val3 = TagValueBuilder.Create().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
+                var val3 = new TagValueBuilder().WithUtcSampleTime(now).WithValue(now.Ticks).Build();
                 var tagId3 = TestContext.TestName;
                 Assert.IsTrue(await feature.ValueReceived(TagValueQueryResult.Create(tagId3, tagId3, val3)), "Exact match value write failed.");
 


### PR DESCRIPTION
`TagValue` now includes an `AdditionalValues` property that can be used to define additional secondary values for a sample. This can be used when e.g. the primary `Value` property holds the numerical value of a digital state, but you also want to return the name of the state for display purposes.