### PR TITLE
ResolveTags now returns IAsyncEnumerable<T>

### DIFF
--- a/test/DataCore.Adapter.Tests/SubscriptionTests.cs
+++ b/test/DataCore.Adapter.Tests/SubscriptionTests.cs
@@ -19,7 +19,7 @@ namespace DataCore.Adapter.Tests {
         [TestMethod]
         public async Task SnapshotSubscriptionManagerShouldNotifyWhenSubscriptionIsAdded() {
             var options = new SnapshotTagValuePushOptions() {
-                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray())
+                TagResolver = (ctx, names, ct) => names.Select(name => new TagIdentifier(name, name)).PublishToChannel().ReadAllAsync(ct)
             };
 
             using (var feature = new SnapshotTagValuePush(options, null, null)) {
@@ -50,7 +50,7 @@ namespace DataCore.Adapter.Tests {
         [TestMethod]
         public async Task SnapshotSubscriptionManagerShouldNotifyWhenSubscriptionIsCancelled() {
             var options = new SnapshotTagValuePushOptions() {
-                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray())
+                TagResolver = (ctx, names, ct) => names.Select(name => new TagIdentifier(name, name)).PublishToChannel().ReadAllAsync(ct)
             };
 
             using (var feature = new SnapshotTagValuePush(options, null, null)) {
@@ -84,7 +84,7 @@ namespace DataCore.Adapter.Tests {
             var now = DateTime.UtcNow;
 
             var options = new SnapshotTagValuePushOptions() {
-                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray())
+                TagResolver = (ctx, names, ct) => names.Select(name => new TagIdentifier(name, name)).PublishToChannel().ReadAllAsync(ct)
             };
 
             using (var feature = new SnapshotTagValuePush(options, null, null)) {
@@ -130,7 +130,7 @@ namespace DataCore.Adapter.Tests {
             var now = DateTime.UtcNow;
 
             var options = new SnapshotTagValuePushOptions() {
-                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray())
+                TagResolver = (ctx, names, ct) => names.Select(name => new TagIdentifier(name, name)).PublishToChannel().ReadAllAsync(ct)
             };
 
             using (var feature = new SnapshotTagValuePush(options, null, null)) {
@@ -182,7 +182,7 @@ namespace DataCore.Adapter.Tests {
             var now = DateTime.UtcNow;
 
             var options = new SnapshotTagValuePushOptions() {
-                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray())
+                TagResolver = (ctx, names, ct) => names.Select(name => new TagIdentifier(name, name)).PublishToChannel().ReadAllAsync(ct)
             };
 
             using (var feature = new SnapshotTagValuePush(options, null, null)) {
@@ -247,7 +247,7 @@ namespace DataCore.Adapter.Tests {
             var publishInterval = TimeSpan.FromSeconds(1);
 
             var options = new SnapshotTagValuePushOptions() {
-                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray())
+                TagResolver = (ctx, names, ct) => names.Select(name => new TagIdentifier(name, name)).PublishToChannel().ReadAllAsync(ct)
             };
 
             var valueCount = 0;
@@ -290,7 +290,7 @@ namespace DataCore.Adapter.Tests {
 
             var options = new SnapshotTagValuePushOptions() {
                 MaxSubscriptionCount = 1,
-                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray())
+                TagResolver = (ctx, names, ct) => names.Select(name => new TagIdentifier(name, name)).PublishToChannel().ReadAllAsync(ct)
             };
 
             using (var feature = new SnapshotTagValuePush(options, null, null)) {
@@ -341,7 +341,7 @@ namespace DataCore.Adapter.Tests {
             var now = DateTime.UtcNow;
 
             var options = new SnapshotTagValuePushOptions() {
-                TagResolver = (ctx, names, ct) => new ValueTask<IEnumerable<TagIdentifier>>(names.Select(name => new TagIdentifier(name, name)).ToArray()),
+                TagResolver = (ctx, names, ct) => names.Select(name => new TagIdentifier(name, name)).PublishToChannel().ReadAllAsync(ct),
                 IsTopicMatch = (subscribed, received, ct) => {
                     // If we subscribe to "tag_root", we should receive messages with a topic of 
                     // e.g. "tag_root/sub_tag".


### PR DESCRIPTION
Updates `ResolveTags` method in `SnapshotTagValuePush` to return `IAsyncEnumerable<T>` instead of `ValueTask<IEnumerable<T>>`.

This is intended to allow implementations to stream results back from an adapter's `ITagInfo.GetTags` method, without having to worry about reading all results from that method's `IAsyncEnumerable<T>` before returning.

In `SnapshotTagValuePush`, resolved tags are now read from the `IAsyncEnumerable<T>` and then processed in batches of up to 100 tags. The static `CreateTagResolverFromAdapter` and `CreateTagResolverFromFeature` methods have been modified to match the new required signature, as has the `SnapshotTagValuePushOptions.TagResolver` property.