### PR TITLE
MVC controller and SignalR route changes

### DIFF
--- a/examples/DataCore.Adapter.AspNetCoreExample/Properties/launchSettings.json
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "DataCore.Adapter.AspNetCoreExample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/app-store-connect/v1.0/host-info",
+      "launchUrl": "api/app-store-connect/v2.0/host-info",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
@@ -17,7 +17,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// </summary>
     [ApiController]
     [Area("app-store-connect")]
-    [Route("api/[area]/v1.0/adapters")]
+    [Route("api/[area]/v2.0/adapters")]
     // Legacy route for compatibility with v1 of the toolkit
     [Route("api/data-core/v1.0/adapters")] 
     public class AdaptersController : ControllerBase {

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AssetModelBrowserController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AssetModelBrowserController.cs
@@ -17,7 +17,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// </summary>
     [ApiController]
     [Area("app-store-connect")]
-    [Route("api/[area]/v1.0/asset-model")]
+    [Route("api/[area]/v2.0/asset-model")]
     // Legacy route for compatibility with v1 of the toolkit
     [Route("api/data-core/v1.0/asset-model")] 
     public class AssetModelBrowserController : ControllerBase {

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/EventsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/EventsController.cs
@@ -20,7 +20,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// </summary>
     [ApiController]
     [Area("app-store-connect")]
-    [Route("api/[area]/v1.0/events")]
+    [Route("api/[area]/v2.0/events")]
     // Legacy route for compatibility with v1 of the toolkit
     [Route("api/data-core/v1.0/events")] 
     public class EventsController : ControllerBase {

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
@@ -19,7 +19,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// </summary>
     [ApiController]
     [Area("app-store-connect")]
-    [Route("api/[area]/v1.0/extensions")]
+    [Route("api/[area]/v2.0/extensions")]
     // Legacy route for compatibility with v1 of the toolkit
     [Route("api/data-core/v1.0/extensions")] 
     public class ExtensionFeaturesController : ControllerBase {

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/HostInfoController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/HostInfoController.cs
@@ -13,7 +13,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// </summary>
     [ApiController]
     [Area("app-store-connect")]
-    [Route("api/[area]/v1.0/host-info")]
+    [Route("api/[area]/v2.0/host-info")]
     // Legacy route for compatibility with v1 of the toolkit
     [Route("api/data-core/v1.0/host-info")] 
     public class HostInfoController: ControllerBase {

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagAnnotationsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagAnnotationsController.cs
@@ -17,7 +17,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// </summary>
     [ApiController]
     [Area("app-store-connect")]
-    [Route("api/[area]/v1.0/tag-annotations")]
+    [Route("api/[area]/v2.0/tag-annotations")]
     // Legacy route for compatibility with v1 of the toolkit
     [Route("api/data-core/v1.0/tag-annotations")] 
     public class TagAnnotationsController: ControllerBase {

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
@@ -18,7 +18,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// </summary>
     [ApiController]
     [Area("app-store-connect")]
-    [Route("api/[area]/v1.0/tags")]
+    [Route("api/[area]/v2.0/tags")]
     // Legacy route for compatibility with v1 of the toolkit
     [Route("api/data-core/v1.0/tags")] 
     public class TagSearchController : ControllerBase {

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagValuesController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagValuesController.cs
@@ -21,7 +21,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     /// </summary>
     [ApiController]
     [Area("app-store-connect")]
-    [Route("api/[area]/v1.0/tag-values")]
+    [Route("api/[area]/v2.0/tag-values")]
     // Legacy route for compatibility with v1 of the toolkit
     [Route("api/data-core/v1.0/tag-values")] 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Validation is performed by MVC framework")]

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/AdapterSignalRClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/AdapterSignalRClient.cs
@@ -15,7 +15,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client {
         /// <summary>
         /// The relative SignalR hub route.
         /// </summary>
-        public const string DefaultHubRoute = "/signalr/app-store-connect/v1.0";
+        public const string DefaultHubRoute = "/signalr/app-store-connect/v2.0";
 
         /// <summary>
         /// Indicates if the client has been diposed.

--- a/src/DataCore.Adapter.AspNetCore.SignalR/SignalRConfigurationExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/SignalRConfigurationExtensions.cs
@@ -20,13 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection {
         /// <summary>
         /// SignalR Hub route.
         /// </summary>
-        public const string HubRoute = "/signalr/app-store-connect/v1.0";
-
-        /// <summary>
-        /// Legacy SignalR hub route.
-        /// </summary>
-        [Obsolete("Use HubRoute instead.", false)]
-        private const string LegacyHubRoute = "/signalr/data-core/v1.0";
+        public const string HubRoute = "/signalr/app-store-connect/v2.0";
 
 
         /// <summary>
@@ -74,7 +68,6 @@ namespace Microsoft.Extensions.DependencyInjection {
                 throw new ArgumentNullException(nameof(endpoints));
             }
             endpoints.MapHub<AdapterHub>(HubRoute);
-            endpoints.MapHub<AdapterHub>(LegacyHubRoute);
             return endpoints;
         }
 
@@ -111,9 +104,6 @@ namespace Microsoft.Extensions.DependencyInjection {
         /// </returns>
         public static IEndpointRouteBuilder MapDataCoreAdapterHubs(this IEndpointRouteBuilder endpoints, Action<Type, HubEndpointConventionBuilder>? builder) {
             var hubEndpointBuilder = endpoints.MapHub<AdapterHub>(HubRoute);
-            builder?.Invoke(typeof(AdapterHub), hubEndpointBuilder);
-
-            hubEndpointBuilder = endpoints.MapHub<AdapterHub>(LegacyHubRoute);
             builder?.Invoke(typeof(AdapterHub), hubEndpointBuilder);
 
             return endpoints;

--- a/src/DataCore.Adapter.Http.Client/AdapterHttpClient.cs
+++ b/src/DataCore.Adapter.Http.Client/AdapterHttpClient.cs
@@ -160,6 +160,18 @@ namespace DataCore.Adapter.Http.Client {
         }
 
 
+        /// <summary>
+        /// Gets the base relative API path to use.
+        /// </summary>
+        /// <returns>
+        ///   The base relative API path for the client.
+        /// </returns>
+        internal string GetBaseUrl() {
+            return CompatibilityVersion == CompatibilityVersion.Version_1_0
+                ? "api/data-core/v1.0"
+                : "api/app-store-connect/v2.0";
+        }
+
 
         /// <summary>
         /// Creates a new <see cref="HttpRequestMessage"/> that has the specified metadata attached.
@@ -182,7 +194,6 @@ namespace DataCore.Adapter.Http.Client {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="url"/> is <see langword="null"/>.
         /// </exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller is responsible for disposing the object")]
         protected internal static HttpRequestMessage CreateHttpRequestMessage(
             HttpMethod method, 
             Uri url, 

--- a/src/DataCore.Adapter.Http.Client/Clients/AdaptersClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/AdaptersClient.cs
@@ -18,9 +18,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0 
-            ? "api/data-core/v1.0/adapters" 
-            : "api/app-store-connect/v1.0/adapters";
+        private string UrlPrefix => string.Concat(_client.GetBaseUrl(), "/adapters");
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/AssetModelBrowserClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/AssetModelBrowserClient.cs
@@ -17,9 +17,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
-            ? "api/data-core/v1.0/asset-model"
-            : "api/app-store-connect/v1.0/asset-model";
+        private string UrlPrefix => string.Concat(_client.GetBaseUrl(), "/asset-model");
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/EventsClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/EventsClient.cs
@@ -17,9 +17,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
-            ? "api/data-core/v1.0/events"
-            : "api/app-store-connect/v1.0/events";
+        private string UrlPrefix => string.Concat(_client.GetBaseUrl(), "/events");
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/ExtensionFeaturesClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/ExtensionFeaturesClient.cs
@@ -18,9 +18,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
-            ? "api/data-core/v1.0/extensions"
-            : "api/app-store-connect/v1.0/extensions";
+        private string UrlPrefix => string.Concat(_client.GetBaseUrl(), "/extensions");
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/HostInfoClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/HostInfoClient.cs
@@ -16,9 +16,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
-            ? "api/data-core/v1.0/host-info"
-            : "api/app-store-connect/v1.0/host-info";
+        private string UrlPrefix => string.Concat(_client.GetBaseUrl(), "/host-info");
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/TagSearchClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagSearchClient.cs
@@ -18,9 +18,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
-            ? "api/data-core/v1.0/tags"
-            : "api/app-store-connect/v1.0/tags";
+        private string UrlPrefix => string.Concat(_client.GetBaseUrl(), "/tags");
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/TagValueAnnotationsClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagValueAnnotationsClient.cs
@@ -17,9 +17,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
-            ? "api/data-core/v1.0/tag-annotations"
-            : "api/app-store-connect/v1.0/tag-annotations";
+        private string UrlPrefix => string.Concat(_client.GetBaseUrl(), "/tag-annotations");
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.

--- a/src/DataCore.Adapter.Http.Client/Clients/TagValuesClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagValuesClient.cs
@@ -17,9 +17,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
         /// <summary>
         /// The URL prefix for API calls.
         /// </summary>
-        private string UrlPrefix => _client.CompatibilityVersion == CompatibilityVersion.Version_1_0
-            ? "api/data-core/v1.0/tag-values"
-            : "api/app-store-connect/v1.0/tag-values";
+        private string UrlPrefix => string.Concat(_client.GetBaseUrl(), "/tag-values");
 
         /// <summary>
         /// The adapter HTTP client that is used to perform the requests.


### PR DESCRIPTION
MVC and SignalR routes have been modified to specify `v2.0` instead of `v1.0`.

This change serves to highlight the major API changes between v1 and v2 of the toolkit, and also to try and distinguish the toolkit API routes from the existing Industrial App Store data APIs.