### PR TITLE
Deprecate all types in DataCore.Adapter.Proxy

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
@@ -97,7 +97,9 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <summary>
         /// A factory delegate for creating extension feature implementations.
         /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
         private readonly ExtensionFeatureFactory<SignalRAdapterProxy>? _extensionFeatureFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// The client used in standard adapter queries.
@@ -146,7 +148,9 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
             Encoders = encoders?.ToArray() ?? throw new ArgumentNullException(nameof(encoders));
             _remoteAdapterId = Options?.RemoteId ?? throw new ArgumentException(Resources.Error_AdapterIdIsRequired, nameof(options));
             _connectionFactory = Options?.ConnectionFactory ?? throw new ArgumentException(Resources.Error_ConnectionFactoryIsRequired, nameof(options));
+#pragma warning disable CS0618 // Type or member is obsolete
             _extensionFeatureFactory = Options?.ExtensionFeatureFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
             _client = new Lazy<AdapterSignalRClient>(() => {
                 var conn = _connectionFactory.Invoke(null);
                 AddHubEventHandlers(conn);

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxyOptions.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxyOptions.cs
@@ -1,6 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 using DataCore.Adapter.AspNetCore.SignalR.Client;
+using DataCore.Adapter.Extensions;
 using DataCore.Adapter.Proxy;
 
 namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
@@ -31,6 +33,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// A factory method that the proxy calls to request a concrete implementation of an 
         /// extension feature.
         /// </summary>
+        [Obsolete(ExtensionFeatureConstants.ObsoleteMessage, ExtensionFeatureConstants.ObsoleteError)]
         public ExtensionFeatureFactory<SignalRAdapterProxy>? ExtensionFeatureFactory { get; set; }
 
     }

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
@@ -45,8 +45,6 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         /// </summary>
         protected IBackgroundTaskService BackgroundTaskService { get; }
 
-#if NETCOREAPP
-
         /// <summary>
         /// JSON serialization options.
         /// </summary>
@@ -79,30 +77,6 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             BackgroundTaskService = taskScheduler ?? IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default;
             _jsonOptions = jsonOptions?.Value?.PayloadSerializerOptions;
         }
-
-#else
-        /// <summary>
-        /// Creates a new <see cref="AdapterHub"/> object.
-        /// </summary>
-        /// <param name="hostInfo">
-        ///   The host information.
-        /// </param>
-        /// <param name="adapterAccessor">
-        ///   For accessing runtime adapters.
-        /// </param>
-        /// <param name="taskScheduler">
-        ///   The background task scheduler to use.
-        /// </param>
-        public AdapterHub(
-            HostInfo hostInfo, 
-            IAdapterAccessor adapterAccessor,
-            IBackgroundTaskService taskScheduler
-        ) {
-            HostInfo = hostInfo ?? throw new ArgumentNullException(nameof(hostInfo));
-            AdapterAccessor = adapterAccessor ?? throw new ArgumentNullException(nameof(adapterAccessor));
-            BackgroundTaskService = taskScheduler ?? IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default;
-        }
-#endif
 
 
         /// <summary>

--- a/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.cs
@@ -113,7 +113,9 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         /// A factory delegate for creating extension feature implementations.
         /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
         private readonly ExtensionFeatureFactory<GrpcAdapterProxy>? _extensionFeatureFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         /// <summary>
@@ -163,7 +165,9 @@ namespace DataCore.Adapter.Grpc.Proxy {
             _remoteAdapterId = Options?.RemoteId ?? throw new ArgumentException(Resources.Error_AdapterIdIsRequired, nameof(options));
             _channel = channel ?? throw new ArgumentNullException(nameof(channel));
             _getCallCredentials = Options?.GetCallCredentials;
+#pragma warning disable CS0618 // Type or member is obsolete
             _extensionFeatureFactory = Options?.ExtensionFeatureFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
             _closeChannelOnDispose = Options?.CloseChannelOnDispose ?? false;
         }
 

