### PR TITLE
Revert build script changes in 2.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,14 +20,31 @@
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts\packages\$(Configuration)</PackageOutputPath>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <NeutralLanguage>en</NeutralLanguage>
+    <CopyrightStartYear>2019</CopyrightStartYear>
   </PropertyGroup>
 
-  <!-- Jaahas.MSBuild.Extensions uses these properties to set our copyright message and version 
-       properties at build time. -->
   <PropertyGroup>
-    <CopyrightStartYear>2019</CopyrightStartYear>
-    <VersionPropertiesInputFile Condition="Exists('$(MSBuildThisFileDirectory)build\version.json')">$(MSBuildThisFileDirectory)build\version.json</VersionPropertiesInputFile>
+    <!-- 
+    IMPORTANT: 
+    This version will always be overridden by the version specified in build\version.json when 
+    building via build.ps1 or build.sh. It is defined here to allow Visual Studio to build with 
+    the solution with the correct version number.
+    -->
+    <Version>2.3.1</Version>
   </PropertyGroup>
+
+  <Choose>
+    <When Condition=" $([System.DateTime]::UtcNow.Year) > $(CopyrightStartYear) ">
+      <PropertyGroup>
+        <Copyright>Copyright © $(CopyrightStartYear)-$([System.DateTime]::UtcNow.Year) $(Company)</Copyright>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <Copyright>Copyright © $(CopyrightStartYear) $(Company)</Copyright>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <!-- Extension point to allow Continuous Integration systems to inject their own configuration. -->
   <Import Project="CI.props" Condition="Exists('CI.props')" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,15 +19,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <!-- Add MSBuild extensions (for setting copyright notice and version numbers). -->
-  <ItemGroup>
-    <PackageReference Remove="Jaahas.MSBuild.Extensions" />
-    <PackageReference Include="Jaahas.MSBuild.Extensions" Version="$(JaahasMSBuildExtensionsVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(IncludeDevelopmentPackages)' == 'true' ">
     <!-- .NET Analyzers NuGet Package -->
     <PackageReference Remove="Microsoft.CodeAnalysis.NetAnalyzers" />

--- a/build.cake
+++ b/build.cake
@@ -93,10 +93,27 @@ Setup<BuildState>(context => {
         var patchVersion = versionJson.Value<int>("Patch");
         var versionSuffix = versionJson.Value<string>("PreRelease");
 
-        // Compute build number.
+        // Compute build and version numbers.
 
         var buildCounter = Argument("build-counter", 0);
+        var buildMetadata = Argument("build-metadata", "");
         var branch = GitBranchCurrent(DirectoryPath.FromString(".")).FriendlyName;
+
+        state.AssemblyVersion = $"{majorVersion}.{minorVersion}.0.0";
+
+        state.AssemblyFileVersion = $"{majorVersion}.{minorVersion}.{patchVersion}.{buildCounter}";
+
+        state.InformationalVersion = string.IsNullOrWhiteSpace(versionSuffix)
+            ? $"{majorVersion}.{minorVersion}.{patchVersion}.{buildCounter}+{branch}"
+            : $"{majorVersion}.{minorVersion}.{patchVersion}-{versionSuffix}.{buildCounter}+{branch}";
+
+        if (!string.IsNullOrWhiteSpace(buildMetadata)) {
+            state.InformationalVersion = string.Concat(state.InformationalVersion, "#", buildMetadata);
+        }
+
+        state.PackageVersion = string.IsNullOrWhiteSpace(versionSuffix)
+            ? $"{majorVersion}.{minorVersion}.{patchVersion}"
+            : $"{majorVersion}.{minorVersion}.{patchVersion}-{versionSuffix}.{buildCounter}";
 
         state.BuildNumber = string.IsNullOrWhiteSpace(versionSuffix)
             ? $"{majorVersion}.{minorVersion}.{patchVersion}.{buildCounter}+{branch}"

--- a/build/build-state.cake
+++ b/build/build-state.cake
@@ -31,6 +31,18 @@ public class BuildState {
     // Specifies if output signing is allowed.
     public bool CanSignOutput => SignOutput && ContinuousIntegrationBuild;
 
+    // MSBuild AssemblyVersion property value.
+    public string AssemblyVersion { get; set; }
+
+    // MSBuild AssemblyFileVersion property value.
+    public string AssemblyFileVersion { get; set; }
+
+    // MSBuild InformationalVersion property value.
+    public string InformationalVersion { get; set; }
+
+    // MSBuild Version property value.
+    public string PackageVersion { get; set; }
+
     // Specifies if verbose logging should be used.
     public bool Verbose { get; set; }
 

--- a/build/build-utilities.cake
+++ b/build/build-utilities.cake
@@ -6,6 +6,10 @@ public static class BuildUtilities {
         // Tell TeamCity the build number if required.
         if (buildSystem.IsRunningOnTeamCity) {
             buildSystem.TeamCity.SetBuildNumber(buildState.BuildNumber);
+            buildSystem.TeamCity.SetParameter("system.AssemblyVersion", buildState.AssemblyVersion);
+            buildSystem.TeamCity.SetParameter("system.AssemblyFileVersion", buildState.AssemblyFileVersion);
+            buildSystem.TeamCity.SetParameter("system.InformationalVersion", buildState.InformationalVersion);
+            buildSystem.TeamCity.SetParameter("system.PackageVersion", buildState.PackageVersion);
         }
     }
 
@@ -106,6 +110,12 @@ public static class BuildUtilities {
         if (state.CanSignOutput) {
             settings.Properties["SignOutput"] = new List<string> { "True" };
         }
+
+        // Set version numbers.
+        settings.Properties["AssemblyVersion"] = new List<string> { state.AssemblyVersion };
+        settings.Properties["FileVersion"] = new List<string> { state.AssemblyFileVersion };
+        settings.Properties["Version"] = new List<string> { state.PackageVersion };
+        settings.Properties["InformationalVersion"] = new List<string> { state.InformationalVersion };
     }
 
 

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
   "Minor": 3,
-  "Patch": 0,
+  "Patch": 1,
   "PreRelease": ""
 }


### PR DESCRIPTION
Build script changes in 2.3.0 caused NuGet packages for projects in the repository to reference the wrong versions of other packages built using the repository (e.g. the `IntelligentPlant.AppStoreConnect.Adapters` package referenced the wrong version of `IntelligentPlant.AppStoreConnect.Adapters.Abstractions`).