### PR TITLE
Add RFC 7807 support to adapter HTTP client

### DIFF
--- a/examples/ExampleHostedAdapter/README_TEMPLATE.md
+++ b/examples/ExampleHostedAdapter/README_TEMPLATE.md
@@ -35,8 +35,8 @@ You can connect to the adapter host using REST API calls, SignalR, or gRPC. Use 
 
 To connect a local App Store Connect instance to your adapter using the REST API, configure a new `App Store Connect Adapter (HTTP Proxy)` data source in the App Store Connect UI, using the following settings:
 
-- **Address:** https://localhost:44300/
-- **Adapter ID:** fdb421d7-03b2-49e8-880a-224e8e5f04ef
+- `Address`: https://localhost:44300/
+- `Adapter ID`: fdb421d7-03b2-49e8-880a-224e8e5f04ef
 
 
 ## SignalR

--- a/src/DataCore.Adapter.Http.Client/AdapterHttpClient.cs
+++ b/src/DataCore.Adapter.Http.Client/AdapterHttpClient.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+
 using DataCore.Adapter.Http.Client.Clients;
 using DataCore.Adapter.Json;
 
@@ -194,7 +195,7 @@ namespace DataCore.Adapter.Http.Client {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="url"/> is <see langword="null"/>.
         /// </exception>
-        protected internal static HttpRequestMessage CreateHttpRequestMessage(
+        public static HttpRequestMessage CreateHttpRequestMessage(
             HttpMethod method, 
             Uri url, 
             RequestMetadata? metadata
@@ -227,7 +228,7 @@ namespace DataCore.Adapter.Http.Client {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="url"/> is <see langword="null"/>.
         /// </exception>
-        protected internal static HttpRequestMessage CreateHttpRequestMessage(
+        public static HttpRequestMessage CreateHttpRequestMessage(
             HttpMethod method, 
             string url, 
             RequestMetadata? metadata
@@ -270,7 +271,7 @@ namespace DataCore.Adapter.Http.Client {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="url"/> is <see langword="null"/>.
         /// </exception>
-        protected internal static HttpRequestMessage CreateHttpRequestMessage<TContent>(
+        public static HttpRequestMessage CreateHttpRequestMessage<TContent>(
             HttpMethod method, 
             Uri url, 
             TContent content, 
@@ -281,6 +282,43 @@ namespace DataCore.Adapter.Http.Client {
             result.Content = System.Net.Http.Json.JsonContent.Create(content, options: options);
 
             return result;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="HttpRequestMessage"/> that has the specified content and metadata attached.
+        /// </summary>
+        /// <typeparam name="TContent">
+        ///   The type of the <paramref name="content"/>.
+        /// </typeparam>
+        /// <param name="method">
+        ///   The request method.
+        /// </param>
+        /// <param name="url">
+        ///   The request URL.
+        /// </param>
+        /// <param name="content">
+        ///   The content for the request. The content will be serialized to JSON.
+        /// </param>
+        /// <param name="metadata">
+        ///   The request metadata.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="HttpRequestMessage"/> object.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="method"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="url"/> is <see langword="null"/>.
+        /// </exception>
+        public HttpRequestMessage CreateHttpRequestMessage<TContent>(
+            HttpMethod method,
+            Uri url,
+            TContent content,
+            RequestMetadata? metadata
+        ) {
+            return CreateHttpRequestMessage(method, url, content, metadata, JsonSerializerOptions);
         }
 
 
@@ -314,7 +352,7 @@ namespace DataCore.Adapter.Http.Client {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="url"/> is <see langword="null"/>.
         /// </exception>
-        protected internal static HttpRequestMessage CreateHttpRequestMessage<TContent>(
+        public static HttpRequestMessage CreateHttpRequestMessage<TContent>(
             HttpMethod method, 
             string url, 
             TContent content, 
@@ -328,6 +366,43 @@ namespace DataCore.Adapter.Http.Client {
                 metadata,
                 options
             );
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="HttpRequestMessage"/> that has the specified content and metadata attached.
+        /// </summary>
+        /// <typeparam name="TContent">
+        ///   The type of the <paramref name="content"/>.
+        /// </typeparam>
+        /// <param name="method">
+        ///   The request method.
+        /// </param>
+        /// <param name="url">
+        ///   The request URL.
+        /// </param>
+        /// <param name="content">
+        ///   The content for the request. The content will be serialized to JSON.
+        /// </param>
+        /// <param name="metadata">
+        ///   The request metadata.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="HttpRequestMessage"/> object.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="method"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="url"/> is <see langword="null"/>.
+        /// </exception>
+        public HttpRequestMessage CreateHttpRequestMessage<TContent>(
+            HttpMethod method,
+            string url,
+            TContent content,
+            RequestMetadata? metadata
+        ) {
+            return CreateHttpRequestMessage(method, url, content, metadata, JsonSerializerOptions);
         }
 
     }

--- a/src/DataCore.Adapter.Http.Client/AdapterHttpClientException.cs
+++ b/src/DataCore.Adapter.Http.Client/AdapterHttpClientException.cs
@@ -1,0 +1,259 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DataCore.Adapter.Http.Client {
+
+    /// <summary>
+    /// Exception raised when an adapter HTTP request returns a result with a non-good status code.
+    /// </summary>
+    public class AdapterHttpClientException : HttpRequestException {
+
+        /// <summary>
+        /// Gets the HTTP verb that was used in the request.
+        /// </summary>
+        public string Verb { get; }
+
+        /// <summary>
+        /// Gets the URL that was used in the request.
+        /// </summary>
+        public string Url { get; }
+
+        /// <summary>
+        /// Gets the HTTP status code that was returned.
+        /// </summary>
+        public HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// The HTTP request headers.
+        /// </summary>
+        public IDictionary<string, string[]> RequestHeaders { get; }
+
+        /// <summary>
+        /// The HTTP response headers.
+        /// </summary>
+        public IDictionary<string, string[]> ResponseHeaders { get; }
+
+        /// <summary>
+        /// Gets the response content that was returned.
+        /// </summary>
+        public string? Content { get; }
+
+        /// <summary>
+        /// The RFC 7807 problem details object that was returned in the response body, if 
+        /// available.
+        /// </summary>
+        public ProblemDetails? ProblemDetails { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="AdapterHttpClientException"/> object.
+        /// </summary>
+        /// <param name="message">
+        ///   The error message.
+        /// </param>
+        /// <param name="verb">
+        ///   The HTTP verb.
+        /// </param>
+        /// <param name="url">
+        ///   The request URL.
+        /// </param>
+        /// <param name="statusCode">
+        ///   The HTTP status code.
+        /// </param>
+        /// <param name="requestHeaders">
+        ///   The HTTP request headers.
+        /// </param>
+        /// <param name="responseHeaders">
+        ///   The HTTP response headers.
+        /// </param>
+        /// <param name="responseContent">
+        ///   The response content.
+        /// </param>
+        /// <param name="problemDetails">
+        ///   The RFC 7807 problem details object describing the error.
+        /// </param>
+        public AdapterHttpClientException(string message, string verb, string url, HttpStatusCode statusCode, IDictionary<string, string[]> requestHeaders, IDictionary<string, string[]> responseHeaders, string? responseContent, ProblemDetails? problemDetails)
+            : this(message, verb, url, statusCode, requestHeaders, responseHeaders, responseContent, problemDetails, null) { }
+
+
+        /// <summary>
+        /// Creates a new <see cref="AdapterHttpClientException"/> object with an inner exception.
+        /// </summary>
+        /// <param name="message">
+        ///   The error message.
+        /// </param>
+        /// <param name="verb">
+        ///   The HTTP verb.
+        /// </param>
+        /// <param name="url">
+        ///   The request URL.
+        /// </param>
+        /// <param name="statusCode">
+        ///   The HTTP status code.
+        /// </param>
+        /// <param name="requestHeaders">
+        ///   The HTTP request headers.
+        /// </param>
+        /// <param name="responseHeaders">
+        ///   The HTTP response headers.
+        /// </param>
+        /// <param name="responseContent">
+        ///   The response content.
+        /// </param>
+        /// <param name="problemDetails">
+        ///   The RFC 7807 problem details object describing the error.
+        /// </param>
+        /// <param name="inner">
+        ///   The inner exception.
+        /// </param>
+        public AdapterHttpClientException(string message, string verb, string url, HttpStatusCode statusCode, IDictionary<string, string[]> requestHeaders, IDictionary<string, string[]> responseHeaders, string? responseContent, ProblemDetails? problemDetails, Exception? inner)
+            : base(message, inner) {
+            Verb = verb;
+            Url = url;
+            StatusCode = statusCode;
+            RequestHeaders = new ReadOnlyDictionary<string, string[]>(requestHeaders ?? new Dictionary<string, string[]>());
+            ResponseHeaders = new ReadOnlyDictionary<string, string[]>(responseHeaders ?? new Dictionary<string, string[]>());
+            Content = responseContent;
+            ProblemDetails = problemDetails;
+        }
+
+
+        /// <summary>
+        /// Creates an <see cref="AdapterHttpClientException"/> using the specified HTTP response 
+        /// message.
+        /// </summary>
+        /// <param name="errorMessage">
+        ///   The error message.
+        /// </param>
+        /// <param name="response">
+        ///   The HTTP response.
+        /// </param>
+        /// <returns>
+        /// A task that will return the exception.
+        /// </returns>
+        /// <remarks>
+        ///   If the response contains an RFC 7807 problem details object, the <see cref="ProblemDetails"/> 
+        ///   property of the exception will be set.
+        /// </remarks>
+        internal static Task<AdapterHttpClientException> FromHttpResponseMessage(string errorMessage, HttpResponseMessage response) {
+            return FromHttpResponseMessage(errorMessage, response, null);
+        }
+
+
+        /// <summary>
+        /// Creates an <see cref="AdapterHttpClientException"/> with an inner exception, using 
+        /// the specified HTTP response message.
+        /// </summary>
+        /// <param name="errorMessage">
+        ///   The error message.
+        /// </param>
+        /// <param name="response">
+        ///   The HTTP response.
+        /// </param>
+        /// <param name="inner">
+        ///   The inner exception.
+        /// </param>
+        /// <returns>
+        /// A task that will return the exception.
+        /// </returns>
+        /// <remarks>
+        ///   If the response contains an RFC 7807 problem details object, the <see cref="ProblemDetails"/> 
+        ///   property of the exception will be set.
+        /// </remarks>
+        internal static async Task<AdapterHttpClientException> FromHttpResponseMessage(string errorMessage, HttpResponseMessage response, Exception? inner) {
+            if (response == null) {
+                throw new ArgumentNullException(nameof(response));
+            }
+
+            var requestHeaders = response.RequestMessage.Content == null
+                ? response.RequestMessage.Headers.ToDictionary(x => x.Key, x => x.Value.ToArray())
+                : response.RequestMessage.Headers.Concat(response.RequestMessage.Content.Headers).ToDictionary(x => x.Key, x => x.Value.ToArray());
+
+            var responseHeaders = response.Content == null
+                ? response.Headers.ToDictionary(x => x.Key, x => x.Value.ToArray())
+                : response.Headers.Concat(response.Content.Headers).ToDictionary(x => x.Key, x => x.Value.ToArray());
+
+            string? content = null;
+            ProblemDetails? problemDetails = null;
+
+            if (response.Content != null) {
+                var includeContent = responseHeaders.TryGetValue("Content-Type", out var contentTypes) && contentTypes != null
+                    ? contentTypes.Any(CanIncludeContent)
+                    : false;
+
+                if (includeContent) {
+                    content = await response.Content!.ReadAsStringAsync().ConfigureAwait(false);
+                }
+
+                if (content != null && includeContent && contentTypes.Any(IsProblemDetailsResponse)) {
+                    problemDetails = System.Text.Json.JsonSerializer.Deserialize<ProblemDetails>(content);
+                };
+            }
+
+            return new AdapterHttpClientException(
+                problemDetails == null
+                    ? errorMessage
+                    : string.Concat(errorMessage, " ", Resources.Error_SeeProblemDetails),
+                response.RequestMessage.Method.Method,
+                response.RequestMessage.RequestUri.ToString(),
+                response.StatusCode,
+                requestHeaders,
+                responseHeaders,
+                content,
+                problemDetails,
+                inner
+            );
+        }
+
+
+        /// <summary>
+        /// Tests if the specified content type represents an RFC 7807 response.
+        /// </summary>
+        /// <param name="contentType">
+        ///   The content type.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the content type is an RFC 7807 object, or <see langword="false"/> 
+        ///   otherwise.
+        /// </returns>
+        private static bool IsProblemDetailsResponse(string contentType) {
+            return contentType.StartsWith(ProblemDetails.JsonMediaType);
+        }
+
+
+        /// <summary>
+        /// Tests if the content of an HTTP response can be included in a 
+        /// <see cref="AdapterHttpClientException"/>.
+        /// </summary>
+        /// <param name="contentType">
+        ///   The content type of the response.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the content can be included; otherwise, 
+        ///   <see langword="false"/>.
+        /// </returns>
+        private static bool CanIncludeContent(string contentType) {
+            if (string.IsNullOrWhiteSpace(contentType)) {
+                return false;
+            }
+            if (IsProblemDetailsResponse(contentType)) {
+                return true;
+            }
+            if (contentType.StartsWith("application/json")) {
+                return true;
+            }
+            if (contentType.StartsWith("text/")) {
+                return true;
+            }
+
+            return false;
+        }
+
+    }
+
+}

--- a/src/DataCore.Adapter.Http.Client/Clients/AdaptersClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/AdaptersClient.cs
@@ -64,7 +64,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, UrlPrefix, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<AdapterDescriptor>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -102,7 +102,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Get, url, metadata))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<AdapterDescriptorExtended>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -139,7 +139,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Get, url, metadata))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<HealthCheckResult>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }

--- a/src/DataCore.Adapter.Http.Client/Clients/AssetModelBrowserClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/AssetModelBrowserClient.cs
@@ -81,7 +81,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<AssetModelNode>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -129,7 +129,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<AssetModelNode>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -178,7 +178,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<AssetModelNode>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }

--- a/src/DataCore.Adapter.Http.Client/Clients/EventsClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/EventsClient.cs
@@ -81,7 +81,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<EventMessage>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -130,7 +130,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<EventMessageWithCursorPosition>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -180,7 +180,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<WriteEventMessageResult>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }

--- a/src/DataCore.Adapter.Http.Client/Clients/ExtensionFeaturesClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/ExtensionFeaturesClient.cs
@@ -81,7 +81,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Get, url, metadata))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<FeatureDescriptor>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -129,7 +129,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Get, url, metadata))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<ExtensionFeatureOperationDescriptor>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -178,7 +178,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<InvocationResponse>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }

--- a/src/DataCore.Adapter.Http.Client/Clients/HostInfoClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/HostInfoClient.cs
@@ -56,7 +56,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
         ) {
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Get, UrlPrefix, metadata))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<HostInfo>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }

