### PR TITLE
Fixes #126

### DIFF
--- a/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
+++ b/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
@@ -182,6 +182,37 @@ namespace DataCore.Adapter.Tests {
         #region [ IAdapter ]
 
         /// <summary>
+        /// Ensures that exceptions are not thrown if an adapter is disposed multiple times.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public Task AdapterShouldAllowDisposeToBeCalledMultipleTimes() {
+            return RunAdapterTest((adapter, context, ct) => {
+                adapter.Dispose();
+                adapter.Dispose();
+                return Task.CompletedTask;
+            });
+        }
+
+
+        /// <summary>
+        /// Ensures that exceptions are not thrown if an adapter is disposed multiple times.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the test.
+        /// </returns>
+        [TestMethod]
+        public Task AdapterShouldAllowDisposeAsyncToBeCalledMultipleTimes() {
+            return RunAdapterTest(async (adapter, context, ct) => {
+                await adapter.DisposeAsync().ConfigureAwait(false);
+                await adapter.DisposeAsync().ConfigureAwait(false);
+            });
+        }
+
+
+        /// <summary>
         /// Verifies that the adapter's <see cref="IBackgroundTaskServiceProvider.BackgroundTaskService"/> 
         /// property is not <see langword="null"/>.
         /// </summary>

--- a/src/DataCore.Adapter/Diagnostics/ConfigurationChanges.cs
+++ b/src/DataCore.Adapter/Diagnostics/ConfigurationChanges.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
@@ -16,6 +15,12 @@ namespace DataCore.Adapter.Diagnostics {
     /// Default implementation of the <see cref="IConfigurationChanges"/> feature.
     /// </summary>
     public class ConfigurationChanges : SubscriptionManager<ConfigurationChangesOptions, string, ConfigurationChange, ConfigurationChangesSubscription>, IConfigurationChanges {
+
+        /// <summary>
+        /// Flags if the object has been disposed.
+        /// </summary>
+        private bool _isDisposed;
+
 
         /// <summary>
         /// Creates a new <see cref="ConfigurationChanges"/> object.
@@ -62,7 +67,7 @@ namespace DataCore.Adapter.Diagnostics {
             ConfigurationChangesSubscriptionRequest request, 
             CancellationToken cancellationToken
         ) {
-            if (IsDisposed) {
+            if (_isDisposed) {
                 throw new ObjectDisposedException(GetType().FullName);
             }
             if (context == null) {
@@ -91,7 +96,15 @@ namespace DataCore.Adapter.Diagnostics {
 
         /// <inheritdoc/>
         protected override bool IsTopicMatch(ConfigurationChange value, IEnumerable<string> topics) {
-            return topics.Any(x => string.Equals(value.ItemType, x, StringComparison.OrdinalIgnoreCase));
+            var result = topics.Any(x => string.Equals(value.ItemType, x, StringComparison.OrdinalIgnoreCase));
+            return result;
+        }
+
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing) {
+            base.Dispose(disposing);
+            _isDisposed = true;
         }
 
     }

--- a/src/DataCore.Adapter/Events/EventMessagePush.cs
+++ b/src/DataCore.Adapter/Events/EventMessagePush.cs
@@ -26,6 +26,11 @@ namespace DataCore.Adapter.Events {
     public class EventMessagePush : SubscriptionManager<EventMessagePushOptions, string, EventMessage, EventSubscriptionChannel>, IEventMessagePush {
 
         /// <summary>
+        /// Flags if the object has been disposed.
+        /// </summary>
+        private bool _isDisposed;
+
+        /// <summary>
         /// Indicates if the subscription manager holds any active subscriptions. If your adapter uses 
         /// a forward-only cursor that you do not want to advance when only passive listeners are 
         /// attached to the adapter, you can use this property to identify if any active listeners are 
@@ -80,7 +85,7 @@ namespace DataCore.Adapter.Events {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            if (IsDisposed) {
+            if (_isDisposed) {
                 throw new ObjectDisposedException(GetType().FullName);
             }
             if (context == null) {
@@ -125,6 +130,13 @@ namespace DataCore.Adapter.Events {
             result[Resources.HealthChecks_Data_PassiveSubscriberCount] = subscriptions.Count(x => x.SubscriptionType == EventMessageSubscriptionType.Passive).ToString(context?.CultureInfo);
 
             return result;
+        }
+
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing) {
+            base.Dispose(disposing);
+            _isDisposed = true;
         }
 
     }

--- a/src/DataCore.Adapter/RealTimeData/SnapshotTagValuePush.cs
+++ b/src/DataCore.Adapter/RealTimeData/SnapshotTagValuePush.cs
@@ -22,6 +22,11 @@ namespace DataCore.Adapter.RealTimeData {
     public class SnapshotTagValuePush : SubscriptionManager<SnapshotTagValuePushOptions, TagIdentifier, TagValueQueryResult, TagValueSubscriptionChannel>, ISnapshotTagValuePush {
 
         /// <summary>
+        /// Flags if the object has been disposed.
+        /// </summary>
+        private bool _isDisposed;
+
+        /// <summary>
         /// Holds the current values for subscribed tags indexed by tag ID.
         /// </summary>
         private readonly ConcurrentDictionary<string, TagValueQueryResult> _currentValueByTagId = new ConcurrentDictionary<string, TagValueQueryResult>(StringComparer.OrdinalIgnoreCase);
@@ -135,7 +140,7 @@ namespace DataCore.Adapter.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            if (IsDisposed) {
+            if (_isDisposed) {
                 throw new ObjectDisposedException(GetType().FullName);
             }
             if (context == null) {
@@ -630,12 +635,18 @@ namespace DataCore.Adapter.RealTimeData {
         protected override void Dispose(bool disposing) {
             base.Dispose(disposing);
 
+            if (_isDisposed) {
+                return;
+            }
+
             if (disposing) {
                 _topicSubscriptionChangesChannel.Writer.TryComplete();
                 lock (_subscriberCount) {
                     _subscriberCount.Clear();
                 }
             }
+
+            _isDisposed = true;
         }
 
     }


### PR DESCRIPTION
Fixes issue #126 by ensuring that the disposable pattern is correctly implemented in classes derived from `SubscriptionManager`.

Previously, the derived classes were not tracking their own `_isDisposed` flag, meaning that their `Dispose(bool)` methods were allowing disposing code to run multiple times. This caused an error because some dispose code attempted to cancel and then dispose of a `CancellationTokenSource`, but `CancellationTokenSource` throws an exception if you try and cancel it after it has been disposed.