### PR TITLE
Allow use of bespoke interceptors in gRPC adapter proxy

### DIFF
--- a/src/DataCore.Adapter.Grpc.Proxy/GetGrpcClientInterceptors.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/GetGrpcClientInterceptors.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+using Grpc.Core.Interceptors;
+
+namespace DataCore.Adapter.Grpc.Proxy {
+
+    /// <summary>
+    /// Gets interceptors to add to a gRPC client.
+    /// </summary>
+    /// <returns>
+    ///   The interceptors.
+    /// </returns>
+    public delegate IEnumerable<Interceptor> GetGrpcClientInterceptors();
+
+}

--- a/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.cs
@@ -8,6 +8,7 @@ using GrpcNet = Grpc.Net;
 #endif
 
 using GrpcCore = Grpc.Core;
+using Grpc.Core.Interceptors;
 using DataCore.Adapter.Grpc.Client.Authentication;
 using DataCore.Adapter.Common;
 using IntelligentPlant.BackgroundTasks;
@@ -232,6 +233,11 @@ namespace DataCore.Adapter.Grpc.Proxy {
         ///   A new gRPC client instance.
         /// </returns>
         public TClient CreateClient<TClient>() where TClient : GrpcCore.ClientBase<TClient> {
+            var interceptors = Options.GetClientInterceptors?.Invoke()?.ToArray();
+            if (interceptors?.Length > 0) {
+                return (TClient) Activator.CreateInstance(typeof(TClient), _channel.Intercept(interceptors))!;
+            }
+
             return (TClient) Activator.CreateInstance(typeof(TClient), _channel)!;
         }
 

--- a/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxyOptions.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxyOptions.cs
@@ -24,15 +24,21 @@ namespace DataCore.Adapter.Grpc.Proxy {
         public TimeSpan HeartbeatInterval { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        /// A factory that can be used to set per-call credentials for gRPC calls.
+        /// A callback that can be used to set per-call credentials for gRPC calls.
         /// </summary>
-        public GetGrpcCallCredentials GetCallCredentials { get; set; } = default!;
+        public GetGrpcCallCredentials? GetCallCredentials { get; set; }
+
+        /// <summary>
+        /// A callback that is used to retrieve <see cref="GrpcCore.Interceptors.Interceptor"/> 
+        /// instances to attach to all gRPC clients created by the adapter.
+        /// </summary>
+        public GetGrpcClientInterceptors? GetClientInterceptors { get; set; }
 
         /// <summary>
         /// A factory method that the proxy calls to request a concrete implementation of an 
         /// extension feature.
         /// </summary>
-        public ExtensionFeatureFactory<GrpcAdapterProxy> ExtensionFeatureFactory { get; set; } = default!;
+        public ExtensionFeatureFactory<GrpcAdapterProxy>? ExtensionFeatureFactory { get; set; }
 
         /// <summary>
         /// When <see langword="true"/>, <see cref="GrpcCore.ChannelBase.ShutdownAsync"/> will be 

--- a/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
+++ b/src/DataCore.Adapter.Tests.Helpers/AdapterTestsBase.cs
@@ -81,10 +81,13 @@ namespace DataCore.Adapter.Tests {
         /// <param name="callback">
         ///   The callback delegate that will perform the test.
         /// </param>
+        /// <param name="startAdapter">
+        ///   When <see langword="true"/>, the adapter will be started before running the test.
+        /// </param>
         /// <returns>
         ///   A <see cref="Task"/> that will run the test.
         /// </returns>
-        protected async Task RunAdapterTest(Func<TAdapter, IAdapterCallContext, CancellationToken, Task> callback) {
+        protected async Task RunAdapterTest(Func<TAdapter, IAdapterCallContext, CancellationToken, Task> callback, bool startAdapter = true) {
             if (callback == null) {
                 throw new ArgumentNullException(nameof(callback));
             }
@@ -97,7 +100,9 @@ namespace DataCore.Adapter.Tests {
                 }
 
                 try {
-                    await adapter.StartAsync(CancellationToken).ConfigureAwait(false);
+                    if (startAdapter) {
+                        await adapter.StartAsync(CancellationToken).ConfigureAwait(false);
+                    }
                     var context = CreateCallContext(TestContext);
                     await callback(adapter, context, CancellationToken).ConfigureAwait(false);
                 }

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -53,6 +53,9 @@
         <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.SignalR\DataCore.Adapter.AspNetCore.SignalR.csproj" />
         <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.SignalR.Proxy\DataCore.Adapter.AspNetCore.SignalR.Proxy.csproj" />
         <ProjectReference Include="..\..\src\DataCore.Adapter.Grpc.Proxy\DataCore.Adapter.Grpc.Proxy.csproj" />
+        <ProjectReference Include="..\..\src\DataCore.Adapter.Grpc.Client\DataCore.Adapter.Grpc.Client.csproj">
+          <Aliases>DataCoreAdapterGrpcClient</Aliases>
+        </ProjectReference>
       </ItemGroup>
     </When>
     <!-- .NET Framework 4.8 references -->

--- a/test/DataCore.Adapter.Tests/GrpcProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/GrpcProxyTests.cs
@@ -1,6 +1,16 @@
-﻿using System;
-#if NETCOREAPP
+﻿#if NETCOREAPP
+extern alias DataCoreAdapterGrpcClient;
+
+using System;
+using System.Threading.Tasks;
+
 using DataCore.Adapter.Grpc.Proxy;
+
+using DataCoreAdapterGrpcClient::DataCore.Adapter.Grpc;
+
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -9,11 +19,51 @@ namespace DataCore.Adapter.Tests {
     [TestClass]
     public class GrpcProxyTests : ProxyAdapterTests<GrpcAdapterProxy> {
 
-        protected override GrpcAdapterProxy CreateProxy(string remoteAdapterId, IServiceProvider serviceProvider) {
-
-            return ActivatorUtilities.CreateInstance<GrpcAdapterProxy>(serviceProvider, nameof(GrpcProxyTests), new GrpcAdapterProxyOptions() {
+        protected override GrpcAdapterProxy CreateProxy(TestContext context, string remoteAdapterId, IServiceProvider serviceProvider) {
+            var options = new GrpcAdapterProxyOptions() {
                 RemoteId = remoteAdapterId
-            });
+            };
+
+            if (string.Equals(context.TestName, nameof(GrpcAdapterProxyShouldAddInterceptorToClient))) {
+                var interceptor = new TestInterceptor();
+                context.Properties.Add(nameof(TestInterceptor), interceptor);
+                options.GetClientInterceptors = () => {
+                    return new[] {
+                        interceptor
+                    };
+                };
+            }
+
+            return ActivatorUtilities.CreateInstance<GrpcAdapterProxy>(serviceProvider, nameof(GrpcProxyTests), options);
+        }
+
+
+        [TestMethod]
+        public Task GrpcAdapterProxyShouldAddInterceptorToClient() {
+            return RunAdapterTest(async (adapter, ctx, ct) => {
+                var interceptor = TestContext.Properties[nameof(TestInterceptor)] as TestInterceptor;
+                Assert.IsNotNull(interceptor);
+
+                var client = adapter.CreateClient<HostInfoService.HostInfoServiceClient>();
+
+                Assert.IsFalse(interceptor.Intercepted);
+                var hostInfo = client.GetHostInfoAsync(new GetHostInfoRequest(), cancellationToken: ct);
+                var response = await hostInfo.ResponseAsync.ConfigureAwait(false);
+                Assert.IsTrue(interceptor.Intercepted);
+
+            }, false);
+        }
+
+
+        private class TestInterceptor : Interceptor {
+
+            public bool Intercepted { get; private set; }
+
+            public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, AsyncUnaryCallContinuation<TRequest, TResponse> continuation) {
+                Intercepted = true;
+                return continuation(request, context);
+            }
+
         }
 
     }

--- a/test/DataCore.Adapter.Tests/HttpProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/HttpProxyTests.cs
@@ -30,7 +30,7 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected override HttpAdapterProxy CreateProxy(string remoteAdapterId, IServiceProvider serviceProvider) {
+        protected override HttpAdapterProxy CreateProxy(TestContext context, string remoteAdapterId, IServiceProvider serviceProvider) {
             return ActivatorUtilities.CreateInstance<HttpAdapterProxy>(serviceProvider, nameof(HttpProxyTests), new HttpAdapterProxyOptions() {
                 RemoteId = remoteAdapterId
             });

--- a/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
@@ -26,7 +26,7 @@ namespace DataCore.Adapter.Tests {
 
 
         protected sealed override TProxy CreateAdapter(TestContext context, IServiceProvider serviceProvider) {
-            return CreateProxy(WebHostConfiguration.AdapterId, serviceProvider);
+            return CreateProxy(context, WebHostConfiguration.AdapterId, serviceProvider);
         }
 
 
@@ -305,7 +305,7 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected abstract TProxy CreateProxy(string remoteAdapterId, IServiceProvider serviceProvider);
+        protected abstract TProxy CreateProxy(TestContext context, string remoteAdapterId, IServiceProvider serviceProvider);
 
 
 

--- a/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
@@ -12,7 +12,7 @@ namespace DataCore.Adapter.Tests {
 
     public abstract class SignalRProxyTests : ProxyAdapterTests<SignalRAdapterProxy> {
 
-        protected sealed override SignalRAdapterProxy CreateProxy(string remoteAdapterId, IServiceProvider serviceProvider) {
+        protected sealed override SignalRAdapterProxy CreateProxy(TestContext context, string remoteAdapterId, IServiceProvider serviceProvider) {
             return ActivatorUtilities.CreateInstance<SignalRAdapterProxy>(serviceProvider, nameof(SignalRProxyTests), new SignalRAdapterProxyOptions() {
                 RemoteId = remoteAdapterId,
                 ConnectionFactory = key => {


### PR DESCRIPTION
Adds a new  `GetClientInterceptors` property to `GrpcAdapterProxyOptions`, which can be used to provide gRPC interceptors to attach to all gRPC client objects created by a `GrpcAdapterProxy`.

The motivation is to allow OpenTelemetry support to be added to gRPC adapter proxies that are using Grpc.Core instead of Grpc.Net.Client (via [this package](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Contrib.Instrumentation.GrpcCore)).

This also allows arbitrary interceptors to be added, which may be of general use anyway.