### PR TITLE
Support arrays in Variant values

### DIFF
--- a/src/DataCore.Adapter.Core/AssemblyAttributes.cs
+++ b/src/DataCore.Adapter.Core/AssemblyAttributes.cs
@@ -1,0 +1,5 @@
+﻿using System.Runtime.CompilerServices;
+
+// DataCore.Adapter.Json is allowed to use internals from this assembly so that it can correctly 
+// deserialize Variant instances.
+[assembly: InternalsVisibleTo("DataCore.Adapter.Json")]

--- a/src/DataCore.Adapter.Core/Common/Variant.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.cs
@@ -55,24 +55,6 @@ namespace DataCore.Adapter.Common {
         public static Variant Null { get; } = new Variant(null, VariantType.Null, null);
 
         /// <summary>
-        /// The <see cref="VariantType"/> flags to use when trying to parse a value when a 
-        /// value of <see cref="VariantType.Unknown"/> is specified.
-        /// </summary>
-        private static readonly VariantType[] s_tryParseUnknownVariantTypes = {
-            VariantType.Boolean,
-            VariantType.Int32,
-            VariantType.Int64,
-            VariantType.UInt32,
-            VariantType.UInt64,
-            VariantType.Double,
-            VariantType.DateTime,
-            VariantType.TimeSpan,
-            VariantType.Url,
-            // String comes last as it is our final fallback.
-            VariantType.String
-        };
-
-        /// <summary>
         /// The value.
         /// </summary>
         public object? Value { get; }
@@ -121,11 +103,32 @@ namespace DataCore.Adapter.Common {
         ///   <paramref name="value"/> is not a supported type. See <see cref="VariantTypeMap"/> 
         ///   for supported types.
         /// </exception>
+        /// <remarks>
+        ///   
+        /// <para>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </para>
+        /// 
+        /// <para>
+        ///   If <paramref name="value"/> is a <see cref="Variant"/>, the new <see cref="Variant"/> 
+        ///   will be a copy of the existing <paramref name="value"/>.
+        /// </para>
+        /// 
+        /// <para>
+        ///   For any other type, the type of <paramref name="value"/> must have an entry in the 
+        ///   <see cref="VariantTypeMap"/> mapping. If <paramref name="value"/> is an <see cref="Array"/> 
+        ///   type, the element type of the array must have an entry in the <see cref="VariantTypeMap"/> 
+        ///   mapping.
+        /// </para>
+        /// 
+        /// </remarks>
+        /// <seealso cref="VariantTypeMap"/>
         public Variant(object? value) {
             if (value == null) {
-                Value = null;
-                Type = VariantType.Null;
-                ArrayDimensions = null;
+                Value = Null.Value;
+                Type = Null.Type;
+                ArrayDimensions = Null.ArrayDimensions;
                 return;
             }
 
@@ -155,7 +158,7 @@ namespace DataCore.Adapter.Common {
         }
 
 
-        
+
 
         /// <summary>
         /// Creates a new <see cref="Variant"/> object from the specified array.
@@ -167,6 +170,22 @@ namespace DataCore.Adapter.Common {
         ///   The element type of <paramref name="value"/> is not a supported type. See 
         ///   <see cref="VariantTypeMap"/> for supported types.
         /// </exception>
+        /// <remarks>
+        ///   
+        /// <para>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </para>
+        /// 
+        /// <para>
+        ///   For any other type, the type of <paramref name="value"/> must have an entry in the 
+        ///   <see cref="VariantTypeMap"/> mapping. If <paramref name="value"/> is an <see cref="Array"/> 
+        ///   type, the element type of the array must have an entry in the <see cref="VariantTypeMap"/> 
+        ///   mapping.
+        /// </para>
+        /// 
+        /// </remarks>
+        /// <seealso cref="VariantTypeMap"/>
         public Variant(Array? value) {
             if (value == null) {
                 Value = null;
@@ -254,159 +273,6 @@ namespace DataCore.Adapter.Common {
             }
 
             return new Variant(value);
-        }
-
-
-        /// <summary>
-        /// Tries to parse the specified string into a <see cref="Variant"/>, using the provided 
-        /// <paramref name="type"/> hint to identify the target value type.
-        /// </summary>
-        /// <param name="s">
-        ///   The string.
-        /// </param>
-        /// <param name="type">
-        ///   The value type for the variant. Specify <see cref="VariantType.Unknown"/> to try and 
-        ///   detect the value type automatically.
-        /// </param>
-        /// <param name="provider">
-        ///   The format provider to use. Can be <see langword="null"/>.
-        /// </param>
-        /// <param name="variant">
-        ///   The parsed <see cref="Variant"/> instance.
-        /// </param>
-        /// <returns>
-        ///   <see langword="true"/> if the string was successfully parsed, or <see langword="false"/> 
-        ///   otherwise.
-        /// </returns>
-        public static bool TryParse(string s, VariantType type, IFormatProvider? provider, out Variant variant) {
-            if (s == null) {
-                variant = Null;
-                return type == VariantType.Null;
-            }
-
-            switch (type) {
-                case VariantType.Boolean:
-                    if (bool.TryParse(s, out var boolResult)) {
-                        variant = FromValue(boolResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.Byte:
-                    if (byte.TryParse(s, System.Globalization.NumberStyles.Integer, provider, out var byteResult)) {
-                        variant = FromValue(byteResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.DateTime:
-                    if (DateTime.TryParse(s, provider, System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal, out var dateResult)) {
-                        variant = FromValue(dateResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.Double:
-                    if (double.TryParse(s, System.Globalization.NumberStyles.Float | System.Globalization.NumberStyles.AllowThousands, provider, out var doubleResult)) {
-                        variant = FromValue(doubleResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.Float:
-                    if (float.TryParse(s, System.Globalization.NumberStyles.Float | System.Globalization.NumberStyles.AllowThousands, provider, out var floatResult)) {
-                        variant = FromValue(floatResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.Int16:
-                    if (short.TryParse(s, System.Globalization.NumberStyles.Integer, provider, out var shortResult)) {
-                        variant = FromValue(shortResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.Int32:
-                    if (int.TryParse(s, System.Globalization.NumberStyles.Integer, provider, out var intResult)) {
-                        variant = FromValue(intResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.Int64:
-                    if (long.TryParse(s, System.Globalization.NumberStyles.Integer, provider, out var longResult)) {
-                        variant = FromValue(longResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.SByte:
-                    if (sbyte.TryParse(s, System.Globalization.NumberStyles.Integer, provider, out var sbyteResult)) {
-                        variant = FromValue(sbyteResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.String:
-                    variant = FromValue(s);
-                    return true;
-                case VariantType.TimeSpan:
-                    if (TimeSpan.TryParse(s, provider, out var timeSpanResult)) {
-                        variant = FromValue(timeSpanResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.UInt16:
-                    if (ushort.TryParse(s, System.Globalization.NumberStyles.Integer, provider, out var ushortResult)) {
-                        variant = FromValue(ushortResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.UInt32:
-                    if (uint.TryParse(s, System.Globalization.NumberStyles.Integer, provider, out var uintResult)) {
-                        variant = FromValue(uintResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.UInt64:
-                    if (ulong.TryParse(s, System.Globalization.NumberStyles.Integer, provider, out var ulongResult)) {
-                        variant = FromValue(ulongResult);
-                        return true;
-                    }
-                    break;
-                case VariantType.Unknown:
-                    foreach (var vType in s_tryParseUnknownVariantTypes) {
-                        if (TryParse(s, vType, provider, out var v)) {
-                            variant = v;
-                            return true;
-                        }
-                    }
-                    break;
-                case VariantType.Url:
-                    if (Uri.TryCreate(s, UriKind.Absolute, out var url)) {
-                        variant = FromValue(url);
-                        return true;
-                    }
-                    break;
-            }
-
-            variant = Null;
-            return false;
-        }
-
-
-        /// <summary>
-        /// Tries to parse the specified string into a <see cref="Variant"/>, using the provided 
-        /// <paramref name="type"/> hint to identify the target value type.
-        /// </summary>
-        /// <param name="s">
-        ///   The string.
-        /// </param>
-        /// <param name="type">
-        ///   The value type for the variant. Specify <see cref="VariantType.Unknown"/> to try and 
-        ///   detect the value type automatically.
-        /// </param>
-        /// <param name="variant">
-        ///   The parsed <see cref="Variant"/> instance.
-        /// </param>
-        /// <returns>
-        ///   <see langword="true"/> if the string was successfully parsed, or <see langword="false"/> 
-        ///   otherwise.
-        /// </returns>
-        public static bool TryParse(string s, VariantType type, out Variant variant) {
-            return TryParse(s, type, null, out variant);
         }
 
 
@@ -512,7 +378,7 @@ namespace DataCore.Adapter.Common {
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) {
-            if (!(obj is Variant v)) {
+            if (obj is not Variant v) {
                 return false;
             }
 

--- a/src/DataCore.Adapter.Core/Common/Variant.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.cs
@@ -1,12 +1,33 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace DataCore.Adapter.Common {
 
     /// <summary>
     /// Describes a variant value.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Not required at this time")]
     public struct Variant : IEquatable<Variant>, IFormattable {
+
+        /// <summary>
+        /// Maps from type to variant type.
+        /// </summary>
+        public static IReadOnlyDictionary<Type, VariantType> VariantTypeMap { get; } = new System.Collections.ObjectModel.ReadOnlyDictionary<Type, VariantType>(new Dictionary<Type, VariantType>() {
+            { typeof(bool), VariantType.Boolean },
+            { typeof(byte), VariantType.Byte },
+            { typeof(DateTime), VariantType.DateTime },
+            { typeof(double), VariantType.Double },
+            { typeof(float), VariantType.Float },
+            { typeof(short), VariantType.Int16 },
+            { typeof(int), VariantType.Int32 },
+            { typeof(long), VariantType.Int64 },
+            { typeof(sbyte), VariantType.SByte },
+            { typeof(string), VariantType.String },
+            { typeof(TimeSpan), VariantType.TimeSpan },
+            { typeof(ushort), VariantType.UInt16 },
+            { typeof(uint), VariantType.UInt32 },
+            { typeof(ulong), VariantType.UInt64 },
+            { typeof(Uri), VariantType.Url }
+        });
 
         /// <summary>
         /// Default string format to use for date-time variant values (ISO 8601-1:2019 extended profile).
@@ -31,7 +52,7 @@ namespace DataCore.Adapter.Common {
         /// <summary>
         /// Null variant.
         /// </summary>
-        public static Variant Null { get; } = FromValue(null);
+        public static Variant Null { get; } = new Variant(null, VariantType.Null, null);
 
         /// <summary>
         /// The <see cref="VariantType"/> flags to use when trying to parse a value when a 
@@ -61,6 +82,13 @@ namespace DataCore.Adapter.Common {
         /// </summary>
         public VariantType Type { get; }
 
+        /// <summary>
+        /// If <see cref="Value"/> is an array, <see cref="ArrayDimensions"/> defines the 
+        /// dimensions of the array. For all other values, this property will be 
+        /// <see langword="null"/>.
+        /// </summary>
+        public int[]? ArrayDimensions { get; }
+
 
         /// <summary>
         /// Creates a new <see cref="Variant"/> object. It is preferable to call <see cref="FromValue"/> 
@@ -73,10 +101,132 @@ namespace DataCore.Adapter.Common {
         /// <param name="type">
         ///   The variant type.
         /// </param>
-        public Variant(object? value, VariantType type) {
+        /// <param name="arrayDimensions">
+        ///   The array dimensions of the value, if it is an array.
+        /// </param>
+        internal Variant(object? value, VariantType type, int[]? arrayDimensions) {
             Value = value;
             Type = type;
+            ArrayDimensions = arrayDimensions;
         }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> object from the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/> is not a supported type. See <see cref="VariantTypeMap"/> 
+        ///   for supported types.
+        /// </exception>
+        public Variant(object? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            if (value is Variant v) {
+                Value = v.Value;
+                Type = v.Type;
+                ArrayDimensions = v.ArrayDimensions;
+                return;
+            }
+
+            VariantType variantType;
+            int[]? arrayDimensions = null;
+
+            if (value is Array a) {
+                GetArraySettings(a, out variantType, out arrayDimensions);
+            }
+            else {
+                var valueType = value.GetType();
+                if (!VariantTypeMap.TryGetValue(valueType, out variantType)) {
+                    throw new ArgumentOutOfRangeException(nameof(value), valueType, SharedResources.Error_TypeIsUnsupported);
+                }
+            }
+
+            Value = value;
+            Type = variantType;
+            ArrayDimensions = arrayDimensions;
+        }
+
+
+        
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> object from the specified array.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   The element type of <paramref name="value"/> is not a supported type. See 
+        ///   <see cref="VariantTypeMap"/> for supported types.
+        /// </exception>
+        public Variant(Array? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            GetArraySettings(value!, out var variantType, out var arrayDimensions);
+
+            Value = value;
+            Type = variantType;
+            ArrayDimensions = arrayDimensions;
+        }
+
+
+        /// <summary>
+        /// Gets the <see cref="VariantType"/> and array dimensions for the specified array.
+        /// </summary>
+        /// <param name="value">
+        ///   The array.
+        /// </param>
+        /// <param name="variantType">
+        ///   The <see cref="VariantType"/> for the array's element type.
+        /// </param>
+        /// <param name="arrayDimensions">
+        ///   The dimensions of the array.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   The element type of <paramref name="value"/> is not a supported type. See 
+        ///   <see cref="VariantTypeMap"/> for supported types.
+        /// </exception>
+        private static void GetArraySettings(Array value, out VariantType variantType, out int[] arrayDimensions) {
+            Type? elemType = value.GetType().GetElementType();
+            if (elemType == null || !VariantTypeMap.TryGetValue(elemType, out variantType)) {
+                throw new ArgumentOutOfRangeException(nameof(value), elemType, SharedResources.Error_ArrayElementTypeIsUnsupported);
+            }
+
+            arrayDimensions = new int[value.Rank];
+            for (int i = 0; i < value.Rank; i++) {
+                arrayDimensions[i] = value.GetLength(i);
+            }
+        }
+
+
+        /// <summary>
+        /// Tests if the specified variant has a type of <see cref="VariantType.Null"/> or a 
+        /// <see langword="null"/> value.
+        /// </summary>
+        /// <param name="variant">
+        ///   The variant.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the variant type is <see cref="VariantType.Null"/> or the 
+        ///   variant value is <see langword="null"/>, or <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool IsNull(Variant variant) {
+            return variant.Type == VariantType.Null || variant.Value == null;
+        }
+
 
 
         /// <summary>
@@ -86,27 +236,24 @@ namespace DataCore.Adapter.Common {
         /// <param name="value">
         ///   The value.
         /// </param>
-        /// <param name="typeOverride">
-        ///   When a value is provided, the <see cref="Type"/> of the resulting variant is set to 
-        ///   this value instead of being inferred from the <paramref name="value"/>.
-        /// </param>
         /// <remarks>
         ///   If <paramref name="value"/> is a <see cref="Variant"/>, it will be returned 
         ///   unmodified.
         /// </remarks>
-        public static Variant FromValue(object? value, VariantType? typeOverride = null) {
+        public static Variant FromValue(object? value) {
+            if (value == null) {
+                return Null;
+            }
+
             if (value is Variant v) {
                 return v;
             }
 
-            return new Variant(
-                value,
-                typeOverride.HasValue
-                    ? typeOverride.Value
-                    : value == null
-                        ? VariantType.Null
-                        : value.GetType().GetVariantType()
-            );
+            if (value is Array a) {
+                return new Variant(a);
+            }
+
+            return new Variant(value);
         }
 
 
@@ -186,9 +333,6 @@ namespace DataCore.Adapter.Common {
                         return true;
                     }
                     break;
-                case VariantType.Object:
-                    variant = FromValue(s, VariantType.Object);
-                    return true;
                 case VariantType.SByte:
                     if (sbyte.TryParse(s, System.Globalization.NumberStyles.Integer, provider, out var sbyteResult)) {
                         variant = FromValue(sbyteResult);
@@ -341,6 +485,10 @@ namespace DataCore.Adapter.Common {
                 return s;
             }
 
+            if (Value is Array a) {
+                return a.ToString();
+            }
+
             try {
                 return (format != null && Value is IFormattable formattable)
                     ? formattable.ToString(format, formatProvider)
@@ -396,12 +544,24 @@ namespace DataCore.Adapter.Common {
         /// <inheritdoc/>
         public static explicit operator bool(Variant val) => val.Value == null ? default : (bool) val.Value;
 
+        /// <inheritdoc/>
+        public static implicit operator Variant(bool[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator bool[]?(Variant val) => (bool[]?) val.Value;
+
 
         /// <inheritdoc/>
         public static implicit operator Variant(sbyte val) => FromValue(val);
 
         /// <inheritdoc/>
         public static explicit operator sbyte(Variant val) => val.Value == null ? default : (sbyte) val.Value;
+
+        /// <inheritdoc/>
+        public static implicit operator Variant(sbyte[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator sbyte[]?(Variant val) => (sbyte[]?) val.Value;
 
 
         /// <inheritdoc/>
@@ -410,12 +570,24 @@ namespace DataCore.Adapter.Common {
         /// <inheritdoc/>
         public static explicit operator byte(Variant val) => val.Value == null ? default : (byte) val.Value;
 
+        /// <inheritdoc/>
+        public static implicit operator Variant(byte[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator byte[]?(Variant val) => (byte[]?) val.Value;
+
 
         /// <inheritdoc/>
         public static implicit operator Variant(short val) => FromValue(val);
 
         /// <inheritdoc/>
         public static explicit operator short(Variant val) => val.Value == null ? default : (short) val.Value;
+
+        /// <inheritdoc/>
+        public static implicit operator Variant(short[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator short[]?(Variant val) => (short[]?) val.Value;
 
 
         /// <inheritdoc/>
@@ -424,12 +596,24 @@ namespace DataCore.Adapter.Common {
         /// <inheritdoc/>
         public static explicit operator ushort(Variant val) => val.Value == null ? default : (ushort) val.Value;
 
+        /// <inheritdoc/>
+        public static implicit operator Variant(ushort[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator ushort[]?(Variant val) => (ushort[]?) val.Value;
+
 
         /// <inheritdoc/>
         public static implicit operator Variant(int val) => FromValue(val);
 
         /// <inheritdoc/>
         public static explicit operator int(Variant val) => val.Value == null ? default : (int) val.Value;
+
+        /// <inheritdoc/>
+        public static implicit operator Variant(int[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator int[]?(Variant val) => (int[]?) val.Value;
 
 
         /// <inheritdoc/>
@@ -438,12 +622,24 @@ namespace DataCore.Adapter.Common {
         /// <inheritdoc/>
         public static explicit operator uint(Variant val) => val.Value == null ? default : (uint) val.Value;
 
+        /// <inheritdoc/>
+        public static implicit operator Variant(uint[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator uint[]?(Variant val) => (uint[]?) val.Value;
+
 
         /// <inheritdoc/>
         public static implicit operator Variant(long val) => FromValue(val);
 
         /// <inheritdoc/>
         public static explicit operator long(Variant val) => val.Value == null ? default : (long) val.Value;
+
+        /// <inheritdoc/>
+        public static implicit operator Variant(long[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator long[]?(Variant val) => (long[]?) val.Value;
 
 
         /// <inheritdoc/>
@@ -452,12 +648,24 @@ namespace DataCore.Adapter.Common {
         /// <inheritdoc/>
         public static explicit operator ulong(Variant val) => val.Value == null ? default : (ulong) val.Value;
 
+        /// <inheritdoc/>
+        public static implicit operator Variant(ulong[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator ulong[]?(Variant val) => (ulong[]?) val.Value;
+
 
         /// <inheritdoc/>
         public static implicit operator Variant(float val) => FromValue(val);
 
         /// <inheritdoc/>
         public static explicit operator float(Variant val) => val.Value == null ? default : (float) val.Value;
+
+        /// <inheritdoc/>
+        public static implicit operator Variant(float[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator float[]?(Variant val) => (float[]?) val.Value;
 
 
         /// <inheritdoc/>
@@ -466,12 +674,24 @@ namespace DataCore.Adapter.Common {
         /// <inheritdoc/>
         public static explicit operator double(Variant val) => val.Value == null ? default : (double) val.Value;
 
+        /// <inheritdoc/>
+        public static implicit operator Variant(double[]? val) => FromValue(val);
 
         /// <inheritdoc/>
-        public static implicit operator Variant(string val) => FromValue(val);
+        public static explicit operator double[]?(Variant val) => (double[]?) val.Value;
+
 
         /// <inheritdoc/>
-        public static explicit operator string(Variant val) => (string) val.Value!;
+        public static implicit operator Variant(string? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator string?(Variant val) => (string?) val.Value!;
+
+        /// <inheritdoc/>
+        public static implicit operator Variant(string[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator string[]?(Variant val) => (string[]?) val.Value;
 
 
         /// <inheritdoc/>
@@ -480,6 +700,12 @@ namespace DataCore.Adapter.Common {
         /// <inheritdoc/>
         public static explicit operator Uri(Variant val) => (Uri) val.Value!;
 
+        /// <inheritdoc/>
+        public static implicit operator Variant(Uri[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator Uri[]?(Variant val) => (Uri[]?) val.Value;
+
 
         /// <inheritdoc/>
         public static implicit operator Variant(DateTime val) => FromValue(val);
@@ -487,12 +713,24 @@ namespace DataCore.Adapter.Common {
         /// <inheritdoc/>
         public static explicit operator DateTime(Variant val) => val.Value == null ? default : (DateTime) val.Value;
 
+        /// <inheritdoc/>
+        public static implicit operator Variant(DateTime[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator DateTime[]?(Variant val) => (DateTime[]?) val.Value;
+
 
         /// <inheritdoc/>
         public static implicit operator Variant(TimeSpan val) => FromValue(val);
 
         /// <inheritdoc/>
         public static explicit operator TimeSpan(Variant val) => val.Value == null ? default : (TimeSpan) val.Value;
+
+        /// <inheritdoc/>
+        public static implicit operator Variant(TimeSpan[]? val) => FromValue(val);
+
+        /// <inheritdoc/>
+        public static explicit operator TimeSpan[]?(Variant val) => (TimeSpan[]?) val.Value;
 
     }
 

--- a/src/DataCore.Adapter.Core/Common/VariantExtensions.cs
+++ b/src/DataCore.Adapter.Core/Common/VariantExtensions.cs
@@ -10,27 +10,6 @@ namespace DataCore.Adapter.Common {
     /// </summary>
     public static class VariantExtensions {
 
-        /// <summary>
-        /// Maps from type to variant type.
-        /// </summary>
-        private static readonly Dictionary<Type, VariantType> s_variantTypeMap = new Dictionary<Type, VariantType>() {
-            { typeof(bool), VariantType.Boolean },
-            { typeof(byte), VariantType.Byte },
-            { typeof(DateTime), VariantType.DateTime },
-            { typeof(double), VariantType.Double },
-            { typeof(float), VariantType.Float },
-            { typeof(short), VariantType.Int16 },
-            { typeof(int), VariantType.Int32 },
-            { typeof(long), VariantType.Int64 },
-            { typeof(sbyte), VariantType.SByte },
-            { typeof(string), VariantType.String },
-            { typeof(TimeSpan), VariantType.TimeSpan },
-            { typeof(ushort), VariantType.UInt16 },
-            { typeof(uint), VariantType.UInt32 },
-            { typeof(ulong), VariantType.UInt64 },
-            { typeof(Uri), VariantType.Url }
-        };
-
 
         /// <summary>
         /// Tests if a variant contains a null value.
@@ -211,13 +190,11 @@ namespace DataCore.Adapter.Common {
                 return VariantType.Unknown;
             }
 
-            if (s_variantTypeMap.TryGetValue(type, out var variantType)) {
+            if (Variant.VariantTypeMap.TryGetValue(type, out var variantType)) {
                 return variantType;
             }
 
-            return type.IsValueType
-                ? VariantType.Unknown
-                : VariantType.Object;
+            return VariantType.Unknown;
         }
 
 
@@ -231,7 +208,7 @@ namespace DataCore.Adapter.Common {
         ///   The CLR type to for the variant type.
         /// </returns>
         public static Type GetClrType(this VariantType type) {
-            var item = s_variantTypeMap.FirstOrDefault(x => x.Value == type).Key;
+            var item = Variant.VariantTypeMap.FirstOrDefault(x => x.Value == type).Key;
             return item ?? typeof(object);
         }
 
@@ -372,6 +349,21 @@ namespace DataCore.Adapter.Common {
             }
 
             return defaultValue;
+        }
+
+
+        /// <summary>
+        /// Tests if this <see cref="Variant"/> value contains an array.
+        /// </summary>
+        /// <param name="variant">
+        ///   The variant.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the variant is an array, or <see langword="false"/> 
+        ///   otherwise.
+        /// </returns>
+        public static bool IsArray(this Variant variant) {
+            return variant.Value is Array;
         }
 
     }

--- a/src/DataCore.Adapter.Core/Common/VariantType.cs
+++ b/src/DataCore.Adapter.Core/Common/VariantType.cs
@@ -9,92 +9,92 @@
         /// <summary>
         /// Unknown value type.
         /// </summary>
-        Unknown,
+        Unknown = 0,
 
         /// <summary>
         /// No value.
         /// </summary>
-        Null,
+        Null = 1,
 
-        /// <summary>
-        /// Custom object.
-        /// </summary>
-        Object,
+        ///// <summary>
+        ///// Custom object.
+        ///// </summary>
+        //Object = 2,
 
         /// <summary>
         /// Boolean.
         /// </summary>
-        Boolean,
+        Boolean = 3,
 
         /// <summary>
         /// Signed byte.
         /// </summary>
-        SByte,
+        SByte = 4,
 
         /// <summary>
         /// Unsigned byte.
         /// </summary>
-        Byte,
+        Byte = 5,
 
         /// <summary>
         /// Signed 16-bit integer.
         /// </summary>
-        Int16,
+        Int16 = 6,
 
         /// <summary>
         /// Unsigned 16-bit integer.
         /// </summary>
-        UInt16,
+        UInt16 = 7,
 
         /// <summary>
         /// Signed 32-bit integer.
         /// </summary>
-        Int32,
+        Int32 = 8,
 
         /// <summary>
         /// Unsigned 32-bit integer.
         /// </summary>
-        UInt32,
+        UInt32 = 9,
 
         /// <summary>
         /// Signed 64-bit integer.
         /// </summary>
-        Int64,
+        Int64 = 10,
 
         /// <summary>
         /// Unsigned 64-bit integer.
         /// </summary>
-        UInt64,
+        UInt64 = 11,
 
         /// <summary>
         /// Single precision floating point number.
         /// </summary>
-        Float,
+        Float = 12,
 
         /// <summary>
         /// Double precision floating point number.
         /// </summary>
-        Double,
+        Double = 13,
 
         /// <summary>
         /// String.
         /// </summary>
-        String,
+        String = 14,
 
         /// <summary>
         /// Timestamp.
         /// </summary>
-        DateTime,
+        DateTime = 15,
 
         /// <summary>
         /// Time span.
         /// </summary>
-        TimeSpan,
+        TimeSpan = 16,
 
         /// <summary>
         /// URL
         /// </summary>
-        Url
+        Url = 17
 
     }
 

--- a/src/DataCore.Adapter.Core/SharedResources.Designer.cs
+++ b/src/DataCore.Adapter.Core/SharedResources.Designer.cs
@@ -70,11 +70,11 @@ namespace DataCore.Adapter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You must specify one or more values..
+        ///   Looks up a localized string similar to Array element type is unsupported..
         /// </summary>
-        public static string Error_AtLeastOneValueIsRequired {
+        public static string Error_ArrayElementTypeIsUnsupported {
             get {
-                return ResourceManager.GetString("Error_AtLeastOneValueIsRequired", resourceCulture);
+                return ResourceManager.GetString("Error_ArrayElementTypeIsUnsupported", resourceCulture);
             }
         }
         
@@ -264,6 +264,15 @@ namespace DataCore.Adapter {
         public static string Error_TypeIsRequired {
             get {
                 return ResourceManager.GetString("Error_TypeIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type is unsupported..
+        /// </summary>
+        public static string Error_TypeIsUnsupported {
+            get {
+                return ResourceManager.GetString("Error_TypeIsUnsupported", resourceCulture);
             }
         }
         

--- a/src/DataCore.Adapter.Core/SharedResources.resx
+++ b/src/DataCore.Adapter.Core/SharedResources.resx
@@ -120,8 +120,8 @@
   <data name="Error_AbsoluteUriRequired" xml:space="preserve">
     <value>An absolute URI is required.</value>
   </data>
-  <data name="Error_AtLeastOneValueIsRequired" xml:space="preserve">
-    <value>You must specify one or more values.</value>
+  <data name="Error_ArrayElementTypeIsUnsupported" xml:space="preserve">
+    <value>Array element type is unsupported.</value>
   </data>
   <data name="Error_ContentTypeIsRequired" xml:space="preserve">
     <value>You must specify a content type.</value>
@@ -185,6 +185,9 @@
   </data>
   <data name="Error_TypeIsRequired" xml:space="preserve">
     <value>You must specify a type.</value>
+  </data>
+  <data name="Error_TypeIsUnsupported" xml:space="preserve">
+    <value>Type is unsupported.</value>
   </data>
   <data name="HostInfo_Unspecified_Description" xml:space="preserve">
     <value>Host information has not been provided.</value>

--- a/src/DataCore.Adapter.Json/Resources.Designer.cs
+++ b/src/DataCore.Adapter.Json/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace DataCore.Adapter.Json {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You must specify the length of at least one array dimension..
+        /// </summary>
+        internal static string Error_ArrayDimensionsMustBeSpecified {
+            get {
+                return ResourceManager.GetString("Error_ArrayDimensionsMustBeSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified JSON cannot be converted to an instance of {0}..
         /// </summary>
         internal static string Error_InvalidJsonStructure {
@@ -84,6 +93,15 @@ namespace DataCore.Adapter.Json {
         internal static string Error_NoJsonConverter {
             get {
                 return ResourceManager.GetString("Error_NoJsonConverter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Arrays can only be deserialized from JSON array elements..
+        /// </summary>
+        internal static string Error_NotAJsonArray {
+            get {
+                return ResourceManager.GetString("Error_NotAJsonArray", resourceCulture);
             }
         }
     }

--- a/src/DataCore.Adapter.Json/Resources.resx
+++ b/src/DataCore.Adapter.Json/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Error_ArrayDimensionsMustBeSpecified" xml:space="preserve">
+    <value>You must specify the length of at least one array dimension.</value>
+  </data>
   <data name="Error_InvalidJsonStructure" xml:space="preserve">
     <value>The specified JSON cannot be converted to an instance of {0}.</value>
     <comment>{0} - type name</comment>
@@ -127,5 +130,8 @@
   <data name="Error_NoJsonConverter" xml:space="preserve">
     <value>No JSON converter is available for type {0}.</value>
     <comment>{0} - type name</comment>
+  </data>
+  <data name="Error_NotAJsonArray" xml:space="preserve">
+    <value>Arrays can only be deserialized from JSON array elements.</value>
   </data>
 </root>

--- a/src/Protos/datacore/adapter/Types.proto
+++ b/src/Protos/datacore/adapter/Types.proto
@@ -34,6 +34,7 @@ enum VariantType {
 message Variant {
     VariantType type = 1;
     bytes value = 2;
+    repeated int32 array_dimensions = 3;
 }
 
 

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -32,29 +32,46 @@ namespace DataCore.Adapter.Tests {
             var deserialized = JsonSerializer.Deserialize<Variant>(json, options);
             Assert.AreEqual(variant.Type, deserialized.Type);
 
-            var actualVal = (deserialized.Type == VariantType.Object || deserialized.Type == VariantType.Unknown) && deserialized.Value is JsonElement jsonElement
+            var actualVal = (deserialized.Type == VariantType.Unknown) && deserialized.Value is JsonElement jsonElement
                 ? JsonSerializer.Deserialize<T>(jsonElement.GetRawText(), options)
                 : deserialized.Value;
 
-            Assert.AreEqual(variant.Value, actualVal);
+            if (variant.IsArray()) {
+                Assert.IsTrue(((Array) variant.Value).Cast<object>().SequenceEqual(((Array) actualVal).Cast<object>()));
+            }
+            else {
+                Assert.AreEqual(variant.Value, actualVal);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]
-        public void Variant_BooleanShouldRoundTrip(bool value) {
+        [DataRow(true, false)]
+        public void Variant_BooleanShouldRoundTrip(params bool[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow(byte.MinValue)]
         [DataRow(byte.MaxValue)]
-        public void Variant_ByteShouldRoundTrip(byte value) {
+        [DataRow(byte.MinValue, byte.MaxValue)]
+        public void Variant_ByteShouldRoundTrip(params byte[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
@@ -69,54 +86,90 @@ namespace DataCore.Adapter.Tests {
         [DataTestMethod]
         [DataRow(double.MinValue)]
         [DataRow(double.MaxValue)]
-        public void Variant_DoubleShouldRoundTrip(double val) {
+        [DataRow(double.MinValue, double.MaxValue)]
+        public void Variant_DoubleShouldRoundTrip(params double[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(val, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow(float.MinValue)]
         [DataRow(float.MaxValue)]
-        public void Variant_FloatShouldRoundTrip(float val) {
+        [DataRow(float.MinValue, float.MaxValue)]
+        public void Variant_FloatShouldRoundTrip(params float[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(val, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow(short.MinValue)]
         [DataRow(short.MaxValue)]
-        public void Variant_Int16ShouldRoundTrip(short value) {
+        [DataRow(short.MinValue, short.MaxValue)]
+        public void Variant_Int16ShouldRoundTrip(params short[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow(int.MinValue)]
         [DataRow(int.MaxValue)]
-        public void Variant_Int32ShouldRoundTrip(int value) {
+        [DataRow(int.MinValue, int.MaxValue)]
+        public void Variant_Int32ShouldRoundTrip(params int[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow(long.MinValue)]
         [DataRow(long.MaxValue)]
-        public void Variant_Int64ShouldRoundTrip(long value) {
+        [DataRow(long.MinValue, long.MaxValue)]
+        public void Variant_Int64ShouldRoundTrip(params long[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow(sbyte.MinValue)]
         [DataRow(sbyte.MaxValue)]
-        public void Variant_SByteShouldRoundTrip(sbyte value) {
+        [DataRow(sbyte.MinValue, sbyte.MaxValue)]
+        public void Variant_SByteShouldRoundTrip(params sbyte[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
@@ -128,9 +181,15 @@ namespace DataCore.Adapter.Tests {
         [DataRow("テスト")] // "test" in Japanese
         [DataRow("測試")] // "test" in Chinese
         [DataRow("اختبار")] // "test" in Arabic
-        public void Variant_StringShouldRoundTrip(string value) {
+        [DataRow("", " ", "TEST", "контрольная работа", "テスト", "測試", "اختبار")]
+        public void Variant_StringShouldRoundTrip(params string[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
@@ -144,46 +203,86 @@ namespace DataCore.Adapter.Tests {
         [DataTestMethod]
         [DataRow(ushort.MinValue)]
         [DataRow(ushort.MaxValue)]
-        public void Variant_UInt16ShouldRoundTrip(ushort value) {
+        [DataRow(ushort.MinValue, ushort.MaxValue)]
+        public void Variant_UInt16ShouldRoundTrip(params ushort[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow(uint.MinValue)]
         [DataRow(uint.MaxValue)]
-        public void Variant_UInt32ShouldRoundTrip(uint value) {
+        [DataRow(uint.MinValue, uint.MaxValue)]
+        public void Variant_UInt32ShouldRoundTrip(params uint[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow(ulong.MinValue)]
         [DataRow(ulong.MaxValue)]
-        public void Variant_UInt64ShouldRoundTrip(ulong value) {
+        [DataRow(ulong.MinValue, ulong.MaxValue)]
+        public void Variant_UInt64ShouldRoundTrip(params ulong[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(value, options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(values[0], options);
+            }
+            else {
+                VariantRoundTripTest(values, options);
+            }
         }
 
 
         [DataTestMethod]
         [DataRow("https://appstore.intelligentplant.com")]
         [DataRow("https://github.com/intelligentplant/AppStoreConnect.Adapters")]
-        public void Variant_UrlShouldRoundTrip(string value) {
+        [DataRow("https://appstore.intelligentplant.com", "https://github.com/intelligentplant/AppStoreConnect.Adapters")]
+        public void Variant_UrlShouldRoundTrip(params string[] values) {
             var options = GetOptions();
-            VariantRoundTripTest(new Uri(value, UriKind.Absolute), options);
+            if (values.Length == 1) {
+                VariantRoundTripTest(new Uri(values[0], UriKind.Absolute), options);
+            }
+            else {
+                VariantRoundTripTest(values.Select(x => new Uri(x, UriKind.Absolute)).ToArray(), options);
+            }
         }
 
 
         [TestMethod]
-        public void Variant_CustomClassShouldRoundTrip() {
-            var options = GetOptions();
-            VariantRoundTripTest(new VariantTestClass() {
-                TestName = TestContext.TestName, 
-                UtcTimestamp = DateTime.UtcNow
-            }, options);
+        public void Variant_MultidimensionalArrayShouldRoundTrip() {
+            var arr3d = new int[,,] { 
+                { 
+                    { 1, 2, 3 }, 
+                    { 4, 5, 6 } 
+                }, 
+                { 
+                    { 7, 8, 9 }, 
+                    { 10, 11, 12 } 
+                }, 
+                { 
+                    { 13, 14, 15 }, 
+                    { 16, 17, 18 } 
+                }, 
+                { 
+                    { 19, 20, 21 }, 
+                    { 22, 23, 24 } 
+                } 
+            };
+
+            VariantRoundTripTest(arr3d, GetOptions());
+
         }
 
 
@@ -221,7 +320,7 @@ namespace DataCore.Adapter.Tests {
                     "Extension2"
                 },
                 new [] {
-                    new AdapterProperty("Property1", new Variant(100, VariantType.Int32))
+                    new AdapterProperty("Property1", 100)
                 },
                 new AdapterTypeDescriptor(
                     new Uri("asc:unit-tests/json-tests/" + TestContext.TestName), 
@@ -277,7 +376,7 @@ namespace DataCore.Adapter.Tests {
             var options = GetOptions();
             var expected = new AdapterProperty(
                 "Name",
-                new Variant("Value", VariantType.String)
+                "Value"
             );
 
             var json = JsonSerializer.Serialize(expected, options);

--- a/test/DataCore.Adapter.Tests/VariantTests.cs
+++ b/test/DataCore.Adapter.Tests/VariantTests.cs
@@ -22,7 +22,6 @@ namespace DataCore.Adapter.Tests {
         [DataRow(VariantType.Int64, "-9223372036854775808", -9223372036854775808)]
         [DataRow(VariantType.Int64, "9223372036854775807", 9223372036854775807)]
         [DataRow(VariantType.Null, null, null)]
-        [DataRow(VariantType.Object, "test", "test")]
         [DataRow(VariantType.SByte, "-128", (sbyte) -128)]
         [DataRow(VariantType.SByte, "127", (sbyte) 127)]
         [DataRow(VariantType.String, "test", "test")]

--- a/test/DataCore.Adapter.Tests/VariantTests.cs
+++ b/test/DataCore.Adapter.Tests/VariantTests.cs
@@ -74,6 +74,37 @@ namespace DataCore.Adapter.Tests {
             return new Uri(value, UriKind.Absolute);
         }
 
+
+        [TestMethod]
+        public void VariantShouldDetectArray() {
+            var arr = new string[,] {
+                { "Intelligent", "Plant", "Limited" },
+                { "Industrial", "App", "Store" }
+            };
+
+            var variant = new Variant(arr);
+            Assert.AreEqual(VariantType.String, variant.Type);
+            Assert.IsNotNull(variant.ArrayDimensions);
+            Assert.AreEqual(arr.Rank, variant.ArrayDimensions!.Length);
+
+            for (var i = 0; i < arr.Rank; i++) {
+                var length = arr.GetLength(i);
+                Assert.AreEqual(length, variant.ArrayDimensions[i]);
+            }
+        }
+
+
+        [TestMethod]
+        public void VariantShouldNotAllowUnsupportedValueType() {
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new Variant(new System.Drawing.Point(500, 300)));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldNotAllowUnsupportedArrayType() {
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new Variant(new[] { new System.Drawing.Point(500, 300) }));
+        }
+
     }
 
 }

--- a/test/DataCore.Adapter.Tests/VariantTests.cs
+++ b/test/DataCore.Adapter.Tests/VariantTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+
 using DataCore.Adapter.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -7,101 +9,167 @@ namespace DataCore.Adapter.Tests {
     [TestClass]
     public class VariantTests : TestsBase {
 
-        [DataTestMethod]
-        [DataRow(VariantType.Boolean, "true", true)]
-        [DataRow(VariantType.Boolean, "false", false)]
-        [DataRow(VariantType.Byte, "0", (byte) 0)]
-        [DataRow(VariantType.Byte, "255", (byte) 255)]
-        [DataRow(VariantType.DateTime, "2020-02-01T09:05:00", null)]
-        [DataRow(VariantType.Double, "1234567890.12345", 1234567890.12345)]
-        [DataRow(VariantType.Float, "12345.789", 12345.789f)]
-        [DataRow(VariantType.Int16, "-32768", (short) -32768)]
-        [DataRow(VariantType.Int16, "32767", (short) 32767)]
-        [DataRow(VariantType.Int32, "-2147483648", -2147483648)]
-        [DataRow(VariantType.Int32, "2147483647", 2147483647)]
-        [DataRow(VariantType.Int64, "-9223372036854775808", -9223372036854775808)]
-        [DataRow(VariantType.Int64, "9223372036854775807", 9223372036854775807)]
-        [DataRow(VariantType.Null, null, null)]
-        [DataRow(VariantType.SByte, "-128", (sbyte) -128)]
-        [DataRow(VariantType.SByte, "127", (sbyte) 127)]
-        [DataRow(VariantType.String, "test", "test")]
-        [DataRow(VariantType.TimeSpan, "1.23:45:06", null)]
-        [DataRow(VariantType.UInt16, "0", (ushort) 0)]
-        [DataRow(VariantType.UInt16, "65535", (ushort) 65535)]
-        [DataRow(VariantType.UInt32, "0", (uint) 0)]
-        [DataRow(VariantType.UInt32, "4294967295", (uint) 4294967295)]
-        [DataRow(VariantType.UInt64, "0", (ulong) 0)]
-        [DataRow(VariantType.UInt64, "18446744073709551615", (ulong) 18446744073709551615)]
-        [DataRow(VariantType.Unknown, "true", true)]
-        [DataRow(VariantType.Unknown, "1", 1)]
-        [DataRow(VariantType.Unknown, "1.2345", 1.2345)]
-        [DataRow(VariantType.Url, "https://appstore.intelligentplant.com", null)]
-        public void ParseToVariantShouldSucceed(VariantType type, string value, object expectedValue) {
-            Assert.IsTrue(Variant.TryParse(value, type, out var variant));
+        private static void ValidateVariant(Variant variant, VariantType expectedType, object expectedValue, int[] expectedArrayDimensions) {
+            Assert.AreEqual(expectedType, variant.Type);
+            if (expectedValue is Array arr) {
+                Assert.IsTrue(expectedArrayDimensions.SequenceEqual(variant.ArrayDimensions));
+                Assert.AreEqual(arr.Rank, variant.ArrayDimensions!.Length);
 
-            if (type != VariantType.Unknown) {
-                Assert.AreEqual(type, variant.Type);
-            }
-
-            if (expectedValue == null) {
-                switch (type) {
-                    case VariantType.DateTime:
-                        expectedValue = GetExpectedDateTimeValue(value);
-                        break;
-                    case VariantType.TimeSpan:
-                        expectedValue = GetExpectedTimeSpanValue(value);
-                        break;
+                for (var i = 0; i < arr.Rank; i++) {
+                    var length = arr.GetLength(i);
+                    Assert.AreEqual(length, variant.ArrayDimensions[i]);
                 }
-            }
 
-            if (type == VariantType.Null || expectedValue != null) {
+                Assert.IsTrue(arr.Cast<object>().SequenceEqual(((Array) variant.Value).Cast<object>()));
+            }
+            else {
+                Assert.IsNull(variant.ArrayDimensions);
                 Assert.AreEqual(expectedValue, variant.Value);
             }
         }
 
 
-        private DateTime GetExpectedDateTimeValue(string value) {
-            return DateTime.Parse(value, null, System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal);
-        }
-
-
-        private TimeSpan GetExpectedTimeSpanValue(string value) {
-            return TimeSpan.Parse(value);
-        }
-
-
-        private Uri GetExpectedUriValue(string value) {
-            return new Uri(value, UriKind.Absolute);
+        [DataTestMethod]
+        [DataRow(VariantType.Boolean, true)]
+        [DataRow(VariantType.Boolean, false)]
+        [DataRow(VariantType.Byte, (byte) 0)]
+        [DataRow(VariantType.Byte, (byte) 255)]
+        [DataRow(VariantType.Double, 1234567890.12345)]
+        [DataRow(VariantType.Float, 12345.789f)]
+        [DataRow(VariantType.Int16, (short) -32768)]
+        [DataRow(VariantType.Int16, (short) 32767)]
+        [DataRow(VariantType.Int32, -2147483648)]
+        [DataRow(VariantType.Int32, 2147483647)]
+        [DataRow(VariantType.Int64, -9223372036854775808)]
+        [DataRow(VariantType.Int64, 9223372036854775807)]
+        [DataRow(VariantType.Null, null)]
+        [DataRow(VariantType.SByte, (sbyte) -128)]
+        [DataRow(VariantType.SByte, (sbyte) 127)]
+        [DataRow(VariantType.String, "test")]
+        [DataRow(VariantType.UInt16, (ushort) 0)]
+        [DataRow(VariantType.UInt16, (ushort) 65535)]
+        [DataRow(VariantType.UInt32, (uint) 0)]
+        [DataRow(VariantType.UInt32, (uint) 4294967295)]
+        [DataRow(VariantType.UInt64, (ulong) 0)]
+        [DataRow(VariantType.UInt64, (ulong) 18446744073709551615)]
+        public void VariantShouldAllowCreationWithSupportedType(VariantType expectedType, object value) {
+            var variant = new Variant(value);
+            ValidateVariant(variant, expectedType, value, null);
         }
 
 
         [TestMethod]
-        public void VariantShouldDetectArray() {
+        public void VariantShouldAllowCreationWithDateTime() {
+            var value = DateTime.UtcNow;
+            var variant = new Variant(value);
+            ValidateVariant(variant, VariantType.DateTime, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowCreationWithTimeSpan() {
+            var value = TimeSpan.FromSeconds(30);
+            var variant = new Variant(value);
+            ValidateVariant(variant, VariantType.TimeSpan, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowCreationWithUri() {
+            var value = new Uri("https://appstore.intelligentplant.com");
+            var variant = new Variant(value);
+            ValidateVariant(variant, VariantType.Url, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldDetect2DArray() {
             var arr = new string[,] {
                 { "Intelligent", "Plant", "Limited" },
                 { "Industrial", "App", "Store" }
             };
 
             var variant = new Variant(arr);
-            Assert.AreEqual(VariantType.String, variant.Type);
-            Assert.IsNotNull(variant.ArrayDimensions);
-            Assert.AreEqual(arr.Rank, variant.ArrayDimensions!.Length);
-
-            for (var i = 0; i < arr.Rank; i++) {
-                var length = arr.GetLength(i);
-                Assert.AreEqual(length, variant.ArrayDimensions[i]);
-            }
+            ValidateVariant(variant, VariantType.String, arr, new[] { 2, 3 });
         }
 
 
         [TestMethod]
-        public void VariantShouldNotAllowUnsupportedValueType() {
+        public void VariantShouldDetect3DArray() {
+            var arr = new int[,,] { 
+                { 
+                    { 1, 2, 3 }, 
+                    { 4, 5, 6 } 
+                }, 
+                { 
+                    { 7, 8, 9 }, 
+                    { 10, 11, 12 } 
+                }, 
+                { 
+                    { 13, 14, 15 }, 
+                    { 16, 17, 18 } 
+                }, 
+                { 
+                    { 19, 20, 21 }, 
+                    { 22, 23, 24 } 
+                } 
+            };
+
+            var variant = new Variant(arr);
+            ValidateVariant(variant, VariantType.Int32, arr, new[] { 4, 2, 3 });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldDetect4DArray() {
+            var arr = new int[,,,] {
+                {
+                    {
+                        { 1, 2, 3 }
+                    },
+                    {
+                        { 4, 5, 6 }
+                    }
+                },
+                {
+                    {
+                        { 7, 8, 9 }
+                    },
+                    {
+                        { 10, 11, 12 }
+                    }
+                },
+                {
+                    {
+                        { 13, 14, 15 }
+                    },
+                    {
+                        { 16, 17, 18 }
+                    }
+                },
+                {
+                    {
+                        { 19, 20, 21 }
+                    },
+                    {
+                        { 22, 23, 24 }
+                    }
+                }
+            };
+
+            var variant = new Variant(arr);
+            ValidateVariant(variant, VariantType.Int32, arr, new[] { 4, 2, 1, 3 });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldNotAllowCreationWithUnsupportedValueType() {
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => new Variant(new System.Drawing.Point(500, 300)));
         }
 
 
         [TestMethod]
-        public void VariantShouldNotAllowUnsupportedArrayType() {
+        public void VariantShouldNotAllowCreationWithUnsupportedArrayType() {
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => new Variant(new[] { new System.Drawing.Point(500, 300) }));
         }
 


### PR DESCRIPTION
This PR adds the ability to set a `Variant` value to be an array of a supported type. Multidimensional arrays are supported.

Special handling of arrays is required in `DataCore.Adapter.Json` when serializing to/deserializing from JSON, since `System.Text.Json` [does not currently support multidimensional arrays](https://github.com/dotnet/runtime/issues/46399).