--- a/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxyOptions.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxyOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 
+using DataCore.Adapter.Extensions;
 using DataCore.Adapter.Proxy;
 
 using GrpcCore = Grpc.Core;
@@ -38,6 +39,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// A factory method that the proxy calls to request a concrete implementation of an 
         /// extension feature.
         /// </summary>
+        [Obsolete(ExtensionFeatureConstants.ObsoleteMessage, ExtensionFeatureConstants.ObsoleteError)]
         public ExtensionFeatureFactory<GrpcAdapterProxy>? ExtensionFeatureFactory { get; set; }
 
         /// <summary>

--- a/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
+++ b/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
@@ -107,7 +107,9 @@ namespace DataCore.Adapter.Http.Proxy {
         /// <summary>
         /// A factory delegate for creating extension feature implementations.
         /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
         private readonly ExtensionFeatureFactory<HttpAdapterProxy>? _extensionFeatureFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// The client used in standard adapter queries.
@@ -156,7 +158,9 @@ namespace DataCore.Adapter.Http.Proxy {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _client.CompatibilityVersion = options?.CompatibilityVersion ?? CompatibilityVersion.Latest;
             _remoteAdapterId = Options?.RemoteId ?? throw new ArgumentException(Resources.Error_AdapterIdIsRequired, nameof(options));
+#pragma warning disable CS0618 // Type or member is obsolete
             _extensionFeatureFactory = Options?.ExtensionFeatureFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
             _snapshotRefreshInterval = Options?.TagValuePushInterval ?? TimeSpan.FromMinutes(1);
         }
 

--- a/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxyOptions.cs
+++ b/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxyOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 
+using DataCore.Adapter.Extensions;
 using DataCore.Adapter.Http.Client;
 using DataCore.Adapter.Proxy;
 
@@ -42,6 +43,7 @@ namespace DataCore.Adapter.Http.Proxy {
         /// A factory method that the proxy calls to request a concrete implementation of an 
         /// extension feature.
         /// </summary>
+        [Obsolete(ExtensionFeatureConstants.ObsoleteMessage, ExtensionFeatureConstants.ObsoleteError)]
         public ExtensionFeatureFactory<HttpAdapterProxy>? ExtensionFeatureFactory { get; set; }
 
     }

--- a/src/DataCore.Adapter.Proxy/ExtensionFeatureFactory.cs
+++ b/src/DataCore.Adapter.Proxy/ExtensionFeatureFactory.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+using DataCore.Adapter.Extensions;
+
 namespace DataCore.Adapter.Proxy {
     /// <summary>
     /// Delegate for creating extension feature implementations on behalf of a proxy.
@@ -21,6 +23,7 @@ namespace DataCore.Adapter.Proxy {
     ///   If the implementation implements <see cref="IAsyncDisposable"/> or <see cref="IDisposable"/>, 
     ///   it will be disposed when the proxy is disposed.
     /// </remarks>
+    [Obsolete(ExtensionFeatureConstants.ObsoleteMessage, ExtensionFeatureConstants.ObsoleteError)]
     public delegate object ExtensionFeatureFactory<TProxy>(
         string featureUriOrName, 
         TProxy proxy

--- a/src/DataCore.Adapter.Proxy/ExtensionFeatureProxyGenerator.cs
+++ b/src/DataCore.Adapter.Proxy/ExtensionFeatureProxyGenerator.cs
@@ -13,6 +13,7 @@ namespace DataCore.Adapter.Proxy {
     /// <summary>
     /// Generates dynamic implementations of unknown extension adapter features.
     /// </summary>
+    [Obsolete(ExtensionFeatureConstants.ObsoleteMessage, ExtensionFeatureConstants.ObsoleteError)]
     public static class ExtensionFeatureProxyGenerator {
 
         /// <summary>


### PR DESCRIPTION
Marks all types in DataCore.Adapter.Proxy as `[Obsolete]` as per #218.

Also removes some pre-processor directives that should have been removed in #221.