### PR TITLE
Make SubscriptionManager.IsTopicMatch asynchronous

### DIFF
--- a/src/DataCore.Adapter/Diagnostics/ConfigurationChanges.cs
+++ b/src/DataCore.Adapter/Diagnostics/ConfigurationChanges.cs
@@ -95,9 +95,9 @@ namespace DataCore.Adapter.Diagnostics {
 
 
         /// <inheritdoc/>
-        protected override bool IsTopicMatch(ConfigurationChange value, IEnumerable<string> topics) {
+        protected override ValueTask<bool> IsTopicMatch(ConfigurationChange value, IEnumerable<string> topics, CancellationToken cancellationToken) {
             var result = topics.Any(x => string.Equals(value.ItemType, x, StringComparison.OrdinalIgnoreCase));
-            return result;
+            return new ValueTask<bool>(result);
         }
 
 

--- a/src/DataCore.Adapter/SubscriptionManager.cs
+++ b/src/DataCore.Adapter/SubscriptionManager.cs
@@ -206,12 +206,15 @@ namespace DataCore.Adapter {
         /// <param name="topics">
         ///   The topics.
         /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
         /// <returns>
         ///   <see langword="true"/> if the value matches any of the topics, or <see langword="false"/> 
         ///   otherwise.
         /// </returns>
-        protected virtual bool IsTopicMatch(TValue value, IEnumerable<TTopic> topics) {
-            return true;
+        protected virtual ValueTask<bool> IsTopicMatch(TValue value, IEnumerable<TTopic> topics, CancellationToken cancellationToken) {
+            return new ValueTask<bool>(true);
         }
 
 
@@ -380,7 +383,7 @@ namespace DataCore.Adapter {
 
             var subscribers = new List<TSubscription>();
             foreach (var sub in _subscriptions.Values) {
-                if (IsTopicMatch(message, sub.Topics)) {
+                if (await IsTopicMatch(message, sub.Topics, cancellationToken).ConfigureAwait(false)) {
                     subscribers.Add(sub);
                 }
             }

--- a/test/DataCore.Adapter.Tests/SubscriptionTests.cs
+++ b/test/DataCore.Adapter.Tests/SubscriptionTests.cs
@@ -342,10 +342,10 @@ namespace DataCore.Adapter.Tests {
 
             var options = new SnapshotTagValuePushOptions() {
                 TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray()),
-                IsTopicMatch = (subscribed, received) => {
+                IsTopicMatch = (subscribed, received, ct) => {
                     // If we subscribe to "tag_root", we should receive messages with a topic of 
                     // e.g. "tag_root/sub_tag".
-                    return received.Id.Equals(subscribed.Id) || received.Id.StartsWith(subscribed.Id + "/");
+                    return new ValueTask<bool>(received.Id.Equals(subscribed.Id) || received.Id.StartsWith(subscribed.Id + "/"));
                 }
             };
 
@@ -803,10 +803,10 @@ namespace DataCore.Adapter.Tests {
             var topicRoot = Guid.NewGuid().ToString();
 
             var options = new EventMessagePushWithTopicsOptions() {
-                IsTopicMatch = (subscribed, received) => {
+                IsTopicMatch = (subscribed, received, ct) => {
                     // If we subscribe to "topic_root", we should receive messages with a topic of 
                     // e.g. "topic_root/sub_topic".
-                    return received != null && received.StartsWith(subscribed);
+                    return new ValueTask<bool>(received != null && received.StartsWith(subscribed));
                 }
             };
 


### PR DESCRIPTION
`SubscriptionManager.IsTopicMatch` now returns `ValueTask<bool>` instead of `bool`.

This is to account for scenarios where some sort of asynchronous operation may be required to determine a topic match (e.g. in an asset model-based system such as OPC UA, it may be required to query the asset model to determine if a received event message should be forwarded to a subscriber who has subscribed to an ancestor of the node that emitted the message).