### PR TITLE
Add static methods for checking if a type is supported by Variant

### DIFF
--- a/src/DataCore.Adapter.Core/Common/Variant.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.cs
@@ -147,7 +147,7 @@ namespace DataCore.Adapter.Common {
             }
             else {
                 var valueType = value.GetType();
-                if (!VariantTypeMap.TryGetValue(valueType, out variantType)) {
+                if (!TryGetVariantType(valueType, out variantType)) {
                     throw new ArgumentOutOfRangeException(nameof(value), valueType, SharedResources.Error_TypeIsUnsupported);
                 }
             }
@@ -220,14 +220,68 @@ namespace DataCore.Adapter.Common {
         /// </exception>
         private static void GetArraySettings(Array value, out VariantType variantType, out int[] arrayDimensions) {
             Type? elemType = value.GetType().GetElementType();
-            if (elemType == null || !VariantTypeMap.TryGetValue(elemType, out variantType)) {
+            if (elemType == null || !TryGetVariantType(elemType, out variantType)) {
                 throw new ArgumentOutOfRangeException(nameof(value), elemType, SharedResources.Error_ArrayElementTypeIsUnsupported);
             }
 
             arrayDimensions = new int[value.Rank];
-            for (int i = 0; i < value.Rank; i++) {
+            for (var i = 0; i < value.Rank; i++) {
                 arrayDimensions[i] = value.GetLength(i);
             }
+        }
+
+
+        /// <summary>
+        /// Tries to get the <see cref="VariantType"/> for the specified <see cref="Type"/>.
+        /// </summary>
+        /// <param name="type">
+        ///   The type.
+        /// </param>
+        /// <param name="variantType">
+        ///   The <see cref="VariantType"/> that the <paramref name="type"/> maps to.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="type"/> has an equivalent <see cref="VariantType"/>, 
+        ///   or <see langword="false"/> otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="type"/> is <see langword="null"/>.
+        /// </exception>
+        public static bool TryGetVariantType(Type type, out VariantType variantType) {
+            if (type == null) {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (type.IsArray) {
+                var elementType = type.GetElementType();
+                if (elementType == null) {
+                    variantType = VariantType.Unknown;
+                    return false;
+                }
+                return VariantTypeMap.TryGetValue(elementType, out variantType);
+            }
+
+            return VariantTypeMap.TryGetValue(type, out variantType);
+        }
+
+
+        /// <summary>
+        /// Tests if an instance of the specified <see cref="Type"/> can be specified as the value 
+        /// of a <see cref="Variant"/> instance.
+        /// </summary>
+        /// <param name="type">
+        ///   The type.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if an instance of the <paramref name="type"/> can be specified 
+        ///   as the value of a <see cref="Variant"/> instance, or <see langword="false"/> 
+        ///   otherwise.         
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="type"/> is <see langword="null"/>.
+        /// </exception>
+        public static bool IsSupportedValueType(Type type) {
+            return TryGetVariantType(type, out var _);
         }
 
 

--- a/test/DataCore.Adapter.Tests/VariantTests.cs
+++ b/test/DataCore.Adapter.Tests/VariantTests.cs
@@ -9,6 +9,30 @@ namespace DataCore.Adapter.Tests {
     [TestClass]
     public class VariantTests : TestsBase {
 
+        [DataTestMethod]
+        [DataRow(typeof(bool), typeof(bool[]), typeof(bool[,]), typeof(bool[,,]))]
+        [DataRow(typeof(byte), typeof(byte[]), typeof(byte[,]), typeof(byte[,,]))]
+        [DataRow(typeof(DateTime), typeof(DateTime[]), typeof(DateTime[,]), typeof(DateTime[,,]))]
+        [DataRow(typeof(double), typeof(double[]), typeof(double[,]), typeof(double[,,]))]
+        [DataRow(typeof(float), typeof(float[]), typeof(float[,]), typeof(float[,,]))]
+        [DataRow(typeof(short), typeof(short[]), typeof(short[,]), typeof(short[,,]))]
+        [DataRow(typeof(int), typeof(int[]), typeof(int[,]), typeof(int[,,]))]
+        [DataRow(typeof(long), typeof(long[]), typeof(long[,]), typeof(int[,,]))]
+        [DataRow(typeof(sbyte), typeof(sbyte[]), typeof(sbyte[,]), typeof(sbyte[,,]))]
+        [DataRow(typeof(string), typeof(string[]), typeof(string[,]), typeof(string[,,]))]
+        [DataRow(typeof(string), typeof(string[]), typeof(string[,]), typeof(string[,,]))]
+        [DataRow(typeof(TimeSpan), typeof(TimeSpan[]), typeof(TimeSpan[,]), typeof(TimeSpan[,,]))]
+        [DataRow(typeof(ushort), typeof(ushort[]), typeof(ushort[,]), typeof(ushort[,,]))]
+        [DataRow(typeof(uint), typeof(uint[]), typeof(uint[,]), typeof(uint[,,]))]
+        [DataRow(typeof(ulong), typeof(ulong[]), typeof(ulong[,]), typeof(ulong[,,]))]
+        [DataRow(typeof(Uri), typeof(Uri[]), typeof(Uri[,]), typeof(Uri[,,]))]
+        public void VariantTypeShouldBeSupported(params Type[] types) {
+            foreach (var type in types) {
+                Assert.IsTrue(Variant.IsSupportedValueType(type), $"Type should be supported: {type.Name}");
+            }
+        }
+
+
         private static void ValidateVariant(Variant variant, VariantType expectedType, object expectedValue, int[] expectedArrayDimensions) {
             Assert.AreEqual(expectedType, variant.Type);
             if (expectedValue is Array arr) {


### PR DESCRIPTION
- Add static `TryGetVariantType` and `IsSupportedValueType` methods to `Variant`.
- Add unit tests for checking if a given Type is supported.