### PR TITLE
Simplify IAdapterAccessor and AdapterAccessor implementation

### DIFF
--- a/src/DataCore.Adapter.Abstractions/IAdapterAccessor.cs
+++ b/src/DataCore.Adapter.Abstractions/IAdapterAccessor.cs
@@ -26,9 +26,6 @@ namespace DataCore.Adapter {
         /// <param name="request">
         ///   The search filter.
         /// </param>
-        /// <param name="enabledOnly">
-        ///   When <see langword="true"/>, only enabled adapters will be returned.
-        /// </param>
         /// <param name="cancellationToken">
         ///   The cancellation token for the operation.
         /// </param>
@@ -38,8 +35,7 @@ namespace DataCore.Adapter {
         IAsyncEnumerable<IAdapter> FindAdapters(
             IAdapterCallContext context, 
             FindAdaptersRequest request, 
-            bool enabledOnly = true,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken
         );
 
 
@@ -52,9 +48,6 @@ namespace DataCore.Adapter {
         /// <param name="adapterId">
         ///   The ID of the adapter.
         /// </param>
-        /// <param name="enabledOnly">
-        ///   When <see langword="true"/>, the adapter will only be returned if it is enabled.
-        /// </param>
         /// <param name="cancellationToken">
         ///   The cancellation token for the operation.
         /// </param>
@@ -64,8 +57,7 @@ namespace DataCore.Adapter {
         Task<IAdapter?> GetAdapter(
             IAdapterCallContext context, 
             string adapterId,
-            bool enabledOnly = true,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken
         );
 
     }

--- a/src/DataCore.Adapter.AspNetCore.Grpc/Services/AdaptersServiceImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/Services/AdaptersServiceImpl.cs
@@ -45,7 +45,6 @@ namespace DataCore.Adapter.Grpc.Server.Services {
                     PageSize = request.PageSize,
                     Page = request.Page
                 },
-                true,
                 context.CancellationToken
             );
 
@@ -60,7 +59,7 @@ namespace DataCore.Adapter.Grpc.Server.Services {
         /// <inheritdoc/>
         public override async Task<GetAdapterResponse> GetAdapter(GetAdapterRequest request, ServerCallContext context) {
             var adapterCallContext = new GrpcAdapterCallContext(context);
-            var adapter = await _adapterAccessor.GetAdapter(adapterCallContext, request.AdapterId, true, context.CancellationToken).ConfigureAwait(false);
+            var adapter = await _adapterAccessor.GetAdapter(adapterCallContext, request.AdapterId, context.CancellationToken).ConfigureAwait(false);
 
             return new GetAdapterResponse() {
                 Adapter = adapter?.CreateExtendedAdapterDescriptor().ToGrpcExtendedAdapterDescriptor()

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
@@ -107,7 +107,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
                 // Don't allow arbitrarily large queries!
                 request.PageSize = 100;
             }
-            var adapters = _adapterAccessor.FindAdapters(callContext, request, true, cancellationToken);
+            var adapters = _adapterAccessor.FindAdapters(callContext, request, cancellationToken);
 
             var result = new List<AdapterDescriptor>(request.PageSize);
             await foreach (var item in adapters.ConfigureAwait(false)) {
@@ -136,7 +136,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [ProducesResponseType(typeof(AdapterDescriptorExtended), 200)]
         public async Task<IActionResult> GetAdapterById(string adapterId, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
-            var adapter = await _adapterAccessor.GetAdapter(callContext, adapterId, true, cancellationToken).ConfigureAwait(false);
+            var adapter = await _adapterAccessor.GetAdapter(callContext, adapterId, cancellationToken).ConfigureAwait(false);
             if (adapter == null) {
                 return BadRequest(string.Format(callContext.CultureInfo, Resources.Error_CannotResolveAdapterId, adapterId)); // 400
             }

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
@@ -58,7 +58,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [ProducesResponseType(typeof(IEnumerable<string>), 200)]
         public async Task<IActionResult> GetAvailableExtensions(string adapterId, CancellationToken cancellationToken = default) {
             var callContext = new HttpAdapterCallContext(HttpContext);
-            var adapter = await _adapterAccessor.GetAdapter(callContext, adapterId, true, cancellationToken).ConfigureAwait(false);
+            var adapter = await _adapterAccessor.GetAdapter(callContext, adapterId, cancellationToken).ConfigureAwait(false);
             if (adapter == null) {
                 return BadRequest(string.Format(callContext.CultureInfo, Resources.Error_CannotResolveAdapterId, adapterId)); // 400
             }

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
@@ -99,7 +99,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         ) {
             var adapterCallContext = new SignalRAdapterCallContext(Context);
 
-            await foreach (var item in AdapterAccessor.FindAdapters(adapterCallContext, request, true, cancellationToken).ConfigureAwait(false)) {
+            await foreach (var item in AdapterAccessor.FindAdapters(adapterCallContext, request, cancellationToken).ConfigureAwait(false)) {
                 yield return AdapterDescriptor.FromExisting(item.Descriptor);
             }
         }
@@ -116,7 +116,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         /// </returns>
         public async Task<AdapterDescriptorExtended> GetAdapter(string adapterId) {
             var adapterCallContext = new SignalRAdapterCallContext(Context);
-            var adapter = await AdapterAccessor.GetAdapter(adapterCallContext, adapterId, true, Context.ConnectionAborted).ConfigureAwait(false);
+            var adapter = await AdapterAccessor.GetAdapter(adapterCallContext, adapterId, Context.ConnectionAborted).ConfigureAwait(false);
             return adapter == null ? null! : adapter.CreateExtendedAdapterDescriptor();
         }
 

--- a/src/DataCore.Adapter/AdapterAccessorExtensions.cs
+++ b/src/DataCore.Adapter/AdapterAccessorExtensions.cs
@@ -38,7 +38,7 @@ namespace DataCore.Adapter {
             return adapterAccessor.FindAdapters(context, new Common.FindAdaptersRequest() { 
                 Page = 1,
                 PageSize = int.MaxValue
-            }, false, cancellationToken);
+            }, cancellationToken);
         }
 
 
@@ -82,8 +82,8 @@ namespace DataCore.Adapter {
                 throw new ArgumentNullException(nameof(featureUri));
             }
 
-            var adapter = await adapterAccessor.GetAdapter(context, adapterId, true, cancellationToken).ConfigureAwait(false);
-            if (adapter == null) {
+            var adapter = await adapterAccessor.GetAdapter(context, adapterId, cancellationToken).ConfigureAwait(false);
+            if (adapter == null || !adapter.IsEnabled) {
                 return new ResolvedAdapterFeature<TFeature>(null!, default!, false);
             }
 
@@ -121,7 +121,6 @@ namespace DataCore.Adapter {
         ///   A <see cref="ResolvedAdapterFeature{TFeature}"/> describing the adapter, feature, and 
         ///   authorization result.
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:Uri parameters should not be strings", Justification = "Parameter is not guaranteed to be a URI")]
         public static async Task<ResolvedAdapterFeature<TFeature>> GetAdapterAndFeature<TFeature>(
             this IAdapterAccessor adapterAccessor, 
             IAdapterCallContext context, 
@@ -132,8 +131,8 @@ namespace DataCore.Adapter {
                 throw new ArgumentNullException(nameof(adapterAccessor));
             }
             
-            var adapter = await adapterAccessor.GetAdapter(context, adapterId, true, cancellationToken).ConfigureAwait(false);
-            if (adapter == null) {
+            var adapter = await adapterAccessor.GetAdapter(context, adapterId, cancellationToken).ConfigureAwait(false);
+            if (adapter == null || !adapter.IsEnabled) {
                 return new ResolvedAdapterFeature<TFeature>(null!, default!, false);
             }
 

--- a/src/DataCore.Adapter/AdapterBaseT.cs
+++ b/src/DataCore.Adapter/AdapterBaseT.cs
@@ -493,7 +493,7 @@ namespace DataCore.Adapter {
         ///   starting.
         /// </param>
         protected void CheckStarted(bool allowStarting = false) {
-            if (IsRunning || (allowStarting && IsStarting)) {
+            if (IsEnabled && (IsRunning || (allowStarting && IsStarting))) {
                 return;
             }
 


### PR DESCRIPTION
`IAdapterAccessor` no longer makes an explicit demand on whether only enabled adapters should be returned or not; the expected behaviour is that only enabled adapters will be returned.

Additionally, when processing a `FindAdapters` request, `AdapterAccessor` no longer retrieves all adapters from the implementing class and applies filtering and paging in the base class. Instead, it provides helper methods to allow the implementing class to determine if an adapter matches a filter or if the caller is authorized to access the adapter.