### PR TITLE
Add typed Variant constructors

### DIFF
--- a/src/DataCore.Adapter.Core/Common/Variant.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.cs
@@ -203,6 +203,583 @@ namespace DataCore.Adapter.Common {
 
 
         /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(bool value) {
+            Value = value;
+            Type = VariantType.Boolean;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(bool[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Boolean;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(byte value) {
+            Value = value;
+            Type = VariantType.Byte;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(byte[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Byte;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(DateTime value) {
+            Value = value;
+            Type = VariantType.DateTime;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(DateTime[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.DateTime;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(double value) {
+            Value = value;
+            Type = VariantType.Double;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(double[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Double;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(float value) {
+            Value = value;
+            Type = VariantType.Float;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(float[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Float;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(int value) {
+            Value = value;
+            Type = VariantType.Int32;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(int[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Int32;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(long value) {
+            Value = value;
+            Type = VariantType.Int64;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(long[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Int64;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(sbyte value) {
+            Value = value;
+            Type = VariantType.SByte;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(sbyte[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.SByte;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(short value) {
+            Value = value;
+            Type = VariantType.Int16;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(short[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Int16;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(string? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.String;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(string[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.String;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(TimeSpan value) {
+            Value = value;
+            Type = VariantType.TimeSpan;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(TimeSpan[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.TimeSpan;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(uint value) {
+            Value = value;
+            Type = VariantType.UInt32;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(uint[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.UInt32;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(ulong value) {
+            Value = value;
+            Type = VariantType.UInt64;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(ulong[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.UInt64;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(ushort value) {
+            Value = value;
+            Type = VariantType.UInt16;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(ushort[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.UInt16;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(Uri? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Url;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(Uri[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Url;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
         /// Gets the <see cref="VariantType"/> and array dimensions for the specified array.
         /// </summary>
         /// <param name="value">
@@ -224,11 +801,27 @@ namespace DataCore.Adapter.Common {
                 throw new ArgumentOutOfRangeException(nameof(value), elemType, SharedResources.Error_ArrayElementTypeIsUnsupported);
             }
 
-            arrayDimensions = new int[value.Rank];
+            arrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Gets the dimensions of the specified array.
+        /// </summary>
+        /// <param name="value">
+        ///   The array.
+        /// </param>
+        /// <returns>
+        ///   The array dimensions.
+        /// </returns>
+        private static int[] GetArrayDimensions(Array value) {
+            var arrayDimensions = new int[value.Rank];
             for (var i = 0; i < value.Rank; i++) {
                 arrayDimensions[i] = value.GetLength(i);
             }
-        }
+
+            return arrayDimensions;
+        } 
 
 
         /// <summary>
@@ -459,195 +1052,195 @@ namespace DataCore.Adapter.Common {
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(bool val) => FromValue(val);
+        public static implicit operator Variant(bool val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator bool(Variant val) => val.Value == null ? default : (bool) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(bool[]? val) => FromValue(val);
+        public static implicit operator Variant(bool[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator bool[]?(Variant val) => (bool[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(sbyte val) => FromValue(val);
+        public static implicit operator Variant(sbyte val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator sbyte(Variant val) => val.Value == null ? default : (sbyte) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(sbyte[]? val) => FromValue(val);
+        public static implicit operator Variant(sbyte[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator sbyte[]?(Variant val) => (sbyte[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(byte val) => FromValue(val);
+        public static implicit operator Variant(byte val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator byte(Variant val) => val.Value == null ? default : (byte) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(byte[]? val) => FromValue(val);
+        public static implicit operator Variant(byte[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator byte[]?(Variant val) => (byte[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(short val) => FromValue(val);
+        public static implicit operator Variant(short val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator short(Variant val) => val.Value == null ? default : (short) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(short[]? val) => FromValue(val);
+        public static implicit operator Variant(short[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator short[]?(Variant val) => (short[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(ushort val) => FromValue(val);
+        public static implicit operator Variant(ushort val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator ushort(Variant val) => val.Value == null ? default : (ushort) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(ushort[]? val) => FromValue(val);
+        public static implicit operator Variant(ushort[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator ushort[]?(Variant val) => (ushort[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(int val) => FromValue(val);
+        public static implicit operator Variant(int val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator int(Variant val) => val.Value == null ? default : (int) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(int[]? val) => FromValue(val);
+        public static implicit operator Variant(int[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator int[]?(Variant val) => (int[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(uint val) => FromValue(val);
+        public static implicit operator Variant(uint val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator uint(Variant val) => val.Value == null ? default : (uint) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(uint[]? val) => FromValue(val);
+        public static implicit operator Variant(uint[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator uint[]?(Variant val) => (uint[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(long val) => FromValue(val);
+        public static implicit operator Variant(long val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator long(Variant val) => val.Value == null ? default : (long) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(long[]? val) => FromValue(val);
+        public static implicit operator Variant(long[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator long[]?(Variant val) => (long[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(ulong val) => FromValue(val);
+        public static implicit operator Variant(ulong val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator ulong(Variant val) => val.Value == null ? default : (ulong) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(ulong[]? val) => FromValue(val);
+        public static implicit operator Variant(ulong[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator ulong[]?(Variant val) => (ulong[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(float val) => FromValue(val);
+        public static implicit operator Variant(float val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator float(Variant val) => val.Value == null ? default : (float) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(float[]? val) => FromValue(val);
+        public static implicit operator Variant(float[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator float[]?(Variant val) => (float[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(double val) => FromValue(val);
+        public static implicit operator Variant(double val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator double(Variant val) => val.Value == null ? default : (double) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(double[]? val) => FromValue(val);
+        public static implicit operator Variant(double[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator double[]?(Variant val) => (double[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(string? val) => FromValue(val);
+        public static implicit operator Variant(string? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator string?(Variant val) => (string?) val.Value!;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(string[]? val) => FromValue(val);
+        public static implicit operator Variant(string[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator string[]?(Variant val) => (string[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(Uri val) => FromValue(val);
+        public static implicit operator Variant(Uri val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator Uri(Variant val) => (Uri) val.Value!;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(Uri[]? val) => FromValue(val);
+        public static implicit operator Variant(Uri[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator Uri[]?(Variant val) => (Uri[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(DateTime val) => FromValue(val);
+        public static implicit operator Variant(DateTime val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator DateTime(Variant val) => val.Value == null ? default : (DateTime) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(DateTime[]? val) => FromValue(val);
+        public static implicit operator Variant(DateTime[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator DateTime[]?(Variant val) => (DateTime[]?) val.Value;
 
 
         /// <inheritdoc/>
-        public static implicit operator Variant(TimeSpan val) => FromValue(val);
+        public static implicit operator Variant(TimeSpan val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator TimeSpan(Variant val) => val.Value == null ? default : (TimeSpan) val.Value;
 
         /// <inheritdoc/>
-        public static implicit operator Variant(TimeSpan[]? val) => FromValue(val);
+        public static implicit operator Variant(TimeSpan[]? val) => new Variant(val);
 
         /// <inheritdoc/>
         public static explicit operator TimeSpan[]?(Variant val) => (TimeSpan[]?) val.Value;

--- a/test/DataCore.Adapter.Tests/VariantTests.cs
+++ b/test/DataCore.Adapter.Tests/VariantTests.cs
@@ -20,7 +20,6 @@ namespace DataCore.Adapter.Tests {
         [DataRow(typeof(long), typeof(long[]), typeof(long[,]), typeof(int[,,]))]
         [DataRow(typeof(sbyte), typeof(sbyte[]), typeof(sbyte[,]), typeof(sbyte[,,]))]
         [DataRow(typeof(string), typeof(string[]), typeof(string[,]), typeof(string[,,]))]
-        [DataRow(typeof(string), typeof(string[]), typeof(string[,]), typeof(string[,,]))]
         [DataRow(typeof(TimeSpan), typeof(TimeSpan[]), typeof(TimeSpan[,]), typeof(TimeSpan[,,]))]
         [DataRow(typeof(ushort), typeof(ushort[]), typeof(ushort[,]), typeof(ushort[,,]))]
         [DataRow(typeof(uint), typeof(uint[]), typeof(uint[,]), typeof(uint[,,]))]
@@ -53,6 +52,516 @@ namespace DataCore.Adapter.Tests {
         }
 
 
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromBool() {
+            bool value = true;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Boolean, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromBoolArray() {
+            bool[] value = new[] { true, false };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Boolean, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToBool() {
+            bool value = true;
+            Variant variant = value;
+            var actualValue = (bool) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToBoolArray() {
+            bool[] value = new[] { true, false };
+            Variant variant = value;
+            var actualValue = (bool[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromByte() {
+            byte value = 255;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Byte, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromByteArray() {
+            byte[] value = new byte [] { 255, 254 };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Byte, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToByte() {
+            byte value = 255;
+            Variant variant = value;
+            var actualValue = (byte) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToByteArray() {
+            byte[] value = new byte[] { 255, 254 };
+            Variant variant = value;
+            var actualValue = (byte[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromDateTime() {
+            var value = DateTime.UtcNow;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.DateTime, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromDateTimeArray() {
+            var value = new DateTime[] { DateTime.UtcNow, DateTime.UtcNow.AddHours(-1) };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.DateTime, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToDateTime() {
+            var value = DateTime.UtcNow;
+            Variant variant = value;
+            var actualValue = (DateTime) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToDateTimeArray() {
+            var value = new [] { DateTime.UtcNow, DateTime.UtcNow.AddHours(-1) };
+            Variant variant = value;
+            var actualValue = (DateTime[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromDouble() {
+            double value = 1.234;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Double, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromDoubleArray() {
+            double[] value = new double[] { 1.234, 5.678 };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Double, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToDouble() {
+            double value = 1.234;
+            Variant variant = value;
+            var actualValue = (double) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToDoubleArray() {
+            double[] value = new double[] { 1.234, 5.678 };
+            Variant variant = value;
+            var actualValue = (double[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromFloat() {
+            float value = 1.234f;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Float, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromFloatArray() {
+            float[] value = new float[] { 1.234f, 5.678f };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Float, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToFloat() {
+            float value = 1.234f;
+            Variant variant = value;
+            var actualValue = (float) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToFloatArray() {
+            float[] value = new float[] { 1.234f, 5.678f };
+            Variant variant = value;
+            var actualValue = (float[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromInt16() {
+            short value = 255;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Int16, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromInt16Array() {
+            short[] value = new short[] { 255, 254 };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Int16, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToInt16() {
+            short value = 255;
+            Variant variant = value;
+            var actualValue = (short) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToInt16Array() {
+            short[] value = new short[] { 255, 254 };
+            Variant variant = value;
+            var actualValue = (short[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromInt32() {
+            int value = 255;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Int32, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromInt32Array() {
+            int[] value = new int[] { 255, 254 };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Int32, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToInt32() {
+            int value = 255;
+            Variant variant = value;
+            var actualValue = (int) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToInt32Array() {
+            int[] value = new int[] { 255, 254 };
+            Variant variant = value;
+            var actualValue = (int[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromInt64() {
+            long value = 255;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Int64, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromInt64Array() {
+            long[] value = new long[] { 255, 254 };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Int64, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToInt64() {
+            long value = 255;
+            Variant variant = value;
+            var actualValue = (long) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToInt64Array() {
+            long[] value = new long[] { 255, 254 };
+            Variant variant = value;
+            var actualValue = (long[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromSByte() {
+            sbyte value = 127;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.SByte, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromSByteArray() {
+            sbyte[] value = new sbyte[] { -128, 127 };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.SByte, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToSByte() {
+            sbyte value = 127;
+            Variant variant = value;
+            var actualValue = (sbyte) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToSByteArray() {
+            sbyte[] value = new sbyte[] { 127, -128 };
+            Variant variant = value;
+            var actualValue = (sbyte[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromString() {
+            string value = TestContext.TestName;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.String, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromStringArray() {
+            string[] value = new string[] { TestContext.TestName, TestContext.FullyQualifiedTestClassName };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.String, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToString() {
+            var value = TestContext.TestName;
+            Variant variant = value;
+            var actualValue = (string) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToStringArray() {
+            var value = new string[] { TestContext.TestName, TestContext.FullyQualifiedTestClassName };
+            Variant variant = value;
+            var actualValue = (string[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromTimeSpan() {
+            var value = TimeSpan.FromHours(1);
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.TimeSpan, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromTimeSpanArray() {
+            var value = new TimeSpan[] { TimeSpan.FromHours(1), TimeSpan.FromDays(3) };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.TimeSpan, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToTimeSpan() {
+            var value = TimeSpan.FromHours(1);
+            Variant variant = value;
+            var actualValue = (TimeSpan) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToTimeSpanArray() {
+            var value = new TimeSpan[] { TimeSpan.FromHours(1), TimeSpan.FromDays(3) };
+            Variant variant = value;
+            var actualValue = (TimeSpan[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromUInt16() {
+            ushort value = 255;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.UInt16, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromUInt16Array() {
+            ushort[] value = new ushort[] { 255, 254 };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.UInt16, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToUInt16() {
+            ushort value = 255;
+            Variant variant = value;
+            var actualValue = (ushort) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToUInt16Array() {
+            ushort[] value = new ushort[] { 255, 254 };
+            Variant variant = value;
+            var actualValue = (ushort[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromUInt32() {
+            uint value = 255;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.UInt32, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromUInt32Array() {
+            uint[] value = new uint[] { 255, 254 };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.UInt32, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToUInt32() {
+            uint value = 255;
+            Variant variant = value;
+            var actualValue = (uint) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToUInt32Array() {
+            uint[] value = new uint[] { 255, 254 };
+            Variant variant = value;
+            var actualValue = (uint[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromUInt64() {
+            ulong value = 255;
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.UInt64, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromUInt64Array() {
+            ulong[] value = new ulong[] { 255, 254 };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.UInt64, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToUInt64() {
+            ulong value = 255;
+            Variant variant = value;
+            var actualValue = (ulong) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToUInt64Array() {
+            ulong[] value = new ulong[] { 255, 254 };
+            Variant variant = value;
+            var actualValue = (ulong[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromUri() {
+            var value = new Uri("https://appstore.intelligentplant.com");
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Url, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromUriArray() {
+            var value = new [] { new Uri("https://appstore.intelligentplant.com"), new Uri("https://www.intelligentplant.com") };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.Url, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToUri() {
+            var value = new Uri("https://appstore.intelligentplant.com");
+            Variant variant = value;
+            var actualValue = (Uri) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToUriArray() {
+            var value = new[] { new Uri("https://appstore.intelligentplant.com"), new Uri("https://www.intelligentplant.com") };
+            Variant variant = value;
+            var actualValue = (Uri[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
         [DataTestMethod]
         [DataRow(VariantType.Boolean, true)]
         [DataRow(VariantType.Boolean, false)]
@@ -76,31 +585,31 @@ namespace DataCore.Adapter.Tests {
         [DataRow(VariantType.UInt32, (uint) 4294967295)]
         [DataRow(VariantType.UInt64, (ulong) 0)]
         [DataRow(VariantType.UInt64, (ulong) 18446744073709551615)]
-        public void VariantShouldAllowCreationWithSupportedType(VariantType expectedType, object value) {
+        public void VariantShouldAllowCreationFromObject(VariantType expectedType, object value) {
             var variant = new Variant(value);
             ValidateVariant(variant, expectedType, value, null);
         }
 
 
         [TestMethod]
-        public void VariantShouldAllowCreationWithDateTime() {
-            var value = DateTime.UtcNow;
+        public void VariantShouldAllowCreationFromDateTimeAsObject() {
+            object value = DateTime.UtcNow;
             var variant = new Variant(value);
             ValidateVariant(variant, VariantType.DateTime, value, null);
         }
 
 
         [TestMethod]
-        public void VariantShouldAllowCreationWithTimeSpan() {
-            var value = TimeSpan.FromSeconds(30);
+        public void VariantShouldAllowCreationFromTimeSpanAsObject() {
+            object value = TimeSpan.FromSeconds(30);
             var variant = new Variant(value);
             ValidateVariant(variant, VariantType.TimeSpan, value, null);
         }
 
 
         [TestMethod]
-        public void VariantShouldAllowCreationWithUri() {
-            var value = new Uri("https://appstore.intelligentplant.com");
+        public void VariantShouldAllowCreationFromUriAsObject() {
+            object value = new Uri("https://appstore.intelligentplant.com");
             var variant = new Variant(value);
             ValidateVariant(variant, VariantType.Url, value, null);
         }


### PR DESCRIPTION
- Add `Variant` constructors that accept primitive values and arrays (e.g. `byte` and `byte[]`) to prevent boxing that would occur if the `Variant(object?)` constructor was used.
- Update implicit conversions to use new constructors.
- Add unit tests to test implicit conversions to `Variant` and explicit conversions from `Variant`.