### PR TITLE
Update Cake extensions reference

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -51,7 +51,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=1.4.0
+#load nuget:?package=Jaahas.Cake.Extensions&version=1.4.1
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);

--- a/build.cake
+++ b/build.cake
@@ -51,7 +51,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=1.4.1
+#load nuget:?package=Jaahas.Cake.Extensions&version=1.4.2
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);


### PR DESCRIPTION
Ensures that the build number does not get set in TeamCity when running the `BillOfMaterials` target in Cake