--- a/src/DataCore.Adapter.Http.Client/Clients/TagSearchClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagSearchClient.cs
@@ -82,7 +82,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<TagDefinition>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -131,7 +131,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<TagDefinition>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -180,7 +180,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<AdapterProperty>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }

--- a/src/DataCore.Adapter.Http.Client/Clients/TagValueAnnotationsClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagValueAnnotationsClient.cs
@@ -81,7 +81,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Get, url, metadata))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<TagValueAnnotationExtended>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -130,7 +130,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<TagValueAnnotationQueryResult>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -179,7 +179,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request?.Annotation, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<WriteTagValueAnnotationResult>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -228,7 +228,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Put, url, request?.Annotation, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<WriteTagValueAnnotationResult>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -277,7 +277,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Delete, url, metadata))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<WriteTagValueAnnotationResult>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }

--- a/src/DataCore.Adapter.Http.Client/Clients/TagValuesClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/TagValuesClient.cs
@@ -81,7 +81,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<TagValueQueryResult>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -130,7 +130,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<TagValueQueryResult>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -179,7 +179,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<TagValueQueryResult>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -228,7 +228,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<TagValueQueryResult>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -272,7 +272,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<DataFunctionDescriptor>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -321,7 +321,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<ProcessedTagValueQueryResult>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -370,7 +370,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<WriteTagValueResult>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
@@ -419,7 +419,7 @@ namespace DataCore.Adapter.Http.Client.Clients {
 
             using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Post, url, request, metadata, _client.JsonSerializerOptions))
             using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
