### PR TITLE
Variants can define extension objects as their value

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.Grpc/DataCore.Adapter.AspNetCore.Grpc.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/DataCore.Adapter.AspNetCore.Grpc.csproj
@@ -6,6 +6,7 @@
     <Description>ASP.NET Core types for hosting App Store Connect adapter gRPC services.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DataCore.Adapter.Core/Common/ExtensionObject.cs
+++ b/src/DataCore.Adapter.Core/Common/ExtensionObject.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+
+namespace DataCore.Adapter.Common {
+
+    /// <summary>
+    /// Describes a non-standard <see cref="Variant"/> value.
+    /// </summary>
+    public class ExtensionObject : IEquatable<ExtensionObject> {
+
+        /// <summary>
+        /// The URI that defines the extension object type.
+        /// </summary>
+        public Uri TypeId { get; }
+
+        /// <summary>
+        /// The content type for the <see cref="EncodedBody"/>.
+        /// </summary>
+        public string Encoding { get; }
+
+        /// <summary>
+        /// The encoded object body.
+        /// </summary>
+        public byte[] EncodedBody { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="ExtensionObject"/> object.
+        /// </summary>
+        /// <param name="typeId">
+        ///   The URI that defines the extension object type.
+        /// </param>
+        /// <param name="encoding">
+        ///   The content type for the encoded object value.
+        /// </param>
+        /// <param name="encodedBody">
+        ///   The encoded object value.
+        /// </param>
+        public ExtensionObject(Uri typeId, string encoding, byte[] encodedBody) {
+            TypeId = typeId ?? throw new ArgumentNullException(nameof(typeId));
+            Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
+            EncodedBody = encodedBody ?? throw new ArgumentNullException(nameof(encodedBody));
+        }
+
+
+        /// <inheritdoc/>
+        public override int GetHashCode() {
+#if NETSTANDARD2_0 || NET46
+            return HashGenerator.Combine(TypeId, Encoding, EncodedBody);
+#else
+            return HashCode.Combine(TypeId, Encoding, EncodedBody);
+#endif
+        }
+
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) {
+            return obj is ExtensionObject eo 
+                ? Equals(eo) 
+                : false;
+        }
+
+
+        /// <inheritdoc/>
+        public bool Equals(ExtensionObject other) {
+            if (other == null) {
+                return false;
+            }
+
+            return TypeId.Equals(other.TypeId) && 
+                Encoding.Equals(other.Encoding, StringComparison.OrdinalIgnoreCase) && 
+                EncodedBody.SequenceEqual(other.EncodedBody);
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.Core/Common/Variant.Operators.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.Operators.cs
@@ -163,7 +163,7 @@ namespace DataCore.Adapter.Common {
         public static implicit operator Variant(string? val) => new Variant(val);
 
         /// <inheritdoc/>
-        public static explicit operator string?(Variant val) => (string?) val.Value!;
+        public static explicit operator string?(Variant val) => (string?) val.Value;
 
         /// <inheritdoc/>
         public static implicit operator Variant(string[]? val) => new Variant(val);
@@ -176,7 +176,7 @@ namespace DataCore.Adapter.Common {
         public static implicit operator Variant(Uri val) => new Variant(val);
 
         /// <inheritdoc/>
-        public static explicit operator Uri(Variant val) => (Uri) val.Value!;
+        public static explicit operator Uri?(Variant val) => (Uri) val.Value!;
 
         /// <inheritdoc/>
         public static implicit operator Variant(Uri[]? val) => new Variant(val);
@@ -209,6 +209,19 @@ namespace DataCore.Adapter.Common {
 
         /// <inheritdoc/>
         public static explicit operator TimeSpan[]?(Variant val) => (TimeSpan[]?) val.Value;
+
+
+        /// <inheritdoc/>
+        public static implicit operator Variant(ExtensionObject val) => new Variant(val);
+
+        /// <inheritdoc/>
+        public static explicit operator ExtensionObject?(Variant val) => (ExtensionObject?) val.Value;
+
+        /// <inheritdoc/>
+        public static implicit operator Variant(ExtensionObject[]? val) => new Variant(val);
+
+        /// <inheritdoc/>
+        public static explicit operator ExtensionObject[]?(Variant val) => (ExtensionObject[]?) val.Value;
 
     }
 

--- a/src/DataCore.Adapter.Core/Common/Variant.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.cs
@@ -16,6 +16,7 @@ namespace DataCore.Adapter.Common {
             [typeof(byte)] = VariantType.Byte,
             [typeof(DateTime)] = VariantType.DateTime,
             [typeof(double)] = VariantType.Double,
+            [typeof(ExtensionObject)] = VariantType.ExtensionObject,
             [typeof(float)] = VariantType.Float,
             [typeof(short)] = VariantType.Int16,
             [typeof(int)] = VariantType.Int32,
@@ -775,6 +776,50 @@ namespace DataCore.Adapter.Common {
 
             Value = value;
             Type = VariantType.Url;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        public Variant(ExtensionObject? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.ExtensionObject;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(ExtensionObject[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.ExtensionObject;
             ArrayDimensions = GetArrayDimensions(value);
         }
 

--- a/src/DataCore.Adapter.Core/Common/VariantType.cs
+++ b/src/DataCore.Adapter.Core/Common/VariantType.cs
@@ -16,10 +16,10 @@
         /// </summary>
         Null = 1,
 
-        ///// <summary>
-        ///// Custom object.
-        ///// </summary>
-        //Object = 2,
+        /// <summary>
+        /// Custom object.
+        /// </summary>
+        ExtensionObject = 2,
 
         /// <summary>
         /// Boolean.

--- a/src/DataCore.Adapter.Grpc.Client/DataCore.Adapter.Grpc.Client.csproj
+++ b/src/DataCore.Adapter.Grpc.Client/DataCore.Adapter.Grpc.Client.csproj
@@ -6,6 +6,7 @@
     <Description>gRPC client for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">

--- a/src/DataCore.Adapter.Json/ExtensionObjectConverter.cs
+++ b/src/DataCore.Adapter.Json/ExtensionObjectConverter.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Text.Json;
+
+using DataCore.Adapter.Common;
+
+namespace DataCore.Adapter.Json {
+
+    /// <summary>
+    /// JSON converter for <see cref="ExtensionObject"/>.
+    /// </summary>
+    public class ExtensionObjectConverter : AdapterJsonConverter<ExtensionObject> {
+
+
+        /// <inheritdoc/>
+        public override ExtensionObject Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+            if (reader.TokenType != JsonTokenType.StartObject) {
+                ThrowInvalidJsonError();
+            }
+
+            Uri typeId = null!;
+            string encoding = null!;
+            byte[] encodedBody = null!;
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject) {
+                if (reader.TokenType != JsonTokenType.PropertyName) {
+                    continue;
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read()) {
+                    ThrowInvalidJsonError();
+                }
+
+                if (string.Equals(propertyName, nameof(ExtensionObject.TypeId), StringComparison.OrdinalIgnoreCase)) {
+                    typeId = JsonSerializer.Deserialize<Uri>(ref reader, options)!;
+                }
+                else if (string.Equals(propertyName, nameof(ExtensionObject.Encoding), StringComparison.OrdinalIgnoreCase)) {
+                    encoding = JsonSerializer.Deserialize<string>(ref reader, options)!;
+                }
+                else if (string.Equals(propertyName, nameof(ExtensionObject.EncodedBody), StringComparison.OrdinalIgnoreCase)) {
+                    // Body is encoded as a base64web string.
+                    var base64webBody = JsonSerializer.Deserialize<string>(ref reader, options);
+                    if (base64webBody == null) {
+                        encodedBody = Array.Empty<byte>();
+                    }
+                    else {
+                        encodedBody = Base64WebDecode(base64webBody);
+                    }
+                }
+                else {
+                    reader.Skip();
+                }
+            }
+
+            return new ExtensionObject(typeId, encoding, encodedBody);
+        }
+
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, ExtensionObject value, JsonSerializerOptions options) {
+            if (value == null) {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStartObject();
+            WritePropertyValue(writer, nameof(ExtensionObject.TypeId), value.TypeId, options);
+            WritePropertyValue(writer, nameof(ExtensionObject.Encoding), value.Encoding, options);
+            WritePropertyValue(writer, nameof(ExtensionObject.EncodedBody), Base64WebEncode(value.EncodedBody), options);
+            writer.WriteEndObject();
+        }
+
+
+        /// <summary>
+        /// Converts the specified bytes to a base64web string.
+        /// </summary>
+        /// <param name="bytes">
+        ///   The bytes.
+        /// </param>
+        /// <returns>
+        ///   The encoded base64web string.
+        /// </returns>
+        private static string Base64WebEncode(byte[] bytes) {
+            return Convert.ToBase64String(bytes).Replace('/', '_').Replace('+', '-').TrimEnd('=');
+        }
+
+
+        /// <summary>
+        /// Converts the specified base64web string to a byte array.
+        /// </summary>
+        /// <param name="bytes">
+        ///   The base64web-encoded byte string.
+        /// </param>
+        /// <returns>
+        ///   The byte array.
+        /// </returns>
+        private static byte[] Base64WebDecode(string bytes) {
+            var base64 = bytes
+                .Replace('-', '+')
+                .Replace('_', '/');
+
+            switch (base64.Length % 4) {
+                case 0:
+                    // No padding required
+                    break;
+                case 2:
+                    // Pad with '=='
+                    base64 = base64 + "==";
+                    break;
+                case 3:
+                    // Pad with '='
+                    base64 = base64 + "=";
+                    break;
+            }
+
+            return Convert.FromBase64String(base64);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="ExtensionObject"/> with the specified type ID and value that 
+        /// encodes the value using JSON.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The value type.
+        /// </typeparam>
+        /// <param name="typeId">
+        ///   The type ID.
+        /// </param>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        /// <param name="options">
+        ///   Options to control the conversion behaviour.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="ExtensionObject"/> with an <see cref="ExtensionObject.Encoding"/> 
+        ///   set to <c>application/json</c> and a JSON-encoded <see cref="ExtensionObject.EncodedBody"/>.
+        /// </returns>
+        public static ExtensionObject CreateExtensionObject<T>(Uri typeId, T value, JsonSerializerOptions? options = null) {
+            if (typeId == null) {
+                throw new ArgumentNullException(nameof(typeId));
+            }
+
+            if (value == null) {
+                return new ExtensionObject(typeId, "application/json", Array.Empty<byte>());
+            }
+
+            return new ExtensionObject(typeId, "application/json", JsonSerializer.SerializeToUtf8Bytes(value, options));
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.Json/README.md
+++ b/src/DataCore.Adapter.Json/README.md
@@ -1,3 +1,3 @@
 ﻿# DataCore.Adapter.Json
 
-Extensions for [System.Text.Json](https://www.nuget.org/packages/System.Text.Json) such as custom converters. The project will be deprecated once `System.Text.Json` supports deserialization via non-default constructors.
+Extensions for [System.Text.Json](https://www.nuget.org/packages/System.Text.Json) such as custom converters.

--- a/test/DataCore.Adapter.Tests/VariantTests.cs
+++ b/test/DataCore.Adapter.Tests/VariantTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using DataCore.Adapter.Common;
@@ -14,6 +15,7 @@ namespace DataCore.Adapter.Tests {
         [DataRow(typeof(byte), typeof(byte[]), typeof(byte[,]), typeof(byte[,,]))]
         [DataRow(typeof(DateTime), typeof(DateTime[]), typeof(DateTime[,]), typeof(DateTime[,,]))]
         [DataRow(typeof(double), typeof(double[]), typeof(double[,]), typeof(double[,,]))]
+        [DataRow(typeof(ExtensionObject), typeof(ExtensionObject[]), typeof(ExtensionObject[,]), typeof(ExtensionObject[,,]))]
         [DataRow(typeof(float), typeof(float[]), typeof(float[,]), typeof(float[,,]))]
         [DataRow(typeof(short), typeof(short[]), typeof(short[,]), typeof(short[,,]))]
         [DataRow(typeof(int), typeof(int[]), typeof(int[,]), typeof(int[,,]))]
@@ -562,6 +564,58 @@ namespace DataCore.Adapter.Tests {
         }
 
 
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromExtensionObject() {
+            var value = Json.ExtensionObjectConverter.CreateExtensionObject(new Uri("asc:types/test"), new Dictionary<string, string>() { 
+                ["Intelligent"] = "Plant"
+            });
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.ExtensionObject, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowImplicitConversionFromExtensionObjectArray() {
+            var value = new[] {
+                Json.ExtensionObjectConverter.CreateExtensionObject(new Uri("asc:types/test"), new Dictionary<string, string>() {
+                    ["Intelligent"] = "Plant"
+                }),
+                Json.ExtensionObjectConverter.CreateExtensionObject(new Uri("asc:types/test"), new Dictionary<string, string>() {
+                    ["Industrial"] = "App Store"
+                })
+            };
+            Variant variant = value;
+            ValidateVariant(variant, VariantType.ExtensionObject, value, new[] { value.Length });
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToExtensionObject() {
+            var value = Json.ExtensionObjectConverter.CreateExtensionObject(new Uri("asc:types/test"), new Dictionary<string, string>() {
+                ["Intelligent"] = "Plant"
+            });
+            Variant variant = value;
+            var actualValue = (ExtensionObject) variant;
+            Assert.AreEqual(value, actualValue);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowExplicitConversionToExtensionObjectArray() {
+            var value = new[] {
+                Json.ExtensionObjectConverter.CreateExtensionObject(new Uri("asc:types/test"), new Dictionary<string, string>() {
+                    ["Intelligent"] = "Plant"
+                }),
+                Json.ExtensionObjectConverter.CreateExtensionObject(new Uri("asc:types/test"), new Dictionary<string, string>() {
+                    ["Industrial"] = "App Store"
+                })
+            };
+            Variant variant = value;
+            var actualValue = (ExtensionObject[]) variant;
+            Assert.IsTrue(value.SequenceEqual(actualValue));
+        }
+
+
         [DataTestMethod]
         [DataRow(VariantType.Boolean, true)]
         [DataRow(VariantType.Boolean, false)]
@@ -612,6 +666,16 @@ namespace DataCore.Adapter.Tests {
             object value = new Uri("https://appstore.intelligentplant.com");
             var variant = new Variant(value);
             ValidateVariant(variant, VariantType.Url, value, null);
+        }
+
+
+        [TestMethod]
+        public void VariantShouldAllowCreationFromExtensionObjectAsObject() {
+            object value = Json.ExtensionObjectConverter.CreateExtensionObject(new Uri("asc:types/test"), new Dictionary<string, string>() {
+                ["Intelligent"] = "Plant"
+            });
+            var variant = new Variant(value);
+            ValidateVariant(variant, VariantType.ExtensionObject, value, null);
         }
 
 


### PR DESCRIPTION
- `ExtensionObject` is analogous to the same concept in OPC UA i.e. it can be used to define a custom `Variant` value that is not one of the standard variant types. Extension objects specify a type identifier that can be used by the consumer to identify the type, an encoded body containing the actual object, and an encoding type (such as `application/json`) so that the consumer can correctly decode the object.
- In addition to encoding `ExtensionObject` instances to/from JSON, `ExtensionObjectConverter` also defines a static `CreateExtensionObject<T>` method that allows JSON-encoded extension objects to be easily created.