### PR TITLE
Fixes #139

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.HealthChecks/AdapterHealthCheckBuilderExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.HealthChecks/AdapterHealthCheckBuilderExtensions.cs
@@ -23,7 +23,20 @@ namespace Microsoft.Extensions.DependencyInjection {
         /// <returns>
         ///   The <paramref name="builder"/>.
         /// </returns>
-        public static IHealthChecksBuilder AddAdapterHeathChecks(this IHealthChecksBuilder builder) {
+        [Obsolete("This method has a typo in the name. Use " + nameof(AddAdapterHealthChecks) + " instead.", false)]
+        public static IHealthChecksBuilder AddAdapterHeathChecks(this IHealthChecksBuilder builder) => builder.AddAdapterHealthChecks();
+
+
+        /// <summary>
+        /// Registers adapter health checks with ASP.NET Core.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="IHealthChecksBuilder"/> to register the adapter health checks with.
+        /// </param>
+        /// <returns>
+        ///   The <paramref name="builder"/>.
+        /// </returns>
+        public static IHealthChecksBuilder AddAdapterHealthChecks(this IHealthChecksBuilder builder) {
             if (builder == null) {
                 throw new ArgumentNullException(nameof(builder));
             }


### PR DESCRIPTION
Leaves the incorrect method name but marks it as deprecated, and suggests to use the new correctly-spelled method instead.