### PR TITLE
Miscellaneous updates

### DIFF
--- a/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
@@ -78,16 +78,12 @@ namespace DataCore.Adapter.AspNetCoreExample {
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddJsonOptions(options => {
                     options.JsonSerializerOptions.WriteIndented = true;
-                    options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
                 })
                 .AddDataCoreAdapterMvc();
 
             services
                 .AddSignalR()
                 .AddDataCoreAdapterSignalR()
-                .AddJsonProtocol(options => {
-                    options.PayloadSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
-                })
                 .AddMessagePackProtocol();
 
             services

--- a/examples/DataCore.Adapter.ExampleAdapter/IExampleExtensionFeature.cs
+++ b/examples/DataCore.Adapter.ExampleAdapter/IExampleExtensionFeature.cs
@@ -16,25 +16,10 @@ namespace DataCore.Adapter.Example {
     public interface IExampleExtensionFeature : IAdapterExtensionFeature {
 
         [ExtensionFeatureOperation(typeof(ExampleAdapter.ExampleExtensionImpl), nameof(ExampleAdapter.ExampleExtensionImpl.GetPingDescriptor))]
-        PongMessage Ping(
-            PingMessage ping
+        InvocationResponse Ping(
+            IAdapterCallContext context,
+            string correlationId
         );
-
-    }
-
-
-    [ExtensionFeatureDataType(typeof(IExampleExtensionFeature), "ping-message")]
-    public class PingMessage {
-
-        public Guid CorrelationId { get; set; } = Guid.NewGuid();
-
-    }
-
-
-    [ExtensionFeatureDataType(typeof(IExampleExtensionFeature), "pong-message")]
-    public class PongMessage {
-
-        public Guid CorrelationId { get; set; } = Guid.NewGuid();
 
     }
 

--- a/src/DataCore.Adapter.AspNetCore.Mvc/MvcConfigurationExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/MvcConfigurationExtensions.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Extensions.DependencyInjection {
 
             builder.AddApplicationPart(typeof(MvcConfigurationExtensions).Assembly);
 #if NETSTANDARD2_0
-            builder.AddJsonOptions(options => options.SerializerSettings.Converters.AddDataCoreAdapterConverters());
+            builder.AddJsonOptions(options => options.SerializerSettings.AddDataCoreAdapterConverters());
 #else
-            builder.AddJsonOptions(options => options.JsonSerializerOptions.Converters.AddDataCoreAdapterConverters());
+            builder.AddJsonOptions(options => options.JsonSerializerOptions.AddDataCoreAdapterConverters());
 #endif
 
             return builder;

--- a/src/DataCore.Adapter.AspNetCore.SignalR/SignalRConfigurationExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/SignalRConfigurationExtensions.cs
@@ -45,11 +45,11 @@ namespace Microsoft.Extensions.DependencyInjection {
 
 #if NETSTANDARD2_0
             return builder.AddJsonProtocol(options => {
-                options.PayloadSerializerSettings.Converters.AddDataCoreAdapterConverters();
+                options.PayloadSerializerSettings.AddDataCoreAdapterConverters();
             });
 #else
             return builder.AddJsonProtocol(options => {
-                options.PayloadSerializerOptions.Converters.AddDataCoreAdapterConverters();
+                options.PayloadSerializerOptions.AddDataCoreAdapterConverters();
             });
 #endif
         }

--- a/src/DataCore.Adapter.Json/JsonObjectEncoder.cs
+++ b/src/DataCore.Adapter.Json/JsonObjectEncoder.cs
@@ -14,7 +14,7 @@ namespace DataCore.Adapter.Json {
         /// Default <see cref="JsonObjectEncoder"/> instance. You can use this instance if you do 
         /// not need to modify default <see cref="JsonSerializerOptions"/> settings.
         /// </summary>
-        public static JsonObjectEncoder Default { get; } = new JsonObjectEncoder();
+        public static IObjectEncoder Default { get; } = new JsonObjectEncoder();
 
         /// <inheritdoc/>
         public override string EncodingType => "json";

--- a/src/DataCore.Adapter.Json/JsonSerializerOptionsExtensions.cs
+++ b/src/DataCore.Adapter.Json/JsonSerializerOptionsExtensions.cs
@@ -39,12 +39,36 @@ namespace DataCore.Adapter.Json {
         /// <summary>
         /// Registers adapter-related converters.
         /// </summary>
-        /// <param name="converters">
+        /// <param name="options">
         ///   The JSON serialization options.
         /// </param>
+        public static void AddDataCoreAdapterConverters(this JsonSerializerOptions? options) {
+            if (options == null) {
+                return;
+            }
+
+            options.Converters.AddDataCoreAdapterConverters();
+        }
+
+
+        /// <summary>
+        /// Registers adapter-related converters.
+        /// </summary>
+        /// <param name="converters">
+        ///   The JSON converter collection.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="converters"/> is <see langword="null"/>.
+        /// </exception>
         public static void AddDataCoreAdapterConverters(this IList<JsonConverter> converters) {
             if (converters == null) {
                 throw new ArgumentNullException(nameof(converters));
+            }
+
+            // Add a string enum converter if one has not already been registered.
+
+            if (!converters.OfType<JsonStringEnumConverter>().Any()) {
+                converters.Add(new JsonStringEnumConverter());
             }
 
             foreach (var item in s_converters) {

--- a/src/DataCore.Adapter/AdapterRequestExtensions.cs
+++ b/src/DataCore.Adapter/AdapterRequestExtensions.cs
@@ -10,7 +10,7 @@ namespace DataCore.Adapter {
     public static class AdapterRequestExtensions {
 
         /// <summary>
-        /// Selects a page of items based on the paging settings in a request
+        /// Selects a page of items based on the paging settings in a request.
         /// </summary>
         /// <param name="items">
         ///   The items to select from.
@@ -39,7 +39,51 @@ namespace DataCore.Adapter {
                 return items;
             }
 
-            return items.Skip(request.PageSize * (request.Page - 1)).Take(request.PageSize);
+            return items.SelectPage(request.PageSize, request.Page);
+        }
+
+
+        /// <summary>
+        /// Selects a page of items.
+        /// </summary>
+        /// <param name="items">
+        ///   The items to select from.
+        /// </param>
+        /// <param name="pageSize">
+        ///   The page size.
+        /// </param>
+        /// <param name="page">
+        ///   The page number.
+        /// </param>
+        /// <returns>
+        ///   The selected items.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="items"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   If <paramref name="pageSize"/> is less than one, a page size of one will be used.
+        /// </para>
+        /// 
+        /// <para>
+        ///   If <paramref name="page"/> is less than one, the first page of items will be selected.
+        /// </para>
+        /// 
+        /// </remarks>
+        public static IEnumerable<T> SelectPage<T>(this IOrderedEnumerable<T> items, int pageSize, int page) {
+            if (items == null) {
+                throw new ArgumentNullException(nameof(items));
+            }
+            if (pageSize < 1) {
+                pageSize = 1;
+            }
+            if (page < 1) {
+                page = 1;
+            }
+
+            return items.Skip(pageSize * (page - 1)).Take(pageSize);
         }
 
     }

--- a/src/DataCore.Adapter/AssetModel/AssetModelNodeExtensions.cs
+++ b/src/DataCore.Adapter/AssetModel/AssetModelNodeExtensions.cs
@@ -77,6 +77,38 @@ namespace DataCore.Adapter.AssetModel {
             return nodes.Where(x => x.MatchesFilter(filter)).OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase).SelectPage(filter);
         }
 
+
+        /// <summary>
+        /// Applies filter terms to the specified asset model nodes and selects a page of results.
+        /// </summary>
+        /// <param name="nodes">
+        ///   The nodes to filter and select.
+        /// </param>
+        /// <param name="filter">
+        ///   The filter to apply.
+        /// </param>
+        /// <returns>
+        ///   The matching nodes.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="nodes"/> is <see langword="null"/>.
+        /// </exception>
+        public static IEnumerable<AssetModelNode> ApplyFilter(this IEnumerable<AssetModelNode> nodes, BrowseAssetModelNodesRequest? filter) {
+            if (nodes == null) {
+                throw new ArgumentNullException(nameof(nodes));
+            }
+
+            if (filter == null) {
+                return nodes;
+            }
+
+            var result = filter.ParentId == null
+                ? nodes.Where(x => x.Parent == null)
+                : nodes.Where(x => filter.ParentId.Equals(x.Parent, StringComparison.OrdinalIgnoreCase));
+
+            return nodes.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase).SelectPage(filter);
+        }
+
     }
 
 }

--- a/src/DataCore.Adapter/Tags/TagDefinitionExtensions.cs
+++ b/src/DataCore.Adapter/Tags/TagDefinitionExtensions.cs
@@ -97,7 +97,11 @@ namespace DataCore.Adapter.Tags {
                 return tags;
             }
 
-            return tags.Where(x => x.MatchesFilter(filter)).OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase).SelectPage(filter);
+            return tags
+                .Where(x => x.MatchesFilter(filter))
+                .OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .SelectPage(filter)
+                .Select(x => filter.ResultFields == TagDefinitionFields.All ? x : x.Clone(filter.ResultFields));
         }
 
 


### PR DESCRIPTION
- Return type of `JsonObjectEncoder.Default` is now `IObjectEncoder` (easier to call e.g. `Encode` and `Decode` methods without having to cast to `IObjectEncoder` first).
- Allow `SnapshotTagValuePush` to keep cached tag values even when a tag has no subscribers, and add a `ReadSnapshotTagValues` method that is compatible with `IReadSnapshotTagValues`. This allows a `SnapshotTagValuePush` instance to be used as a cache when an adapter implements `IReadSnapshotTagValues` if required.
- `JsonStringEnumConverter` is registered when calling `AddDataCoreAdapterConverters` extension method if it is not already present in the JSON converters collection. This ensures that e.g. SignalR and HTTP clients can deserialize enum values that have been serialized as strings by the server.
- Improvements to extension methods for automatically applying `FindTagsRequest`, `BrowseAssetModelNodesRequest`, and `FindAssetModelNodesRequest`