### PR TITLE
Add Bill of Materials generation to Cake script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -15,7 +15,7 @@ const string VersionFile = "./build/version.json";
 // --target=<TARGET>
 //   The Cake target to run. 
 //     Default: Test
-//     Possible Values: Clean, Restore, Build, Test, Pack
+//     Possible Values: Clean, Restore, Build, Test, Pack, BillOfMaterials
 //
 // --configuration=<CONFIGURATION>
 //   The MSBuild configuration to use. 
@@ -52,9 +52,23 @@ const string VersionFile = "./build/version.json";
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 #load nuget:?package=Jaahas.Cake.Extensions&version=1.3.1
+#tool dotnet:?package=CycloneDX&version=2.3.0
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);
+
+// Add Bill of Materials task
+Task("BillOfMaterials")
+    .IsDependentOn("Pack")
+    .Does<BuildState>(state => {
+        StartProcess("dotnet", new ProcessSettings {
+            Arguments = new ProcessArgumentBuilder()
+                .Append("CycloneDX")
+                .Append(DefaultSolutionFile)
+                .Append("-o")
+                .Append("./artifacts/bom")
+        });
+    });
 
 // Get the target that was specified.
 var target = GetTarget();

--- a/build.cake
+++ b/build.cake
@@ -59,7 +59,6 @@ Bootstrap(DefaultSolutionFile, VersionFile);
 
 // Add Bill of Materials task
 Task("BillOfMaterials")
-    .IsDependentOn("Pack")
     .Does<BuildState>(state => {
         StartProcess("dotnet", new ProcessSettings {
             Arguments = new ProcessArgumentBuilder()


### PR DESCRIPTION
`BillOfMaterials` target in Cake script can now be used to generate a Bill of Materials using CycloneDX