### PR TITLE
Update Cake extensions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.0.0",
+      "version": "2.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/build.cake
+++ b/build.cake
@@ -48,10 +48,20 @@ const string VersionFile = "./build/version.json";
 //   Specifies an additional property to pass to MSBuild during Build and Pack targets. The value
 //   must be specified using a '<NAME>=<VALUE>' format e.g. --property="NoWarn=CS1591". This 
 //   argument can be specified multiple times.
+//
+// --github-username=<USERNAME>
+//   Specifies the GitHub username to use when making authenticated API calls to GitHub while 
+//   running the BillOfMaterials target. You must specify the --github-token argument as well when 
+//   specifying this argument.
+//
+// --github-token=<PERSONAL ACCESS TOKEN>
+//   Specifies the GitHub personal access token to use when making authenticated API calls to 
+//   GitHub while running the BillOfMaterials target. You must specify the --github-username 
+//   argument as well when specifying this argument.
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=1.4.2
+#load nuget:?package=Jaahas.Cake.Extensions&version=1.5.0
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);


### PR DESCRIPTION
Updates the Cake extensions package to allow GitHub credentials to be passed to CycloneDX when generating a Bill of Materials