### PR TITLE
Add callbacks for configuration changes in AssetModelManager and TagManager

### DIFF
--- a/src/DataCore.Adapter/AssetModel/AssetModelManager.cs
+++ b/src/DataCore.Adapter/AssetModel/AssetModelManager.cs
@@ -97,6 +97,28 @@ namespace DataCore.Adapter.AssetModel {
 
 
         /// <summary>
+        /// Creates a delegate compatible with the <see cref="AssetModelManager"/> constructor that 
+        /// forwards configuration changes to a <see cref="ConfigurationChanges"/> instance.
+        /// </summary>
+        /// <param name="configurationChanges">
+        ///   The <see cref="ConfigurationChanges"/> instance to use.
+        /// </param>
+        /// <returns>
+        ///   A delegate that can be passed to the <see cref="AssetModelManager"/> constructor.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configurationChanges"/> is <see langword="null"/>.
+        /// </exception>
+        public static Func<ConfigurationChange, CancellationToken, ValueTask> CreateConfigurationChangeDelegate(ConfigurationChanges configurationChanges) {
+            if (configurationChanges == null) {
+                throw new ArgumentNullException(nameof(configurationChanges));
+            }
+
+            return async (change, ct) => _ = await configurationChanges.ValueReceived(change, ct).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
         /// Throws an <see cref="ObjectDisposedException"/> if the object has been disposed.
         /// </summary>
         private void ThrowOnDisposed() {

--- a/src/DataCore.Adapter/Tags/TagManager.cs
+++ b/src/DataCore.Adapter/Tags/TagManager.cs
@@ -110,6 +110,28 @@ namespace DataCore.Adapter.Tags {
 
 
         /// <summary>
+        /// Creates a delegate compatible with the <see cref="TagManager"/> constructor that 
+        /// forwards configuration changes to a <see cref="ConfigurationChanges"/> instance.
+        /// </summary>
+        /// <param name="configurationChanges">
+        ///   The <see cref="ConfigurationChanges"/> instance to use.
+        /// </param>
+        /// <returns>
+        ///   A delegate that can be passed to the <see cref="TagManager"/> constructor.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configurationChanges"/> is <see langword="null"/>.
+        /// </exception>
+        public static Func<ConfigurationChange, CancellationToken, ValueTask> CreateConfigurationChangeDelegate(ConfigurationChanges configurationChanges) {
+            if (configurationChanges == null) {
+                throw new ArgumentNullException(nameof(configurationChanges));
+            }
+
+            return async (change, ct) => _ = await configurationChanges.ValueReceived(change, ct).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
         /// Throws an <see cref="ObjectDisposedException"/> if the object has been disposed.
         /// </summary>
         private void ThrowOnDisposed() {


### PR DESCRIPTION
`AssetModelManager` and `TagManager` now accept an optional delegate in their constructors to allow integration with an adapter's `IConfigurationChanges` implementation.

This allows an adapter implementer to allow these classes to generate the correct `ConfigurationChange` objects for `IConfigurationChanges` subscribers instead of having to do this themselves.