### PR TITLE
Bump package versions and update SemVer parsing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,11 +26,11 @@
   <ItemGroup>
     <PackageVersion Include="Castle.Core" Version="5.1.0" />
     <PackageVersion Include="CsvHelper" Version="28.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.21.4" />
+    <PackageVersion Include="Google.Protobuf" Version="3.21.5" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.47.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.3" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.47.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.47.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.48.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="8.1.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="8.1.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="8.1.0" />
@@ -38,15 +38,15 @@
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.8" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="6.0.7" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="6.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="3.1.27" />
-    <PackageVersion Include="Microsoft.FASTER.Core" Version="2.0.14" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageVersion Include="Microsoft.FASTER.Core" Version="2.0.16" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="$(PkgVersion_Microsoft_Web_LibraryManager_Build)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,7 +55,6 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="NSwag.AspNetCore" Version="13.16.1" />
-    <PackageVersion Include="NuGet.Versioning" Version="6.2.1" />
     <PackageVersion Include="OpenTelemetry" Version="$(PkgVersion_OpenTelemetry)" />
     <PackageVersion Include="OpenTelemetry.Api" Version="$(PkgVersion_OpenTelemetry_Api)" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="$(PkgVersion_OpenTelemetry_Exporter_Console)" />
@@ -64,6 +63,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(PkgVersion_OpenTelemetry_Instrumentation_AspNetCore)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(PkgVersion_OpenTelemetry_Instrumentation_Http)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="$(PkgVersion_OpenTelemetry_Instrumentation_SqlClient)" />
+    <PackageVersion Include="Semver" Version="2.2.0" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />

--- a/build.cake
+++ b/build.cake
@@ -51,7 +51,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=1.0.0
+#load nuget:?package=Jaahas.Cake.Extensions&version=1.2.0
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);

--- a/examples/ExampleHostedAdapter/Pages/Index.cshtml
+++ b/examples/ExampleHostedAdapter/Pages/Index.cshtml
@@ -5,37 +5,36 @@
 }
 
 <div id="adapter-status">
