### PR TITLE
Merge v2.2.0

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 1,
+  "Minor": 2,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/build/version.json
+++ b/build/version.json
@@ -2,5 +2,5 @@
   "Major": 2,
   "Minor": 2,
   "Patch": 0,
-  "PreRelease": "alpha"
+  "PreRelease": ""
 }

--- a/build/version.json
+++ b/build/version.json
@@ -2,5 +2,5 @@
   "Major": 2,
   "Minor": 2,
   "Patch": 0,
-  "PreRelease": ""
+  "PreRelease": "alpha"
 }

--- a/src/DataCore.Adapter/Extensions/AdapterExtensionFeature.cs
+++ b/src/DataCore.Adapter/Extensions/AdapterExtensionFeature.cs
@@ -80,7 +80,7 @@ namespace DataCore.Adapter.Extensions {
             BackgroundTaskService = backgroundTaskService ?? IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default;
             Encoders = encoders?.ToArray() ?? Array.Empty<IObjectEncoder>();
 
-            foreach (var featureUri in GetType().GetAdapterFeatureUris().Where(x => !ExtensionUriBase.Equals(x) && ExtensionUriBase.IsBaseOf(x))) {
+            void CreateAutoBindings(Uri featureUri) {
                 // Create auto-binding for GetDescriptor method
                 var opUri = GetOperationUri(
                     featureUri,
@@ -89,7 +89,7 @@ namespace DataCore.Adapter.Extensions {
                 );
                 _boundInvokeMethods[opUri] = async (ctx, req, ct) => {
                     var desc = await ((IAdapterExtensionFeature) this).GetDescriptor(ctx, featureUri, ct).ConfigureAwait(false);
-                    return new InvocationResponse() { 
+                    return new InvocationResponse() {
                         Results = new Variant[] {
                             this.ConvertToVariant(desc)!
                         }
@@ -98,18 +98,24 @@ namespace DataCore.Adapter.Extensions {
 
                 // Create auto-binding for GetOperations method
                 opUri = GetOperationUri(
-                    featureUri, 
-                    nameof(IAdapterExtensionFeature.GetOperations), 
+                    featureUri,
+                    nameof(IAdapterExtensionFeature.GetOperations),
                     ExtensionFeatureOperationType.Invoke
                 );
-                _boundInvokeMethods[opUri] = async (ctx, arg, ct) => {
+                _boundInvokeMethods[opUri] = async (ctx, req, ct) => {
                     var ops = await ((IAdapterExtensionFeature) this).GetOperations(ctx, featureUri, ct).ConfigureAwait(false);
-                    return new InvocationResponse() { 
+                    return new InvocationResponse() {
                         Results = new[] {
                             this.ConvertToVariant(ops.ToArray())
                         }
                     };
                 };
+            }
+
+            // Create auto-bindings for GetDescriptor and GetOperations methods for each extension
+            // feature implemented by the current class.
+            foreach (var featureUri in GetType().GetAdapterFeatureUris().Where(x => !ExtensionUriBase.Equals(x) && ExtensionUriBase.IsBaseOf(x))) {
+                CreateAutoBindings(featureUri);
             }
         }
 
@@ -663,7 +669,25 @@ namespace DataCore.Adapter.Extensions {
                 return false;
             }
 
-            // Operation URIs are in the format <feature_uri>/<operation_type>/<operation_name>
+            // Operation URIs should be in the format <feature_uri>/<operation_type>/<operation_name>.
+            // If we split the operation URI using '/', we should end up with at least 3 parts (more
+            // if the feature URI contains '/').
+            var parts = operationUri.AbsoluteUri.Split('/');
+            if (parts.Length < 3) {
+                // Operation URI cannot be valid because it does not contain the parts described above.
+                featureUri = null!;
+                error = Resources.Error_InvalidExtensionFeatureOperationUri;
+                return false;
+            }
+
+            // Second-last URI part should be the operation type.
+            if (!Enum.TryParse<ExtensionFeatureOperationType>(parts[parts.Length - 2], out var _)) {
+                // Not a valid operation type.
+                featureUri = null!;
+                error = Resources.Error_InvalidExtensionFeatureOperationUri;
+                return false;
+            }
+
             featureUri = new Uri(operationUri, "../../");
             return true;
         }

--- a/src/DataCore.Adapter/Extensions/AdapterExtensionFeature.cs
+++ b/src/DataCore.Adapter/Extensions/AdapterExtensionFeature.cs
@@ -672,7 +672,11 @@ namespace DataCore.Adapter.Extensions {
             // Operation URIs should be in the format <feature_uri>/<operation_type>/<operation_name>.
             // If we split the operation URI using '/', we should end up with at least 3 parts (more
             // if the feature URI contains '/').
-            var parts = operationUri.AbsoluteUri.Split('/');
+#if NETSTANDARD2_1_OR_GREATER
+            var parts = operationUri.AbsoluteUri.Split('/', StringSplitOptions.RemoveEmptyEntries);
+#else
+            var parts = operationUri.AbsoluteUri.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+#endif
             if (parts.Length < 3) {
                 // Operation URI cannot be valid because it does not contain the parts described above.
                 featureUri = null!;
@@ -681,14 +685,14 @@ namespace DataCore.Adapter.Extensions {
             }
 
             // Second-last URI part should be the operation type.
-            if (!Enum.TryParse<ExtensionFeatureOperationType>(parts[parts.Length - 2], out var _)) {
+            if (!Enum.TryParse<ExtensionFeatureOperationType>(parts[parts.Length - 2], true, out var _)) {
                 // Not a valid operation type.
                 featureUri = null!;
                 error = Resources.Error_InvalidExtensionFeatureOperationUri;
                 return false;
             }
 
-            featureUri = new Uri(operationUri, "../../");
+            featureUri = new Uri(operationUri.EnsurePathHasTrailingSlash(), "../../");
             return true;
         }
 

--- a/src/DataCore.Adapter/Security/CertificateUtilities.cs
+++ b/src/DataCore.Adapter/Security/CertificateUtilities.cs
@@ -304,7 +304,7 @@ namespace DataCore.Adapter.Security {
         ///   <see langword="true"/> if the certificate could be loaded, or <see langword="false"/> 
         ///   otherwise.
         /// </returns>
-        public static bool TryLoadCertificateFromStore(string path, out X509Certificate2 certificate) {
+        public static bool TryLoadCertificateFromStore(string path, out X509Certificate2? certificate) {
             return TryLoadCertificateFromStore(path, true, out certificate);
         }
 
@@ -327,14 +327,14 @@ namespace DataCore.Adapter.Security {
         ///   <see langword="true"/> if the certificate could be loaded, or <see langword="false"/> 
         ///   otherwise.
         /// </returns>
-        public static bool TryLoadCertificateFromStore(string path, bool validOnly, out X509Certificate2 certificate) {
+        public static bool TryLoadCertificateFromStore(string path, bool validOnly, out X509Certificate2? certificate) {
             if (path == null) {
-                certificate = null!;
+                certificate = null;
                 return false;
             }
 
             if (!TryParseCertificateStorePath(path, out var location, out var name, out var thumbprintOrSubjectName)) {
-                certificate = null!;
+                certificate = null;
                 return false;
             }
 
@@ -343,7 +343,7 @@ namespace DataCore.Adapter.Security {
                 var certs = LoadCertificates(store, thumbprintOrSubjectName, validOnly);
                 
                 if (certs.Length == 0) {
-                    certificate = null!;
+                    certificate = null;
                     return false;
                 }
 

--- a/test/DataCore.Adapter.Tests/AdapterFeatureDefinitionTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterFeatureDefinitionTests.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Text;
 
+using DataCore.Adapter.Extensions;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DataCore.Adapter.Tests {
@@ -24,6 +26,30 @@ namespace DataCore.Adapter.Tests {
                 Assert.IsNotNull(descriptor, $"Decriptor for {uri} should not be null.");
                 Assert.AreEqual(uri, descriptor.Uri);
             }
+        }
+
+
+        [TestMethod]
+        public void ShouldResolveExtensionFeatureFromOperationUri() {
+            var featureUri = new Uri(new Uri(WellKnownFeatures.Extensions.BaseUri), string.Concat("unit-tests/", GetType().Name, "/"));
+            var operationUri = new Uri(featureUri, "invoke/" + TestContext.TestName);
+
+            var success = AdapterExtensionFeature.TryGetFeatureUriFromOperationUri(operationUri, out var featureUriActual, out var error);
+            if (!success) {
+                Assert.Fail(error);
+            }
+            Assert.AreEqual(featureUri, featureUriActual);
+        }
+
+
+        [DataTestMethod]
+        [DataRow(WellKnownFeatures.Extensions.BaseUri + "unit-tests/")]
+        [DataRow(WellKnownFeatures.Extensions.BaseUri + "unit-tests/invoke/")]
+        [DataRow(WellKnownFeatures.Extensions.BaseUri + "unit-tests/GetDescriptor")]
+        [DataRow(WellKnownFeatures.Extensions.BaseUri + "unit-tests/GetOperations")]
+        public void ShouldNotResolveFeatureFromOperationUri(string uri) {
+            var operationUri = new Uri(uri);
+            Assert.IsFalse(AdapterExtensionFeature.TryGetFeatureUriFromOperationUri(operationUri, out var _, out var _));
         }
 
     }


### PR DESCRIPTION
`AdapterExtensionFeature.TryGetFeatureUriFromOperationUri` now ensures that the specified operation ID matches the format `<feature_uri>/<operation_type>/<operation_name>`.

`CertificateUtilities.TryLoadCertificateFromStore` is now guaranteed to return a certificate if a match is found, even if the certificate fails default verification (e.g. if it is self-signed).