### PR TITLE
Revert to single value on tag value objects

### DIFF
--- a/src/DataCore.Adapter.Abstractions/WellKnownProperties.cs
+++ b/src/DataCore.Adapter.Abstractions/WellKnownProperties.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DataCore.Adapter {
+
+    /// <summary>
+    /// Defines names for well-known properties on adapter entities.
+    /// </summary>
+    public static class WellKnownProperties {
+
+        /// <summary>
+        /// Properties for <see cref="RealTimeData.TagValueExtended"/>.
+        /// </summary>
+        public static class TagValue {
+
+            /// <summary>
+            /// The display value for the tag value.
+            /// </summary>
+            /// <remarks>
+            ///   This property can be used to supply a pre-formatted value instead of relying on 
+            ///   calling <see cref="Common.Variant.ToString(string?, IFormatProvider?)"/>. An 
+            ///   example use case is to supply the value of a digital tag as an <see cref="int"/>
+            ///   value, but to use the <see cref="DisplayValue"/> property to define the name of
+            ///   the digital state.
+            /// </remarks>
+            public const string DisplayValue = "Display-Value";
+
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
@@ -1753,7 +1753,7 @@ namespace DataCore.Adapter {
 
             return new RealTimeData.TagValueExtended(
                 tagValue.UtcSampleTime.ToDateTime(),
-                tagValue.Values.Select(x => x.ToAdapterVariant()),
+                tagValue.Value.ToAdapterVariant(),
                 tagValue.Status.ToAdapterTagValueStatus(),
                 tagValue.Units,
                 tagValue.Notes,
@@ -1783,13 +1783,8 @@ namespace DataCore.Adapter {
                 Status = tagValue.Status.ToGrpcTagValueStatus(),
                 Units = tagValue.Units ?? string.Empty,
                 UtcSampleTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(tagValue.UtcSampleTime),
+                Value = tagValue.Value.ToGrpcVariant()
             };
-
-            if (tagValue.Values != null) {
-                foreach (var item in tagValue.Values) {
-                    result.Values.Add(item.ToGrpcVariant());
-                }
-            }
 
             if (tagValue.Properties != null) {
                 foreach (var item in tagValue.Properties) {
@@ -1824,13 +1819,8 @@ namespace DataCore.Adapter {
                 Status = tagValue.Status.ToGrpcTagValueStatus(),
                 Units = tagValue.Units ?? string.Empty,
                 UtcSampleTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(tagValue.UtcSampleTime),
+                Value = tagValue.Value.ToGrpcVariant()
             };
-
-            if (tagValue.Values != null) {
-                foreach (var item in tagValue.Values) {
-                    result.Values.Add(item.ToGrpcVariant());
-                }
-            }
 
             return result;
         }

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValueExtended.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValueExtended.cs
@@ -32,11 +32,8 @@ namespace DataCore.Adapter.RealTimeData {
         /// <param name="utcSampleTime">
         ///   The UTC sample time.
         /// </param>
-        /// <param name="values">
-        ///   The values for the sample. In the majority of cases, this collection will contain a 
-        ///   single item. However, multiple items are allowed to account for situations where the 
-        ///   sample represents a digital state, and both the numerical and text values of the state 
-        ///   are being returned.
+        /// <param name="value">
+        ///   The values for the sample.
         /// </param>
         /// <param name="status">
         ///   The quality status for the value.
@@ -55,13 +52,13 @@ namespace DataCore.Adapter.RealTimeData {
         /// </param>
         public TagValueExtended(
             DateTime utcSampleTime, 
-            IEnumerable<Variant> values,
+            Variant value,
             TagValueStatus status, 
             string? units, 
             string? notes, 
             string? error, 
             IEnumerable<AdapterProperty>? properties
-        ) : base(utcSampleTime, values, status, units) {
+        ) : base(utcSampleTime, value, status, units) {
             Notes = notes;
             Error = error;
             Properties = properties?.ToArray() ?? Array.Empty<AdapterProperty>();
@@ -98,7 +95,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// </param>
         [Obsolete("Use constructor directly", true)]
         public static TagValueExtended Create(DateTime utcSampleTime, Variant value, IEnumerable<Variant>? additionalValues, TagValueStatus status, string? units, string? notes, string? error, IEnumerable<AdapterProperty>? properties) {
-            return new TagValueExtended(utcSampleTime, new[] { value }, status, units, notes, error, properties);
+            return new TagValueExtended(utcSampleTime, value, status, units, notes, error, properties);
         }
 
     }

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValueExtensions.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValueExtensions.cs
@@ -11,13 +11,14 @@ namespace DataCore.Adapter.RealTimeData {
     public static class TagValueExtensions {
 
         /// <summary>
-        /// Gets all values in the <see cref="TagValue"/> that have a numeric type.
+        /// Tests if the <see cref="TagValue.Value"/> of a <see cref="TagValue"/> has a numeric type.
         /// </summary>
         /// <param name="value">
         ///   The <see cref="TagValue"/>.
         /// </param>
         /// <returns>
-        ///   The <see cref="TagValue.Values"/> entries that have a numeric type.
+        ///   <see langword="true"/> if the <see cref="TagValue.Value"/> has a numeric type, or <see langword="false"/> 
+        ///   otherwise.
         /// </returns>
         /// <remarks>
         /// 
@@ -62,81 +63,12 @@ namespace DataCore.Adapter.RealTimeData {
         /// All other types are considered to be non-numeric.
         /// 
         /// </remarks>
-        public static IEnumerable<Variant> GetNumericValues(this TagValue value) {
+        public static bool IsNumericType(this TagValue value) {
             if (value == null) {
                 throw new ArgumentNullException(nameof(value));
             }
 
-            foreach (var val in value.Values) {
-                if (val.IsNumericType()) {
-                    yield return val;
-                }
-            }
-        }
-
-
-        /// <summary>
-        /// Gets all values in the <see cref="TagValue"/> that do not have a numeric type.
-        /// </summary>
-        /// <param name="value">
-        ///   The <see cref="TagValue"/>.
-        /// </param>
-        /// <returns>
-        ///   The <see cref="TagValue.Values"/> entries that do not have a numeric type.
-        /// </returns>
-        /// <remarks>
-        /// 
-        /// The following value types are considered to be numeric:
-        /// 
-        /// <list type="bullet">
-        ///   <item>
-        ///     <description><see cref="VariantType.Boolean"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.Byte"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.Double"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.Float"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.Int16"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.Int32"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.Int64"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.SByte"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.UInt16"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.UInt32"/></description>
-        ///   </item>
-        ///   <item>
-        ///     <description><see cref="VariantType.UInt64"/></description>
-        ///   </item>
-        /// </list>
-        /// 
-        /// All other types are considered to be non-numeric.
-        /// 
-        /// </remarks>
-        public static IEnumerable<Variant> GetNonNumericValues(this TagValue value) {
-            if (value == null) {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            foreach (var val in value.Values) {
-                if (!val.IsNumericType()) {
-                    yield return val;
-                }
-            }
+            return value.Value.IsNumericType();
         }
 
 
@@ -184,7 +116,7 @@ namespace DataCore.Adapter.RealTimeData {
                 throw new ArgumentNullException(nameof(value));
             }
 
-            return value.Values.GetValueOrDefault(defaultValue);
+            return value.Value.GetValueOrDefault(defaultValue);
         }
 
     }

--- a/src/DataCore.Adapter.Csv/CsvAdapter.cs
+++ b/src/DataCore.Adapter.Csv/CsvAdapter.cs
@@ -464,19 +464,20 @@ namespace DataCore.Adapter.Csv {
                                 : (object) numericValue
                             : unparsedValue;
 
-                        var builder = new TagValueBuilder()
-                            .WithUtcSampleTime(sampleTime)
-                            .WithValue(primaryValue)
-                            .WithStatus(TagValueStatus.Good)
-                            .WithUnits(tag.Units);
-
+                        string? displayValue = null;
                         if (hasNumericValue && isDigitalTag) {
                             // This is a digital tag; we'll add the digital state name as a secondary value.
                             var state = tag.States.FirstOrDefault(x => x.Value == numericValue);
                             if (state != null) {
-                                builder.WithValue(state.Name);
+                                displayValue = state.Name;
                             }
                         }
+
+                        var builder = new TagValueBuilder()
+                            .WithUtcSampleTime(sampleTime)
+                            .WithValue(primaryValue, displayValue)
+                            .WithStatus(TagValueStatus.Good)
+                            .WithUnits(tag.Units);
 
                         valuesForTag.Add(sampleTime, builder.Build());
                     }

--- a/src/DataCore.Adapter.Json/TagValueConverter.cs
+++ b/src/DataCore.Adapter.Json/TagValueConverter.cs
@@ -17,8 +17,7 @@ namespace DataCore.Adapter.Json {
             }
 
             DateTime utcSampleTime = default;
-            Variant? value = null; 
-            Variant[] values = null!;
+            Variant value = Variant.Null;
             TagValueStatus status = TagValueStatus.Uncertain;
             string units = null!;
 
@@ -35,12 +34,8 @@ namespace DataCore.Adapter.Json {
                 if (string.Equals(propertyName, nameof(TagValue.UtcSampleTime), StringComparison.OrdinalIgnoreCase)) {
                     utcSampleTime = JsonSerializer.Deserialize<DateTime>(ref reader, options);
                 }
-                // Allow a "Value" property with a single value for backwards compatibility.
-                else if (string.Equals(propertyName, "Value", StringComparison.OrdinalIgnoreCase)) {
-                    value = JsonSerializer.Deserialize<Variant>(ref reader, options);
-                }
-                else if (string.Equals(propertyName, nameof(TagValue.Values), StringComparison.OrdinalIgnoreCase)) {
-                    values = JsonSerializer.Deserialize<Variant[]>(ref reader, options)!;
+                else if (string.Equals(propertyName, nameof(TagValue.Value), StringComparison.OrdinalIgnoreCase)) {
+                    value = JsonSerializer.Deserialize<Variant>(ref reader, options)!;
                 }
                 else if (string.Equals(propertyName, nameof(TagValue.Status), StringComparison.OrdinalIgnoreCase)) {
                     status = JsonSerializer.Deserialize<TagValueStatus>(ref reader, options);
@@ -53,9 +48,7 @@ namespace DataCore.Adapter.Json {
                 }
             }
 
-            return value == null 
-                ? new TagValue(utcSampleTime, values, status, units)
-                : new TagValue(utcSampleTime, new[] { value.Value }, status, units);
+            return new TagValue(utcSampleTime, value, status, units);
         }
 
 
@@ -68,7 +61,7 @@ namespace DataCore.Adapter.Json {
 
             writer.WriteStartObject();
             WritePropertyValue(writer, nameof(TagValue.UtcSampleTime), value.UtcSampleTime, options);
-            WritePropertyValue(writer, nameof(TagValue.Values), value.Values, options);
+            WritePropertyValue(writer, nameof(TagValue.Value), value.Value, options);
             WritePropertyValue(writer, nameof(TagValue.Status), value.Status, options);
             WritePropertyValue(writer, nameof(TagValue.Units), value.Units, options);
             writer.WriteEndObject();

--- a/src/DataCore.Adapter.Json/TagValueExtendedConverter.cs
+++ b/src/DataCore.Adapter.Json/TagValueExtendedConverter.cs
@@ -18,8 +18,7 @@ namespace DataCore.Adapter.Json {
             }
 
             DateTime utcSampleTime = default;
-            Variant? value = null;
-            Variant[] values = null!;
+            Variant value = Variant.Null;
             TagValueStatus status = TagValueStatus.Uncertain;
             string units = null!;
             string notes = null!;
@@ -39,12 +38,8 @@ namespace DataCore.Adapter.Json {
                 if (string.Equals(propertyName, nameof(TagValueExtended.UtcSampleTime), StringComparison.OrdinalIgnoreCase)) {
                     utcSampleTime = JsonSerializer.Deserialize<DateTime>(ref reader, options);
                 }
-                // Allow a "Value" property with a single value for backwards compatibility.
-                else if (string.Equals(propertyName, "Value", StringComparison.OrdinalIgnoreCase)) {
-                    value = JsonSerializer.Deserialize<Variant>(ref reader, options);
-                }
-                else if (string.Equals(propertyName, nameof(TagValueExtended.Values), StringComparison.OrdinalIgnoreCase)) {
-                    values = JsonSerializer.Deserialize<Variant[]>(ref reader, options)!;
+                else if (string.Equals(propertyName, nameof(TagValueExtended.Value), StringComparison.OrdinalIgnoreCase)) {
+                    value = JsonSerializer.Deserialize<Variant>(ref reader, options)!;
                 }
                 else if (string.Equals(propertyName, nameof(TagValueExtended.Status), StringComparison.OrdinalIgnoreCase)) {
                     status = JsonSerializer.Deserialize<TagValueStatus>(ref reader, options);
@@ -66,9 +61,7 @@ namespace DataCore.Adapter.Json {
                 }
             }
 
-            return value == null 
-                ? new TagValueExtended(utcSampleTime, values, status, units, notes, error, properties)
-                : new TagValueExtended(utcSampleTime, new[] { value.Value }, status, units, notes, error, properties);
+            return new TagValueExtended(utcSampleTime, value, status, units, notes, error, properties);
         }
 
 
@@ -81,7 +74,7 @@ namespace DataCore.Adapter.Json {
 
             writer.WriteStartObject();
             WritePropertyValue(writer, nameof(TagValueExtended.UtcSampleTime), value.UtcSampleTime, options);
-            WritePropertyValue(writer, nameof(TagValueExtended.Values), value.Values, options);
+            WritePropertyValue(writer, nameof(TagValueExtended.Value), value.Value, options);
             WritePropertyValue(writer, nameof(TagValueExtended.Status), value.Status, options);
             WritePropertyValue(writer, nameof(TagValueExtended.Units), value.Units, options);
             WritePropertyValue(writer, nameof(TagValueExtended.Notes), value.Notes, options);

--- a/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
@@ -17,9 +17,9 @@ namespace DataCore.Adapter.RealTimeData {
         private DateTime _utcSampleTime = DateTime.UtcNow;
 
         /// <summary>
-        /// The values for the sample.
+        /// The value for the sample.
         /// </summary>
-        private readonly List<Variant> _values = new List<Variant>();
+        private Variant _value = Variant.Null;
 
         /// <summary>
         /// The quality status.
@@ -69,7 +69,7 @@ namespace DataCore.Adapter.RealTimeData {
             }
 
             WithUtcSampleTime(existing.UtcSampleTime);
-            WithValues(existing.Values);
+            WithValue(existing.Value);
             WithStatus(existing.Status);
             WithNotes(existing.Notes);
             WithError(existing.Error);
@@ -119,7 +119,7 @@ namespace DataCore.Adapter.RealTimeData {
         ///   A new <see cref="TagValueExtended"/> object.
         /// </returns>
         public TagValueExtended Build() {
-            return new TagValueExtended(_utcSampleTime, _values, _status, _units, _notes, _error, _properties);
+            return new TagValueExtended(_utcSampleTime, _value, _status, _units, _notes, _error, _properties);
         }
 
 
@@ -145,11 +145,20 @@ namespace DataCore.Adapter.RealTimeData {
         /// <param name="value">
         ///   The value.
         /// </param>
+        /// <param name="displayValue">
+        ///   The display value for the sample. Specifying a display value adds a 
+        ///   <see cref="WellKnownProperties.TagValue.DisplayValue"/> property to the sample.
+        /// </param>
         /// <returns>
         ///   The updated <see cref="TagValueBuilder"/>.
         /// </returns>
-        public TagValueBuilder WithValue(Variant value) {
-            return WithValues(value);
+        public TagValueBuilder WithValue(Variant value, string? displayValue = null) {
+            _value = value;
+            var existingDisplayValue = _properties.RemoveAll(x => x.Name.Equals(WellKnownProperties.TagValue.DisplayValue, StringComparison.OrdinalIgnoreCase));
+            if (displayValue != null) {
+                return WithProperty(WellKnownProperties.TagValue.DisplayValue, displayValue);
+            }
+            return this;
         }
 
 
@@ -162,54 +171,15 @@ namespace DataCore.Adapter.RealTimeData {
         /// <param name="value">
         ///   The value.
         /// </param>
-        /// <returns>
-        ///   The updated <see cref="TagValueBuilder"/>.
-        /// </returns>
-        public TagValueBuilder WithValue<T>(T value) {
-            return WithValue(Variant.FromValue(value));
-        }
-
-
-        /// <summary>
-        /// Adds multiple values to the sample.
-        /// </summary>
-        /// <param name="values">
-        ///   The values.
+        /// <param name="displayValue">
+        ///   The display value for the sample. Specifying a display value adds a 
+        ///   <see cref="WellKnownProperties.TagValue.DisplayValue"/> property to the sample.
         /// </param>
         /// <returns>
         ///   The updated <see cref="TagValueBuilder"/>.
         /// </returns>
-        public TagValueBuilder WithValues(params Variant[] values) {
-            return WithValues((IEnumerable<Variant>) values);
-        }
-
-
-        /// <summary>
-        /// Adds multiple values to the sample.
-        /// </summary>
-        /// <param name="values">
-        ///   The values.
-        /// </param>
-        /// <returns>
-        ///   The updated <see cref="TagValueBuilder"/>.
-        /// </returns>
-        public TagValueBuilder WithValues(IEnumerable<Variant> values) {
-            if (values != null) {
-                _values.AddRange(values);
-            }
-            return this;
-        }
-
-
-        /// <summary>
-        /// Removes all value from the sample.
-        /// </summary>
-        /// <returns>
-        ///   The updated <see cref="TagValueBuilder"/>.
-        /// </returns>
-        public TagValueBuilder ClearValues() {
-            _values.Clear();
-            return this;
+        public TagValueBuilder WithValue<T>(T value, string? displayValue = null) {
+            return WithValue(Variant.FromValue(value), displayValue);
         }
 
 

--- a/src/Protos/datacore/adapter/Types.proto
+++ b/src/Protos/datacore/adapter/Types.proto
@@ -313,13 +313,12 @@ enum TagValueStatus {
 
 message TagValue {
     google.protobuf.Timestamp utc_sample_time = 1;
-    // Ordinal 2 is no longer in use.
+    Variant value = 2;
     TagValueStatus status = 3;
     string units = 4;
     string notes = 5;
     string error = 6;
     repeated AdapterProperty properties = 7;
-    repeated Variant values = 8;
 }
 
 

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -601,14 +601,15 @@ namespace DataCore.Adapter.Tests {
                "Name",
                new TagValueExtended(
                    DateTime.UtcNow, 
-                   new[] { Variant.FromValue(100), Variant.FromValue("OPEN") },
+                   Variant.FromValue(100),
                    TagValueStatus.Good, 
                    "Units", 
                    "Notes", 
                    "Error",
                    new[] {
                         AdapterProperty.Create("Prop1", 100),
-                        AdapterProperty.Create("Prop2", "Value")
+                        AdapterProperty.Create("Prop2", "Value"),
+                        AdapterProperty.Create(WellKnownProperties.TagValue.DisplayValue, "OPEN")
                    }
                 ),
                "DataFunction"
@@ -624,14 +625,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expected.Value.Status, actual.Value.Status);
             Assert.AreEqual(expected.Value.Units, actual.Value.Units);
             Assert.AreEqual(expected.Value.Notes, actual.Value.Notes);
-
-            Assert.AreEqual(expected.Value.Values.Count(), actual.Value.Values.Count());
-            for (var i = 0; i < expected.Value.Values.Count(); i++) {
-                var expectedValue = expected.Value.Values.ElementAt(i);
-                var actualValue = actual.Value.Values.ElementAt(i);
-
-                Assert.AreEqual(expectedValue, actualValue);
-            }
+            Assert.AreEqual(expected.Value.Value, actual.Value.Value);
 
             Assert.AreEqual(expected.Value.Properties.Count(), actual.Value.Properties.Count());
             for (var i = 0; i < expected.Value.Properties.Count(); i++) {
@@ -1016,7 +1010,7 @@ namespace DataCore.Adapter.Tests {
             var expected =
             new TagValue(
                 DateTime.UtcNow,
-                new[] { Variant.FromValue(100), Variant.FromValue("OPEN") },
+                Variant.FromValue(100),
                 TagValueStatus.Good,
                 "Units"
             );
@@ -1028,13 +1022,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expected.Status, actual.Status);
             Assert.AreEqual(expected.Units, actual.Units);
 
-            Assert.AreEqual(expected.Values.Count(), actual.Values.Count());
-            for (var i = 0; i < expected.Values.Count(); i++) {
-                var expectedValue = expected.Values.ElementAt(i);
-                var actualValue = actual.Values.ElementAt(i);
-
-                Assert.AreEqual(expectedValue, actualValue);
-            }
+            Assert.AreEqual(expected.Value, actual.Value);
         }
 
 
@@ -1044,14 +1032,15 @@ namespace DataCore.Adapter.Tests {
             var expected =
             new TagValueExtended(
                 DateTime.UtcNow,
-                new[] { Variant.FromValue(100),Variant.FromValue("OPEN") },
+                Variant.FromValue(100),
                 TagValueStatus.Good,
                 "Units",
                 "Notes",
                 "Error",
                 new[] {
                     AdapterProperty.Create("Prop1", 100),
-                    AdapterProperty.Create("Prop2", "Value")
+                    AdapterProperty.Create("Prop2", "Value"),
+                    AdapterProperty.Create(WellKnownProperties.TagValue.DisplayValue, "OPEN")
                 }
             );
 
@@ -1063,13 +1052,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expected.Units, actual.Units);
             Assert.AreEqual(expected.Notes, actual.Notes);
 
-            Assert.AreEqual(expected.Values.Count(), actual.Values.Count());
-            for (var i = 0; i < expected.Values.Count(); i++) {
-                var expectedValue = expected.Values.ElementAt(i);
-                var actualValue = actual.Values.ElementAt(i);
-
-                Assert.AreEqual(expectedValue, actualValue);
-            }
+            Assert.AreEqual(expected.Value, actual.Value);
 
             Assert.AreEqual(expected.Properties.Count(), actual.Properties.Count());
             for (var i = 0; i < expected.Properties.Count(); i++) {
@@ -1090,14 +1073,15 @@ namespace DataCore.Adapter.Tests {
                "Name",
                new TagValueExtended(
                    DateTime.UtcNow,
-                   new[] { Variant.FromValue(100),Variant.FromValue("OPEN") },
+                   Variant.FromValue(100),
                    TagValueStatus.Good,
                    "Units",
                    "Notes",
                    "Error",
                    new[] {
                         AdapterProperty.Create("Prop1", 100),
-                        AdapterProperty.Create("Prop2", "Value")
+                        AdapterProperty.Create("Prop2", "Value"),
+                        AdapterProperty.Create(WellKnownProperties.TagValue.DisplayValue, "OPEN")
                    }
                 )
             );
@@ -1112,13 +1096,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expected.Value.Units, actual.Value.Units);
             Assert.AreEqual(expected.Value.Notes, actual.Value.Notes);
 
-            Assert.AreEqual(expected.Value.Values.Count(), actual.Value.Values.Count());
-            for (var i = 0; i < expected.Value.Values.Count(); i++) {
-                var expectedValue = expected.Value.Values.ElementAt(i);
-                var actualValue = actual.Value.Values.ElementAt(i);
-
-                Assert.AreEqual(expectedValue, actualValue);
-            }
+            Assert.AreEqual(expected.Value.Value, actual.Value.Value);
 
             Assert.AreEqual(expected.Value.Properties.Count(), actual.Value.Properties.Count());
             for (var i = 0; i < expected.Value.Properties.Count(); i++) {


### PR DESCRIPTION
The move to allow multiple values on `TagValue` and `TagValueExtended` types in #93 is unnecessarily confusing, given that the only real use case is to be able to return both the numeric value and display value for a digital state.

This commit reverses the changes by removing the `Values` property on a tag value and re-adding the original `Value` property, so that the value is only a single `Variant` again.

To allow digital state names to be passed as part of a `TagValueExtended`, the `WellKnownProperties` type has been added to provide well-known property names that can be added to adapter entities. The display value for a tag value can therefore be specified as a bespoke property on the tag value.

There is still a use case for allowing multiple values to be passed in a tag value (e.g. the use of multidimensional arrays in OPC UA, or data sets/data tables in MTConnect), but this is best solved by improvements to the `Variant` type itself to support multidimensional arrays (and possibly key-value maps).