-@await Html.PartialAsync("_AdapterStatusPartial", Model)
+  @await Html.PartialAsync("_AdapterStatusPartial")
 </div>
 
 @section Scripts {
   <script defer>
     $(() => {
-        function setLastUpdated() {
-            $('#last-updated').text('Last Updated: ' + new Date().toLocaleString());
-        }
-
-        setLastUpdated();
-
         let updateInProgress = false;
-        setInterval(function() { 
+
+        const setLastUpdatedTime = () => $('#last-updated').text('Last Updated: ' + new Date().toLocaleString());
+        
+        const updateStatus = async () => {
             if (updateInProgress) {
                 return;
             }
 
-            $.get({
-                url: '@Url.Page("Index", "Status")',
-                beforeSend: function() { 
-                    updateInProgress = true;
-                },
-                complete: function() { 
-                    updateInProgress = false;
-                },
-                success: function(response) {
-                    $('#adapter-status').html(response);
-                    setLastUpdated();
-                }
-            });
+            updateInProgress = true;
+            try {
+                const response = await $.get('@Url.Page("Index", "Status")');
+                $('#adapter-status').html(response);
+                setLastUpdatedTime();;
+            }
+            finally {
+                updateInProgress = false;
+            }
+        };
+
+        setLastUpdatedTime();
+        
+        setInterval(async () => { 
+            await updateStatus();
         }, 15000);
     });
   </script>

--- a/examples/ExampleHostedAdapter/Pages/Settings.cshtml
+++ b/examples/ExampleHostedAdapter/Pages/Settings.cshtml
@@ -24,7 +24,7 @@
       </div>
     }
 
-    <div class="card-body pt-0 pb-0">
+    <div class="card-body pb-0">
       <div class="w-100">
         <label asp-for="Options!.Name" class="form-label"></label>
         <input asp-for="Options!.Name" asp-placeholder-for="Options!.Name" class="form-control" />

--- a/src/DataCore.Adapter.Core/Common/AdapterTypeDescriptor.cs
+++ b/src/DataCore.Adapter.Core/Common/AdapterTypeDescriptor.cs
@@ -64,18 +64,38 @@ namespace DataCore.Adapter.Common {
             Id = id ?? throw new ArgumentNullException(nameof(id));
             Name = name;
             Description = description;
-            if (version == null) {
-                Version = null;
-            }
-            else {
-                Version = NuGet.Versioning.SemanticVersion.TryParse(version, out var semVer)
-                    ? semVer.ToFullString()
-                    : System.Version.TryParse(version, out var v)
-                        ? new NuGet.Versioning.SemanticVersion(v.Major, v.Minor, v.Build, string.Empty, v.Revision.ToString(System.Globalization.CultureInfo.CurrentCulture)).ToFullString()
-                        : null;
-            }
+            Version = GetNormalisedVersion(version);
             Vendor = vendor;
             HelpUrl = helpUrl;
+        }
+
+
+        /// <summary>
+        /// Converts the specified version string into a normalised format.
+        /// </summary>
+        /// <param name="version">
+        ///   The version string.
+        /// </param>
+        /// <param name="style">
+        ///   The <see cref="Semver.SemVersionStyles"/> to use when converting <paramref name="version"/> 
+        ///   into a <see cref="Semver.SemVersion"/> instance.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>
+        ///   <see cref="GetNormalisedVersion"/> will attempt to convert <paramref name="version"/> 
+        ///   into a <see cref="Semver.SemVersion"/> instance and return a <see cref="string"/> 
+        ///   representation of the version.
+        /// </remarks>
+        internal static string? GetNormalisedVersion(string? version, Semver.SemVersionStyles style = Semver.SemVersionStyles.Strict) {
+            if (version == null) {
+                return null;
+            }
+
+            return Semver.SemVersion.TryParse(version, style, out var semVer)
+                ? semVer.ToString()
+                : System.Version.TryParse(version, out var v)
+                    ? Semver.SemVersion.FromVersion(v).ToString()
+                    : null;
         }
 
     }

--- a/src/DataCore.Adapter.Core/Common/HostInfo.cs
+++ b/src/DataCore.Adapter.Core/Common/HostInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace DataCore.Adapter.Common {
@@ -65,11 +64,7 @@ namespace DataCore.Adapter.Common {
         public HostInfo(string? name, string? description, string? version, VendorInfo? vendor, IEnumerable<AdapterProperty>? properties) {
             Name = name?.Trim();
             Description = description?.Trim();
-            Version = NuGet.Versioning.SemanticVersion.TryParse(version, out var semVer)
-                ? semVer.ToFullString()
-                : System.Version.TryParse(version, out var v)
-                    ? new NuGet.Versioning.SemanticVersion(v.Major, v.Minor, v.Build, string.Empty, v.Revision.ToString(System.Globalization.CultureInfo.CurrentCulture)).ToFullString()
-                    : new NuGet.Versioning.SemanticVersion(0, 0, 0).ToFullString();
+            Version = AdapterTypeDescriptor.GetNormalisedVersion(version) ?? new Semver.SemVersion(0, 0, 0).ToString();
             Vendor = vendor;
             Properties = properties?.ToArray() ?? Array.Empty<AdapterProperty>();
         }

--- a/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
+++ b/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Versioning" />
+    <PackageReference Include="Semver" />
     <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
 

--- a/src/DataCore.Adapter.Templates/templates/aschostedadapter/.template.config/template.json
+++ b/src/DataCore.Adapter.Templates/templates/aschostedadapter/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Intelligent Plant",
-  "classifications": [ "Industrial App Store", "Web", "MVC", "IoT" ],
+  "classifications": [ "Industrial App Store", "Web", "Razor Pages", "IoT" ],
   "identity": "IntelligentPlant.AppStoreConnect.Adapter.AppStoreConnectAdapterHost",
   "name": "Industrial App Store Connect Adapter Host",
   "description": "A project for creating a data adapter that connects to the Industrial App Store using App Store Connect.",

--- a/src/DataCore.Adapter/AdapterBaseT.cs
+++ b/src/DataCore.Adapter/AdapterBaseT.cs
@@ -97,7 +97,7 @@ namespace DataCore.Adapter {
         private readonly Nito.AsyncEx.AsyncManualResetEvent _shutdownInProgress = new Nito.AsyncEx.AsyncManualResetEvent(true); // Initial state is set
 
         /// <summary>
-        /// Fires when <see cref="Dispose"/> or <see cref="DisposeAsync"/> are called.
+        /// Fires when <see cref="Dispose()"/> or <see cref="DisposeAsync"/> are called.
         /// </summary>
         private readonly CancellationTokenSource _disposedTokenSource = new CancellationTokenSource();
 


### PR DESCRIPTION
- Updates some NuGet package references
- Replaces `NuGet.Versioning` with `Semver` for parsing SemVer v2.0.0 versions
- Updates build tools to ensure that assembly informational versions are SemVer-compatible