### PR TITLE
Do not start new activity when publishing to each subscriber in HealthCheckManager

### DIFF
--- a/src/DataCore.Adapter/Diagnostics/HealthCheckManager.cs
+++ b/src/DataCore.Adapter/Diagnostics/HealthCheckManager.cs
@@ -137,17 +137,15 @@ namespace DataCore.Adapter.Diagnostics {
                         break;
                     }
 
-                    using (var publishActivity = Telemetry.ActivitySource.StartActivity("publish_to_subscriber")) {
-                        try {
-                            var success = subscriber.Publish(update);
-                            if (!success) {
-                                _adapter.Logger.LogTrace(Resources.Log_PublishToSubscriberWasUnsuccessful, subscriber.Context?.ConnectionId);
-                            }
+                    try {
+                        var success = subscriber.Publish(update);
+                        if (!success) {
+                            _adapter.Logger.LogTrace(Resources.Log_PublishToSubscriberWasUnsuccessful, subscriber.Context?.ConnectionId);
                         }
-                        catch (OperationCanceledException) { }
-                        catch (Exception e) {
-                            _adapter.Logger.LogError(e, Resources.Log_PublishToSubscriberThrewException, subscriber.Context?.ConnectionId);
-                        }
+                    }
+                    catch (OperationCanceledException) { }
+                    catch (Exception e) {
+                        _adapter.Logger.LogError(e, Resources.Log_PublishToSubscriberThrewException, subscriber.Context?.ConnectionId);
                     }
                 }
             }


### PR DESCRIPTION
Creating a new activity for each publish in `HealthCheckManager` is unnecessary, as the host interface already maintains activities on behalf of the subscription