-                httpResponse.EnsureSuccessStatusCode();
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<WriteTagValueResult>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }

--- a/src/DataCore.Adapter.Http.Client/HttpRequestMessageExtensions.cs
+++ b/src/DataCore.Adapter.Http.Client/HttpRequestMessageExtensions.cs
@@ -9,34 +9,6 @@ namespace DataCore.Adapter.Http.Client {
     public static class HttpRequestMessageExtensions {
 
         /// <summary>
-        /// Sets a correlation ID on the request by setting the <c>Request-Id</c> header.
-        /// </summary>
-        /// <param name="request">
-        ///   The request.
-        /// </param>
-        /// <param name="correlationId">
-        ///   The correlation ID.
-        /// </param>
-        /// <returns>
-        ///   The <paramref name="request"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="request"/> is <see langword="null"/>.
-        /// </exception>
-        private static HttpRequestMessage AddCorrelationId(this HttpRequestMessage request, string? correlationId) {
-            if (request == null) {
-                throw new ArgumentNullException(nameof(request));
-            }
-
-            if (!string.IsNullOrWhiteSpace(correlationId)) {
-                request.Headers.Add("Request-Id", correlationId);
-            }
-
-            return request;
-        }
-
-
-        /// <summary>
         /// Associates metadata with the request.
         /// </summary>
         /// <param name="request">
@@ -59,9 +31,7 @@ namespace DataCore.Adapter.Http.Client {
                 }
             }
 
-            return request
-                .AddStateProperty(metadata)
-                .AddCorrelationId(metadata?.CorrelationId);
+            return request.AddStateProperty(metadata);
         }
 
 

