### PR TITLE
Allow key-value store to be null

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -2,5 +2,5 @@
   "Major": 2,
   "Minor": 4,
   "Patch": 0,
-  "PreRelease": "rc1"
+  "PreRelease": "rc2"
 }

--- a/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
@@ -95,7 +95,7 @@ namespace DataCore.Adapter.AspNetCoreExample {
             // Add OpenTelemetry tracing
             services.AddOpenTelemetryTracing(builder => {
                 builder
-                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddDataCoreAdapterApiService(System.Net.Dns.GetHostName()))
+                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddDataCoreAdapterApiService())
                     .AddAspNetCoreInstrumentation()
                     .AddDataCoreAdapterInstrumentation()
                     .AddJaegerExporter();

--- a/examples/ExampleHostedAdapter/Program.cs
+++ b/examples/ExampleHostedAdapter/Program.cs
@@ -41,20 +41,29 @@ builder.Services
 builder.Services
     .AddGrpc();
 
-// Register adapter health checks.
+// Register adapter health checks. See https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks
+// for more information about ASP.NET Core health checks.
 builder.Services
     .AddHealthChecks()
     .AddAdapterHealthChecks();
 
 // Register OpenTelemetry trace instrumentation. This can be safely removed if not required.
 builder.Services.AddOpenTelemetryTracing(otel => otel
-    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddDataCoreAdapterApiService(AdapterId))
-    .AddAspNetCoreInstrumentation() // Records incoming HTTP requests made to the adapter host.
-    .AddHttpClientInstrumentation() // Records outgoing HTTP requests made by the adapter host.
-    .AddSqlClientInstrumentation() // Records queries made by System.Data.SqlClient and Microsoft.Data.SqlClient.
-    .AddDataCoreAdapterInstrumentation() // Records activities created by adapters and adapter hosting packages.
-    .AddJaegerExporter()); // Exports traces to Jaeger (https://www.jaegertracing.io/) using default settings.
+    // Specify an OpenTelemetry service instance ID in AddDataCoreAdapterApiService below to
+    // override the use of the DNS host name for the local machine.
+    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddDataCoreAdapterApiService())
+    // Records incoming HTTP requests made to the adapter host.
+    .AddAspNetCoreInstrumentation()
+    // Records outgoing HTTP requests made by the adapter host.
+    .AddHttpClientInstrumentation()
+    // Records queries made by System.Data.SqlClient and Microsoft.Data.SqlClient.
+    .AddSqlClientInstrumentation()
+    // Records activities created by adapters and adapter hosting packages.
+    .AddDataCoreAdapterInstrumentation()
+    // Exports traces to Jaeger (https://www.jaegertracing.io/) using default settings.
+    .AddJaegerExporter());
 
+// Build the app and the request pipeline.
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment()) {

--- a/examples/MinimalApiExample/Program.cs
+++ b/examples/MinimalApiExample/Program.cs
@@ -40,7 +40,7 @@ builder.Services
     .AddAdapterHealthChecks();
 
 builder.Services.AddOpenTelemetryTracing(otel => otel
-    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddDataCoreAdapterApiService(System.Net.Dns.GetHostName()))
+    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddDataCoreAdapterApiService())
     .AddAspNetCoreInstrumentation()
     .AddDataCoreAdapterInstrumentation()
     .AddJaegerExporter()

--- a/src/DataCore.Adapter.OpenTelemetry/DCAResourceBuilderExtensions.cs
+++ b/src/DataCore.Adapter.OpenTelemetry/DCAResourceBuilderExtensions.cs
@@ -23,7 +23,8 @@ namespace OpenTelemetry.Resources {
         ///   The <see cref="ResourceBuilder"/>.
         /// </param>
         /// <param name="serviceInstanceId">
-        ///   The instance ID for the service.
+        ///   The instance ID for the service. Specify <see langword="null"/> to use the DNS host 
+        ///   name of the local machine.
         /// </param>
         /// <returns>
         ///   The <see cref="ResourceBuilder"/>.
@@ -32,7 +33,7 @@ namespace OpenTelemetry.Resources {
             return builder.AddService(
                 serviceName: AdapterApiServiceName, 
                 serviceVersion: Assembly.GetEntryAssembly().GetInformationalVersion(), 
-                serviceInstanceId: serviceInstanceId
+                serviceInstanceId: serviceInstanceId ?? System.Net.Dns.GetHostName()
             );
         }
 


### PR DESCRIPTION
Update `AssetModelManager` and `SnapshotTagValueManager` to allow a null `IKeyValueStore` to be specified. When this is the case, persistence is disabled for these classes.