### PR TITLE
Allow automatic feature registration to be disabled

### DIFF
--- a/src/DataCore.Adapter/AdapterBaseT.cs
+++ b/src/DataCore.Adapter/AdapterBaseT.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,6 +26,7 @@ namespace DataCore.Adapter {
     /// <typeparam name="TAdapterOptions">
     ///   The options type for the adapter.
     /// </typeparam>
+    [AutomaticFeatureRegistration(true)]
     public abstract class AdapterBase<TAdapterOptions> : IAdapter where TAdapterOptions : AdapterOptions, new() {
 
         #region [ Fields / Properties ]
@@ -194,7 +196,12 @@ namespace DataCore.Adapter {
 
             _healthCheckManager = new HealthCheckManager<TAdapterOptions>(this);
             AddFeatures(_healthCheckManager);
-            AddFeatures(this);
+
+            // Automatically register features implemented directly on the adapter if required. 
+            var autoRegisterFeatures = GetType().GetCustomAttribute<AutomaticFeatureRegistrationAttribute>(true);
+            if (autoRegisterFeatures?.IsEnabled ?? true) {
+                AddFeatures(this);
+            }
         }
 
 

--- a/src/DataCore.Adapter/AutomaticFeatureRegistrationAttribute.cs
+++ b/src/DataCore.Adapter/AutomaticFeatureRegistrationAttribute.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace DataCore.Adapter {
+
+    /// <summary>
+    /// Adapters that are derived from <see cref="AdapterBase{TAdapterOptions}"/> can be annotated 
+    /// with this attribute to control if adapter features implemented directly by the adapter are 
+    /// automatically added to the adapter's <see cref="IAdapter.Features"/> collection by default.
+    /// </summary>
+    /// <remarks>
+    /// 
+    /// <para>
+    ///   The default behaviour of <see cref="AdapterBase{TAdapterOptions}"/> is to automatically 
+    ///   register all adapter features that are implemented on the adapter class. This behaviour 
+    ///   is inherited by derived types unless the derived type is annotated with its own 
+    ///   <see cref="AutomaticFeatureRegistrationAttribute"/> annotation that changes the 
+    ///   inherited behaviour. For example, if adapter class <c>AdapterA</c> is derived from 
+    ///   <see cref="AdapterBase{TAdapterOptions}"/> and is annotated with an <see cref="AutomaticFeatureRegistrationAttribute"/> 
+    ///   that disables automatic feature registration, adapters derived from <c>AdapterA</c> will 
+    ///   also have automatic feature registration disabled by default.
+    /// </para>
+    /// 
+    /// <para>
+    ///   If automatic feature registration is disabled, it is the responsibility of the adapter 
+    ///   to add appropriate features to its <see cref="IAdapter.Features"/> collection.
+    /// </para>
+    /// 
+    /// <para>
+    ///   The <see cref="Diagnostics.IHealthCheck"/> feature provided by <see cref="AdapterBase{TAdapterOptions}"/> 
+    ///   will always be registered, regardless of whether or not automatic feature registration 
+    ///   is enabled.
+    /// </para>
+    /// 
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class AutomaticFeatureRegistrationAttribute : Attribute {
+    
+        /// <summary>
+        /// Specifies if automatic feature registration is enabled for the adapter.
+        /// </summary>
+        public bool IsEnabled { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="AutomaticFeatureRegistrationAttribute"/> object.
+        /// </summary>
+        /// <param name="enabled">
+        ///   <see langword="true"/> to enable automatic feature registration for the adapter, or 
+        ///   <see langword="false"/> if the adapter will manually register all features.
+        /// </param>
+        /// <remarks>
+        ///   The <see cref="Diagnostics.IHealthCheck"/> feature provided by <see cref="AdapterBase{TAdapterOptions}"/> 
+        ///   will always be registered, regardless of whether or not automatic feature 
+        ///   registration is enabled.
+        /// </remarks>
+        public AutomaticFeatureRegistrationAttribute(bool enabled = true) {
+            IsEnabled = enabled;
+        }
+    
+    }
+}

--- a/src/DataCore.Adapter/SubscriptionChannel.cs
+++ b/src/DataCore.Adapter/SubscriptionChannel.cs
@@ -216,7 +216,7 @@ namespace DataCore.Adapter {
         ///   The value.
         /// </param>
         /// <param name="immediate">
-        ///   When <see langword="true"/>, the value will be sent to the <see cref="Reader"/> 
+        ///   When <see langword="true"/>, the value will be published to the subscriber
         ///   immediately, even if the subscription is using a publish interval.
         /// </param>
         /// <returns>

--- a/test/DataCore.Adapter.Tests/AutomaticFeatureRegistrationTests.cs
+++ b/test/DataCore.Adapter.Tests/AutomaticFeatureRegistrationTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.RealTimeData;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DataCore.Adapter.Tests {
+    [TestClass]
+    public class AutomaticFeatureRegistrationTests : TestsBase {
+
+        [TestMethod]
+        public void AdapterFeaturesShouldBeRegisteredByDefaultWhenInheritingFromAdapterBaseTOptions() {
+            // Ensures that automatic feature registration is enabled when inheriting from
+            // AdapterBase<TOptions>.
+            using (var adapter = new FeatureRegistrationEnabledAdapter(TestContext.TestName)) {
+                Assert.IsTrue(adapter.TryGetFeature<IReadSnapshotTagValues>(out var _));
+            }
+        }
+
+
+        [TestMethod]
+        public void AdapterFeaturesShouldNotBeRegisteredWhenAutomaticRegistrationIsExplicitlyDisabled() {
+            // Ensures that automatic feature registration is disabled when the adapter class is
+            // annotated with [AutomaticFeatureRegistration(false)].
+            using (var adapter = new FeatureRegistrationDisabledAdapter(TestContext.TestName)) {
+                Assert.IsFalse(adapter.TryGetFeature<IReadSnapshotTagValues>(out var _));
+            }
+        }
+
+
+        [TestMethod]
+        public void AdapterFeaturesShouldBeRegisteredWhenAutomaticRegistrationIsExplicitlyEnabled() {
+            // Ensures that automatic feature registration is enabled when the adapter class is
+            // annotated with [AutomaticFeatureRegistration(true)], even if the base class is
+            // annotated with [AutomaticFeatureRegistration(false)].
+            using (var adapter = new FeatureRegistrationEnabledAdapter2(TestContext.TestName)) {
+                Assert.IsTrue(adapter.TryGetFeature<IReadSnapshotTagValues>(out var _));
+            }
+        }
+
+
+        [TestMethod]
+        public void AdapterFeaturesShouldNotBeRegisteredWhenAutomaticRegistrationIsImplicitlyDisabled() {
+            // Ensures that automatic feature registration is disabled by default when inheriting
+            // from a base class that is annotated with [AutomaticFeatureRegistration(false)].
+            using (var adapter = new FeatureRegistrationDisabledAdapter2(TestContext.TestName)) {
+                Assert.IsFalse(adapter.TryGetFeature<IReadSnapshotTagValues>(out var _));
+            }
+        }
+
+
+        private abstract class TestAdapterBase : AdapterBase, IReadSnapshotTagValues {
+
+            protected TestAdapterBase(string id) : base(id, null, null, null, null) { }
+
+            protected override Task StartAsync(CancellationToken cancellationToken) {
+                return Task.CompletedTask;
+            }
+
+            protected override Task StopAsync(CancellationToken cancellationToken) {
+                return Task.CompletedTask;
+            }
+
+            public IAsyncEnumerable<TagValueQueryResult> ReadSnapshotTagValues(IAdapterCallContext context, ReadSnapshotTagValuesRequest request, CancellationToken cancellationToken) {
+                return Array.Empty<TagValueQueryResult>().PublishToChannel().ReadAllAsync(cancellationToken);
+            }
+
+        }
+
+
+        private class FeatureRegistrationEnabledAdapter : TestAdapterBase {
+
+            public FeatureRegistrationEnabledAdapter(string id) : base(id) { }
+
+        }
+
+
+        [AutomaticFeatureRegistration(false)]
+        private class FeatureRegistrationDisabledAdapter : TestAdapterBase {
+
+            public FeatureRegistrationDisabledAdapter(string id) : base(id) { }
+
+        }
+
+
+        [AutomaticFeatureRegistration]
+        private class FeatureRegistrationEnabledAdapter2 : FeatureRegistrationDisabledAdapter {
+
+            public FeatureRegistrationEnabledAdapter2(string id) : base(id) { }
+
+        }
+
+
+        private class FeatureRegistrationDisabledAdapter2 : FeatureRegistrationDisabledAdapter {
+
+            public FeatureRegistrationDisabledAdapter2(string id) : base(id) { }
+
+        }
+
+    }
+}


### PR DESCRIPTION
The current default behaviour in `AdapterBase<TOptions>` is to automatically register all adapter features that are implemented by the adapter class.

In some use cases, it may be desirable to disable automatic registration, so that features could be added to the adapter's `Features` collection only if they were enabled in an adapter's option. For example, an adapter author may want to implement a feature for writing tag values to an adapter, but only enable it at runtime if the adapter options specify that it should be enabled.

The solution to this situation is the new `[AutomaticFeatureRegistration(bool)]` attribute, which can be used to annotate any adapter class inheriting from `AdapterBase<TOptions>` to control automatic feature registration when the adapter is created.

`AdapterBase<TOptions>` itself is now annotated with `[AutomaticFeatureRegistration(true)]`, meaning that the current behaviour remains the default, but can be modified on a case-by-case basis as required.

If automatic feature registration is turned off, it is the responsibility of the adapter to add features to its `Features` collection as and when required.