--- a/src/DataCore.Adapter.Http.Client/HttpResponseMessageExtensions.cs
+++ b/src/DataCore.Adapter.Http.Client/HttpResponseMessageExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DataCore.Adapter.Http.Client {
+
+    /// <summary>
+    /// Extensions for <see cref="HttpResponseMessage"/>
+    /// </summary>
+    public static class HttpResponseMessageExtensions {
+
+        /// <summary>
+        /// Throws an <see cref="AdapterHttpClientException"/> if the response returned a non-good 
+        /// status code.
+        /// </summary>
+        /// <param name="response">
+        ///   The response.
+        /// </param>
+        /// <returns>
+        ///   A task that will throw an <see cref="AdapterHttpClientException"/> if the response 
+        ///   returned a non-good status code.
+        /// </returns>
+        public static async ValueTask ThrowOnErrorResponse(this HttpResponseMessage response) {
+            if (response == null) {
+                throw new ArgumentNullException(nameof(response));
+            }
+            if (response.IsSuccessStatusCode) {
+                return;
+            }
+
+            var msg = string.Format(CultureInfo.CurrentCulture, Resources.Error_DefaultHttpErrorMessage, response.RequestMessage.Method.Method, response.RequestMessage.RequestUri, (int) response.StatusCode, response.ReasonPhrase);
+            throw await AdapterHttpClientException.FromHttpResponseMessage(msg, response).ConfigureAwait(false);
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.Http.Client/ProblemDetails.cs
+++ b/src/DataCore.Adapter.Http.Client/ProblemDetails.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace DataCore.Adapter.Http.Client {
+
+    /// <summary>
+    /// An RFC 7807 problem details object.
+    /// </summary>
+    public class ProblemDetails {
+
+        /// <summary>
+        /// Media type for a JSON-encoded problem details object.
+        /// </summary>
+        public const string JsonMediaType = "application/problem+json";
+
+        /// <summary>
+        /// A URI reference that identifies the problem type.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        /// <summary>
+        /// A short, human-readable summary of the problem.
+        /// </summary>
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// The HTTP status code for the problem.
+        /// </summary>
+        [JsonPropertyName("status")]
+        public int? Status { get; set; }
+
+        /// <summary>
+        /// A human-readable explanation of the problem.
+        /// </summary>
+        [JsonPropertyName("detail")]
+        public string? Detail { get; set; }
+
+        /// <summary>
+        /// A URI reference that identifies the specific occurrence of the problem.
+        /// </summary>
+        [JsonPropertyName("instance")]
+        public string? Instance { get; set; }
+
+        /// <summary>
+        /// A dictionary of extension members for the problem.
+        /// </summary>
+        /// <remarks>
+        ///   Problem type definitions may extend the problem details object with additional 
+        ///   members. When the object is deserialized, these additonal members are added to 
+        ///   this dictionary.
+        /// </remarks>
+        [JsonExtensionData]
+        public IDictionary<string, object>? Extensions { get; set; }
+
+    }
+}

--- a/src/DataCore.Adapter.Http.Client/Resources.Designer.cs
+++ b/src/DataCore.Adapter.Http.Client/Resources.Designer.cs
@@ -61,11 +61,29 @@ namespace DataCore.Adapter.Http.Client {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A non-good status code was returned: {0} {1} {2}/{3}..
+        /// </summary>
+        internal static string Error_DefaultHttpErrorMessage {
+            get {
+                return ResourceManager.GetString("Error_DefaultHttpErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A value is required for this parameter..
         /// </summary>
         internal static string Error_ParameterIsRequired {
             get {
                 return ResourceManager.GetString("Error_ParameterIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;ProblemDetails&apos; property on the exception contains the RFC 7807 response received from the server..
+        /// </summary>
+        internal static string Error_SeeProblemDetails {
+            get {
+                return ResourceManager.GetString("Error_SeeProblemDetails", resourceCulture);
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Client/Resources.resx
+++ b/src/DataCore.Adapter.Http.Client/Resources.resx
@@ -117,7 +117,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Error_DefaultHttpErrorMessage" xml:space="preserve">
+    <value>A non-good status code was returned: {0} {1} {2}/{3}.</value>
+    <comment>{0} - HTTP verb
+{1} - URL
+{2} - status code
+{3} - reason phrase</comment>
+  </data>
   <data name="Error_ParameterIsRequired" xml:space="preserve">
     <value>A value is required for this parameter.</value>
+  </data>
+  <data name="Error_SeeProblemDetails" xml:space="preserve">
+    <value>The 'ProblemDetails' property on the exception contains the RFC 7807 response received from the server.</value>
   </data>
 </root>

--- a/test/DataCore.Adapter.Tests/HttpClientTests.cs
+++ b/test/DataCore.Adapter.Tests/HttpClientTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.Http.Client;
+using DataCore.Adapter.RealTimeData;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DataCore.Adapter.Tests {
+
+    [TestClass]
+    public class HttpClientTests : TestsBase {
+
+        [TestMethod]
+        public async Task HttpClientShouldDeserializeProblemDetailsResponse() {
+            var client = AssemblyInitializer.ApplicationServices.GetRequiredService<AdapterHttpClient>();
+
+            // Request will fail validation because it does not specify any tags.
+            var requestContent = new ReadSnapshotTagValuesRequest();
+            var url = "api/app-store-connect/v2.0/tag-values/" + WebHostConfiguration.AdapterId + "/snapshot";
+
+            using (var ctSource = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+            using (var request = client.CreateHttpRequestMessage(HttpMethod.Post, url, requestContent, null))
+            using (var response = await client.HttpClient.SendAsync(request, ctSource.Token).ConfigureAwait(false)) {
+                Assert.IsFalse(response.IsSuccessStatusCode);
+                try {
+                    await response.ThrowOnErrorResponse().ConfigureAwait(false);
+                    Assert.Fail("Error should have been thrown.");
+                }
+                catch (AdapterHttpClientException e) {
+                    Assert.IsNotNull(e.ProblemDetails);
+                    Assert.IsNotNull(e.StatusCode);
+#if NETCOREAPP
+                    // The type for the problem details is only set in ASP.NET Core 3.x onwards.
+                    Assert.IsNotNull(e.ProblemDetails.Type);
+#endif
+                    Assert.IsNotNull(e.ProblemDetails.Title);
+                    Assert.IsNotNull(e.ProblemDetails.Extensions);
+                }
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
Adds RFC 7807 problem details support to the `AdapterHttpClient`.

When a non-good status code is returned by a call to an adapter API endpoint, an `AdapterHttpClientException` (derived from `HttpRequestException`) is thrown. If the response contains a JSON-encoded problem details object (`application/problem+json`), this is deserialized and assigned to the `ProblemDetails` property on the exception.

Although the client already ensures that e.g. request payloads are validated before sending, being able to pass through problem details responses is clearly useful when it comes to extracting detailed information about server-side errors.