### PR TITLE
Hosted adapter template improvements

### DIFF
--- a/examples/DataCore.Adapter.AspNetCoreExample/Properties/launchSettings.json
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Properties/launchSettings.json
@@ -4,7 +4,6 @@
     "DataCore.Adapter.AspNetCoreExample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/app-store-connect/v2.0/host-info",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
@@ -171,6 +171,12 @@ namespace DataCore.Adapter.AspNetCoreExample {
                 endpoints.MapControllers();
                 endpoints.MapDataCoreAdapterHubs();
                 endpoints.MapHealthChecks("/health");
+
+                // Redirect all other requests to the host info API endpoint.
+                endpoints.MapFallback("/{*url}", context => {
+                    context.Response.Redirect($"/api/app-store-connect/v2.0/host-info/");
+                    return System.Threading.Tasks.Task.CompletedTask;
+                });
             });
         }
     }

--- a/examples/ExampleHostedAdapter/ExampleHostedAdapter.csproj
+++ b/examples/ExampleHostedAdapter/ExampleHostedAdapter.csproj
@@ -9,12 +9,11 @@
     <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.Grpc" Version="$(Version)" />
     <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.Mvc" Version="$(Version)" />
     <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.SignalR" Version="$(Version)" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.0.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc4" />
   </ItemGroup>
 
 </Project>

--- a/examples/ExampleHostedAdapter/Startup.cs
+++ b/examples/ExampleHostedAdapter/Startup.cs
@@ -11,22 +11,46 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace ExampleHostedAdapter {
+
+    /// <summary>
+    /// ASP.NET Core startup class.
+    /// </summary>
     public class Startup {
 
-        // Our adapter instance will use this ID at runtime.
+        /// <summary>
+        /// The ID of the hosted adapter.
+        /// </summary>
         public const string AdapterId = "fdb421d7-03b2-49e8-880a-224e8e5f04ef";
 
 
+        /// <summary>
+        /// The <see cref="IConfiguration"/> for the application.
+        /// </summary>
         public IConfiguration Configuration { get; }
 
 
+        /// <summary>
+        /// Creates a new <see cref="Startup"/> object.
+        /// </summary>
+        /// <param name="configuration">
+        ///   The <see cref="IConfiguration"/> for the application.
+        /// </param>
         public Startup(IConfiguration configuration) {
             Configuration = configuration;
         }
 
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        /// <summary>
+        /// Configures application services.
+        /// </summary>
+        /// <param name="services">
+        ///   The <see cref="IServiceCollection"/> to register the services with.
+        /// </param>
+        /// <remarks>
+        ///   This method gets called by the ASP.NET Core runtime. Use this method to add services 
+        ///   to the container. For more information on how to configure your application, visit 
+        ///   https://go.microsoft.com/fwlink/?LinkID=398940
+        /// </remarks>
         public void ConfigureServices(IServiceCollection services) {
             // Add adapter services
 
@@ -59,7 +83,8 @@ namespace ExampleHostedAdapter {
 
             services.AddSignalR().AddDataCoreAdapterSignalR();
 
-            // Add OpenTelemetry tracing
+            // Add OpenTelemetry tracing. Refer to https://github.com/open-telemetry/opentelemetry-dotnet 
+            // for more information about configuration and usage.
             services.AddOpenTelemetryTracing(builder => {
                 builder
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(
@@ -67,25 +92,35 @@ namespace ExampleHostedAdapter {
                         serviceVersion: version,
                         serviceInstanceId: AdapterId
                     ))
-                    // Use AddConsoleExporter() to export to stdout. 
-                    //.AddConsoleExporter()    
-                    // Use AddJaegerExporter() to export to Jaeger (https://www.jaegertracing.io/).
-                    //.AddJaegerExporter() 
-                    .AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation()
-                    .AddSqlClientInstrumentation()
-                    .AddDataCoreAdapterInstrumentation();
+                    .AddAspNetCoreInstrumentation() // Records incoming HTTP requests made to the adapter host.
+                    .AddHttpClientInstrumentation() // Records outgoing HTTP requests made by the adapter host.
+                    .AddSqlClientInstrumentation() // Records queries made by System.Data.SqlClient and Microsoft.Data.SqlClient.
+                    .AddDataCoreAdapterInstrumentation() // Records activities created by adapters and adapter hosting packages.
+                    .AddJaegerExporter(); // Exports traces to Jaeger (https://www.jaegertracing.io/) using default settings.
             });
         }
 
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        /// <summary>
+        /// Configures the ASP.NET Core HTTP request pipeline.
+        /// </summary>
+        /// <param name="app">
+        ///   The <see cref="IApplicationBuilder"/> for the application.
+        /// </param>
+        /// <param name="env">
+        ///   The <see cref="IWebHostEnvironment"/> for the application.
+        /// </param>
+        /// <remarks>
+        ///   This method gets called by the ASP.NET Core runtime. Use this method to configure 
+        ///   the HTTP request pipeline.
+        /// </remarks>
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
             if (env.IsDevelopment()) {
                 app.UseDeveloperExceptionPage();
             }
             else {
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                // The default HSTS value is 30 days. You may want to change this for production
+                // scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
 
@@ -95,14 +130,14 @@ namespace ExampleHostedAdapter {
             app.UseRouting();
 
             app.UseEndpoints(endpoints => {
-                // Map MVC API, SignalR, and gRPC endpoints.
+                // Map API, SignalR, and gRPC endpoints.
                 endpoints.MapControllers();
                 endpoints.MapDataCoreAdapterHubs();
                 endpoints.MapDataCoreGrpcServices();
 
-                // Redirect requests to / to the API endpoint for retrieving details about the
+                // Redirect all other requests to the API endpoint for retrieving details about the
                 // adapter.
-                endpoints.MapGet("/", context => {
+                endpoints.MapFallback("/{*url}", context => {
                     context.Response.Redirect($"/api/app-store-connect/v2.0/adapters/{AdapterId}");
                     return Task.CompletedTask;
                 });


### PR DESCRIPTION
This PR sets a fallback route in the templated ASP.NET Core app, updates the OpenTelemetry package references, and enables the Jaeger OpenTelemetry exporter by default.