### PR TITLE
Add hosting and HTTP extensions references to unit test helpers

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -12,12 +12,21 @@
   
   <!-- ASP.NET Core/Microsoft Extension Packages -->
   <PropertyGroup>
+    <!-- 
+      Microsoft.AspNetCore metapackage is referenced by .NET Framework 4.8 unit tests. 
+    -->
     <MicrosoftAspNetCoreVersion>2.2.0</MicrosoftAspNetCoreVersion>
     <MicrosoftAspNetCoreSignalRClientVersion>5.0.3</MicrosoftAspNetCoreSignalRClientVersion>
     <MicrosoftAspNetCoreSignalRProtocolsMessagePackVersion>5.0.3</MicrosoftAspNetCoreSignalRProtocolsMessagePackVersion>
     <MicrosoftAspNetCoreSignalRVersion>1.1.0</MicrosoftAspNetCoreSignalRVersion>
     <MicrosoftAspNetWebApiClientVersion>5.2.7</MicrosoftAspNetWebApiClientVersion>
     <MicrosoftBclAsyncInterfacesVersion>5.0.0</MicrosoftBclAsyncInterfacesVersion>
+    <!-- 
+      Microsoft.Extensions.Hosting and Microsoft.Extensions.Http are referenced by the 
+      DataCore.Adapter.Tests.Helpers project for .NET Standard 2.0 targeting. 
+    -->
+    <MicrosoftExtensionsHostingVersion>2.2.0</MicrosoftExtensionsHostingVersion>
+    <MicrosoftExtensionsHttpVersion>2.2.0</MicrosoftExtensionsHttpVersion>
   </PropertyGroup>
   
   <!-- gRPC Packages -->

--- a/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
+++ b/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
@@ -19,7 +19,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -60,7 +60,6 @@
     <Otherwise>
       <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCoreVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftAspNetCoreVersion)" />
       </ItemGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
Unit test helpers library now adds references to Microsoft.Extensions.Hosting and Microsoft.Extensions.Http when targeting .NET Standard 2.0. This means that no additional packages are required to be able to run unit tests against .NET Framework when using the DI container to provide e.g. logging, HttpClient, etc