### PR TITLE
Allow lazy initialisation of TagManager

### DIFF
--- a/src/DataCore.Adapter/Resources.Designer.cs
+++ b/src/DataCore.Adapter/Resources.Designer.cs
@@ -241,15 +241,6 @@ namespace DataCore.Adapter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The tag manager has not been initialised. Call &apos;{0}&apos; before attempting any other operations..
-        /// </summary>
-        internal static string Error_TagManager_NotInitialised {
-            get {
-                return ResourceManager.GetString("Error_TagManager_NotInitialised", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Too many subscriptions..
         /// </summary>
         internal static string Error_TooManySubscriptions {

--- a/src/DataCore.Adapter/Resources.resx
+++ b/src/DataCore.Adapter/Resources.resx
@@ -190,10 +190,6 @@
     <comment>{0} - IAdapterExtensionFeature name
 {1} - AdapterFeatureAttribute name</comment>
   </data>
-  <data name="Error_TagManager_NotInitialised" xml:space="preserve">
-    <value>The tag manager has not been initialised. Call '{0}' before attempting any other operations.</value>
-    <comment>{0} - init method name</comment>
-  </data>
   <data name="Error_TooManySubscriptions" xml:space="preserve">
     <value>Too many subscriptions.</value>
   </data>


### PR DESCRIPTION
This PR removes the need to call `TagManager.InitAsync` up front to restore tag definitions from the `IKeyValueStore` before a `TagManager` can be used. The eager initialisation can still be performed, but internally the class now uses a `Lazy<Task>` to represent the initialisation task. Calling any operation on the `TagManager` will now await on the initialisation task before continuing. 

The PR also adds a `GetTagAsync` method to allow a single tag to be retrieved from the `TagManager` via name or ID, instead of having to invoke the `ITagInfo.GetTags` implementation.