### PR TITLE
Add in-memory index and compression to file store

### DIFF
--- a/src/DataCore.Adapter.Abstractions/Services/IKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/IKeyValueStore.cs
@@ -75,7 +75,7 @@ namespace DataCore.Adapter.Services {
         /// <returns>
         ///   The keys.
         /// </returns>
-        IEnumerable<KVKey> GetKeys(KVKey? prefix);
+        IAsyncEnumerable<KVKey> GetKeysAsync(KVKey? prefix);
 
     }
 }

--- a/src/DataCore.Adapter.Abstractions/Services/InMemoryKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/InMemoryKeyValueStore.cs
@@ -57,7 +57,8 @@ namespace DataCore.Adapter.Services {
 
 
         /// <inheritdoc/>
-        protected override IEnumerable<KVKey> GetKeys(KVKey? prefix) {
+        protected override async IAsyncEnumerable<KVKey> GetKeysAsync(KVKey? prefix) {
+            await Task.Yield();
             foreach (var item in _values.Keys) {
                 var bytes = ConvertHexStringToBytes(item);
                 if (prefix != null && prefix.Value.Length > 0 && !StartsWithPrefix(prefix.Value.Value, bytes)) {

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStore.cs
@@ -65,7 +65,7 @@ namespace DataCore.Adapter.Services {
         }
 
 
-        IEnumerable<KVKey> IKeyValueStore.GetKeys(KVKey? prefix) {
+        async IAsyncEnumerable<KVKey> IKeyValueStore.GetKeysAsync(KVKey? prefix) {
             if (prefix != null && prefix.Value.Length == 0) {
                 throw new ArgumentException(AbstractionsResources.Error_KeyValueStore_InvalidKey, nameof(prefix));
             }
@@ -81,7 +81,7 @@ namespace DataCore.Adapter.Services {
                     : AddPrefix(_prefix.Value, prefix.Value);
             }
 
-            foreach (var key in GetKeys(compositePrefix)) {
+            await foreach (var key in GetKeysAsync(compositePrefix)) {
                 if (compositePrefix == null) {
                     yield return key;
                 }
@@ -140,7 +140,7 @@ namespace DataCore.Adapter.Services {
         /// <returns>
         ///   The matching keys.
         /// </returns>
-        protected abstract IEnumerable<KVKey> GetKeys(KVKey? prefix);
+        protected abstract IAsyncEnumerable<KVKey> GetKeysAsync(KVKey? prefix);
 
 
         /// <summary>

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace DataCore.Adapter.Services {
     /// <summary>
@@ -53,7 +54,7 @@ namespace DataCore.Adapter.Services {
         ///   The <see cref="IKeyValueStore"/>.
         /// </param>
         /// <param name="prefix">
-        ///   
+        ///   Only keys with this prefix will be returned.
         /// </param>
         /// <returns>
         ///   The keys, converted to strings.
@@ -67,12 +68,12 @@ namespace DataCore.Adapter.Services {
         ///   key will be converted to a string using <see cref="BitConverter.ToString(byte[])"/> 
         ///   instead.
         /// </remarks>
-        public static IEnumerable<string> GetKeysAsStrings(this IKeyValueStore store, KVKey? prefix) {
+        public static async IAsyncEnumerable<string> GetKeysAsStrings(this IKeyValueStore store, KVKey? prefix) {
             if (store == null) {
                 throw new ArgumentNullException(nameof(store));
             }
 
-            foreach (var key in store.GetKeys(prefix)) {
+            await foreach (var key in store.GetKeysAsync(prefix).ConfigureAwait(false)) {
                 string result;
                 try {
                     result = Encoding.UTF8.GetString(key);
@@ -103,7 +104,7 @@ namespace DataCore.Adapter.Services {
         ///   key will be converted to a string using <see cref="BitConverter.ToString(byte[])"/> 
         ///   instead.
         /// </remarks>
-        public static IEnumerable<string> GetKeysAsStrings(this IKeyValueStore store) {
+        public static IAsyncEnumerable<string> GetKeysAsStrings(this IKeyValueStore store) {
             return store.GetKeysAsStrings(default);
         }
 

--- a/src/DataCore.Adapter.Abstractions/Services/ScopedKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/ScopedKeyValueStore.cs
@@ -57,8 +57,8 @@ namespace DataCore.Adapter.Services {
 
 
         /// <inheritdoc/>
-        protected override IEnumerable<KVKey> GetKeys(KVKey? prefix) {
-            return Inner.GetKeys(prefix);
+        protected override IAsyncEnumerable<KVKey> GetKeysAsync(KVKey? prefix) {
+            return Inner.GetKeysAsync(prefix);
         }
 
     }

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
@@ -548,15 +548,16 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
 
 
         /// <inheritdoc/>
-        protected override IEnumerable<KVKey> GetKeys(KVKey? prefix) {
+        protected override async IAsyncEnumerable<KVKey> GetKeysAsync(KVKey? prefix) {
+            await Task.Yield();
             var session = GetPooledSession();
             try {
                 using (var iterator = session.Iterate()) {
                     while (iterator.GetNext(out var recordInfo)) {
-                        var span = iterator.GetKey().AsReadOnlySpan();
+                        var key = iterator.GetKey().AsSpan().ToArray();
 
-                        if (prefix == null || prefix.Value.Length == 0 || span.StartsWith(prefix.Value.Value)) {
-                            yield return span.ToArray();
+                        if (prefix == null || prefix.Value.Length == 0 || StartsWithPrefix(prefix.Value, key)) {
+                            yield return key;
                         }
                     }
                 }

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/DataCore.Adapter.KeyValueStore.FileSystem.csproj
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/DataCore.Adapter.KeyValueStore.FileSystem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.KeyValueStore.FileSystem</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.KeyValueStore.FileSystem</PackageId>
     <Description>File system-based key-value store for App Store Connect adapters.</Description>
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="$(NitoAsyncExCoordinationVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/FileSystemKeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/FileSystemKeyValueStoreOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO.Compression;
 
 namespace DataCore.Adapter.KeyValueStore.FileSystem {
 
@@ -13,12 +14,27 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         public const string DefaultPath = "./KeyValueStore";
 
         /// <summary>
-        /// The base path for the serialized JSON files.
+        /// Default number of hash buckets.
+        /// </summary>
+        public const int DefaultHashBuckets = 20;
+
+        /// <summary>
+        /// The base path for the store's files.
         /// </summary>
         /// <remarks>
         ///   Relative paths will be made absolute relative to <see cref="AppContext.BaseDirectory"/>.
         /// </remarks>
         public string Path { get; set; } = DefaultPath;
+
+        /// <summary>
+        /// The number of hash buckets to distribute files across.
+        /// </summary>
+        public int HashBuckets { get; set; } = DefaultHashBuckets;
+
+        /// <summary>
+        /// The GZip compression level to use when saving value to the files.
+        /// </summary>
+        public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Fastest;
 
     }
 

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/Resources.Designer.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/Resources.Designer.cs
@@ -70,6 +70,24 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error while deserializing index..
+        /// </summary>
+        internal static string Log_ErrorDeserializingIndex {
+            get {
+                return ResourceManager.GetString("Log_ErrorDeserializingIndex", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error while saving index to file..
+        /// </summary>
+        internal static string Log_ErrorProcessingIndexSave {
+            get {
+                return ResourceManager.GetString("Log_ErrorProcessingIndexSave", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error while reading from file &apos;{FilePath}&apos;..
         /// </summary>
         internal static string Log_ErrorReadingFromFile {

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/Resources.resx
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/Resources.resx
@@ -120,6 +120,12 @@
   <data name="Log_ErrorDeletingFile" xml:space="preserve">
     <value>Error while deleting file '{FilePath}'.</value>
   </data>
+  <data name="Log_ErrorDeserializingIndex" xml:space="preserve">
+    <value>Error while deserializing index.</value>
+  </data>
+  <data name="Log_ErrorProcessingIndexSave" xml:space="preserve">
+    <value>Error while saving index to file.</value>
+  </data>
   <data name="Log_ErrorReadingFromFile" xml:space="preserve">
     <value>Error while reading from file '{FilePath}'.</value>
   </data>

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/DataCore.Adapter.KeyValueStore.Sqlite.csproj
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/DataCore.Adapter.KeyValueStore.Sqlite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.KeyValueStore.Sqlite</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.KeyValueStore.Sqlite</PackageId>
     <Description>Sqlite key-value store for App Store Connect adapters.</Description>

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/SqliteKeyValueStore.cs
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/SqliteKeyValueStore.cs
@@ -226,7 +226,9 @@ namespace DataCore.Adapter.KeyValueStore.Sqlite {
 
 
         /// <inheritdoc/>
-        protected override IEnumerable<KVKey> GetKeys(KVKey? prefix) {
+        protected override async IAsyncEnumerable<KVKey> GetKeysAsync(KVKey? prefix) {
+            await Task.Yield();
+
             var hexPrefix = prefix == null || prefix.Value.Length == 0 
                 ? null 
                 : ConvertBytesToHexString(prefix);


### PR DESCRIPTION
**Breaking change:**

- `IKeyValueStore.GetKeys` is now `IKeyValueStore.GetKeysAsync`, and now returns an `IAsyncEnumerable<KVKey>`.

**Other changes:**

- File store now uses an in-memory lookup from key to file rather than using the key to directly determine the file name. This is to protect against keys that generate file names too long for the underlying file system.
  - File names are now generated by hashing the key using SHA256 and then encoding the result as base64url.
  - Files are assigned to a sub-folder under the base folder based on the hash code of the key.
  - The in-memory index is saved to the file system on change after a 1 second delay.
  - Data files can be optionally gzipped. The index file is always gzipped using fastest-possible compression.