### PR TITLE
Add SignalR capabilities to HTTP adapter proxy

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.Common/IApiDescriptorProvider.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/IApiDescriptorProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace DataCore.Adapter.AspNetCore {
+﻿using DataCore.Adapter.Common;
+
+namespace DataCore.Adapter.AspNetCore {
 
     /// <summary>
     /// Service that provides information about an API that is registered with the adapter host.

--- a/src/DataCore.Adapter.AspNetCore.Common/IAvailableApiService.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/IAvailableApiService.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 
+using DataCore.Adapter.Common;
+
 namespace DataCore.Adapter.AspNetCore {
 
     /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Common/Internal/DefaultAvailableApiService.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/Internal/DefaultAvailableApiService.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 
+using DataCore.Adapter.Common;
+
 namespace DataCore.Adapter.AspNetCore.Internal {
 
     /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Grpc/Internal/ApiDescriptorProvider.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/Internal/ApiDescriptorProvider.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Routing;
+﻿using DataCore.Adapter.Common;
+
+using Microsoft.AspNetCore.Routing;
 
 namespace DataCore.Adapter.AspNetCore.Grpc.Internal {
 

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/HostInfoController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/HostInfoController.cs
@@ -55,7 +55,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         /// Gets descriptors for the standard adapter features.
         /// </summary>
         /// <returns>
-        ///   Successful responses contain a collection of <see cref="FeatureDescriptor"/> object 
+        ///   Successful responses contain a collection of <see cref="FeatureDescriptor"/> objects
         ///   describing the standard adapter features.
         /// </returns>
         [HttpGet]
@@ -64,6 +64,25 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [ProducesResponseType(typeof(IEnumerable<FeatureDescriptor>), 200)]
         public IActionResult GetStandardFeatureDescriptors() {
             return Ok(TypeExtensions.GetStandardAdapterFeatureTypes().Select(x => x.CreateFeatureDescriptor()).ToArray()); // 200
+        }
+
+
+        /// <summary>
+        /// Gets the available APIs for the host.
+        /// </summary>
+        /// <param name="apiService">
+        ///   The <see cref="IAvailableApiService"/> that returns information about the enabled APIs.
+        /// </param>
+        /// <returns>
+        ///   Successful responses contain a collection of <see cref="ApiDescriptor"/> objects 
+        ///   describing the available APIs.
+        /// </returns>
+        [HttpGet]
+        [Route("available-apis")]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(IEnumerable<ApiDescriptor>), 200)]
+        public IActionResult GetAvailableApis([FromServices] IAvailableApiService apiService) {
+            return Ok(apiService.GetApiDescriptors().Where(x => x.Enabled).ToArray()); // 200
         }
 
     }

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Internal/ApiDescriptorProvider.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Internal/ApiDescriptorProvider.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Routing;
+﻿using DataCore.Adapter.Common;
+
+using Microsoft.AspNetCore.Routing;
 
 namespace DataCore.Adapter.AspNetCore.Mvc.Internal {
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/ConnectionFactory.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/ConnectionFactory.cs
@@ -3,11 +3,10 @@
 namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
 
     /// <summary>
-    /// Delegate for creating SignalR hub connections on behalf of a proxy.
+    /// Delegate for creating SignalR hub connections.
     /// </summary>
     /// <param name="key">
-    ///   The key for the connection. The value will be <see langword="null"/> unless a connection is 
-    ///   being requested for an extension feature.
+    ///   The identifier for the connection. Can be <see langword="null"/>.
     /// </param>
     /// <returns>
     ///   The configured hub connection.

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Internal/ApiDescriptorProvider.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Internal/ApiDescriptorProvider.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Routing;
+﻿using DataCore.Adapter.Common;
+
+using Microsoft.AspNetCore.Routing;
 
 namespace DataCore.Adapter.AspNetCore.SignalR.Internal {
 

--- a/src/DataCore.Adapter.Core/Common/ApiDescriptor.cs
+++ b/src/DataCore.Adapter.Core/Common/ApiDescriptor.cs
@@ -1,4 +1,6 @@
-﻿namespace DataCore.Adapter.AspNetCore {
+﻿using System.Text.Json.Serialization;
+
+namespace DataCore.Adapter.Common {
 
     /// <summary>
     /// Describes an API that can be used to query adapters (e.g. REST, gRPC, SignalR).
@@ -33,6 +35,7 @@
         /// <param name="enabled">
         ///   Specifies if the API is enabled or not.
         /// </param>
+        [JsonConstructor]
         public ApiDescriptor(string name, string? version, bool enabled) {
             Name = name;
             Version = version;

--- a/src/DataCore.Adapter.Http.Client/Clients/HostInfoClient.cs
+++ b/src/DataCore.Adapter.Http.Client/Clients/HostInfoClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Security.Claims;
@@ -59,6 +60,32 @@ namespace DataCore.Adapter.Http.Client.Clients {
                 await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
 
                 return (await httpResponse.Content.ReadFromJsonAsync<HostInfo>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
+            }
+        }
+
+
+        /// <summary>
+        /// Gets the APIs that are enabled on the remote host.
+        /// </summary>
+        /// <param name="metadata">
+        ///   The metadata to associate with the outgoing request.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A task that will return information about the available APIs.
+        /// </returns>
+        public async Task<IEnumerable<ApiDescriptor>> GetAvailableApisAsync(
+            RequestMetadata? metadata = null, 
+            CancellationToken cancellationToken = default
+        ) {
+            var url = UrlPrefix + "/available-apis";
+            using (var httpRequest = AdapterHttpClient.CreateHttpRequestMessage(HttpMethod.Get, url, metadata))
+            using (var httpResponse = await _client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false)) {
+                await httpResponse.ThrowOnErrorResponse().ConfigureAwait(false);
+
+                return (await httpResponse.Content.ReadFromJsonAsync<IEnumerable<ApiDescriptor>>(_client.JsonSerializerOptions, cancellationToken).ConfigureAwait(false))!;
             }
         }
 

--- a/src/DataCore.Adapter.Http.Client/CompatibilityVersion.cs
+++ b/src/DataCore.Adapter.Http.Client/CompatibilityVersion.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace DataCore.Adapter.Http.Client {
+﻿namespace DataCore.Adapter.Http.Client {
 
     /// <summary>
     /// Describes the App Store Connect adapter toolkit version that the client should use.
@@ -17,6 +13,10 @@ namespace DataCore.Adapter.Http.Client {
         /// v2.0
         /// </summary>
         Version_2_0 = 2,
+        /// <summary>
+        /// v3.0
+        /// </summary>
+        Version_3_0 = 3,
         /// <summary>
         /// The current version.
         /// </summary>

--- a/src/DataCore.Adapter.Http.Proxy/ConnectionFactory.cs
+++ b/src/DataCore.Adapter.Http.Proxy/ConnectionFactory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace DataCore.Adapter.Http.Proxy {
+
+    /// <summary>
+    /// Delegate for creating SignalR hub connections.
+    /// </summary>
+    /// <param name="url">
+    ///   The URL for the connection.
+    /// </param>
+    /// <param name="context">
+    ///   The <see cref="IAdapterCallContext"/> to associated with the connection. Can be <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    ///   The configured hub connection.
+    /// </returns>
+    public delegate HubConnection ConnectionFactory(Uri url, IAdapterCallContext? context);
+
+}

--- a/src/DataCore.Adapter.Http.Proxy/ConnectionIdentityFactory.cs
+++ b/src/DataCore.Adapter.Http.Proxy/ConnectionIdentityFactory.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DataCore.Adapter.Http.Proxy {
+    /// <summary>
+    /// A delegate for extracting the parts used to uniquely identify a SignalR connection from a 
+    /// provided <see cref="IAdapterCallContext"/>.
+    /// </summary>
+    /// <param name="callContext">
+    ///   The <see cref="IAdapterCallContext"/>.
+    /// </param>
+    /// <returns>
+    ///   The identifier parts for the <see cref="IAdapterCallContext"/>.
+    /// </returns>
+    public delegate IEnumerable<string> ConnectionIdentityFactory(IAdapterCallContext callContext); 
+}

--- a/src/DataCore.Adapter.Http.Proxy/DataCore.Adapter.Http.Proxy.csproj
+++ b/src/DataCore.Adapter.Http.Proxy/DataCore.Adapter.Http.Proxy.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DataCore.Adapter\DataCore.Adapter.csproj" />
+    <ProjectReference Include="..\DataCore.Adapter.AspNetCore.SignalR.Client\DataCore.Adapter.AspNetCore.SignalR.Client.csproj" />
     <ProjectReference Include="..\DataCore.Adapter.Http.Client\DataCore.Adapter.Http.Client.csproj" />
     <ProjectReference Include="..\DataCore.Adapter.Proxy\DataCore.Adapter.Proxy.csproj" />
   </ItemGroup>

--- a/src/DataCore.Adapter.Http.Proxy/Diagnostics/ConfigurationChangesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Diagnostics/ConfigurationChangesImpl.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.Diagnostics;
+
+namespace DataCore.Adapter.Http.Proxy.Diagnostics {
+
+    /// <summary>
+    /// Implements <see cref="IConfigurationChanges"/>.
+    /// </summary>
+    internal class ConfigurationChangesImpl : ProxyAdapterFeature, IConfigurationChanges {
+
+        /// <summary>
+        /// Creates a new <see cref="ConfigurationChangesImpl"/> object.
+        /// </summary>
+        /// <param name="proxy">
+        ///   The owning proxy.
+        /// </param>
+        public ConfigurationChangesImpl(HttpAdapterProxy proxy) : base(proxy) { }
+
+
+        /// <inheritdoc />
+        public async IAsyncEnumerable<ConfigurationChange> Subscribe(
+            IAdapterCallContext context,
+            ConfigurationChangesSubscriptionRequest request,
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            Proxy.ValidateInvocation(context, request);
+
+            var client = GetSignalRClient(context);
+
+            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
+                await client.StreamStartedAsync().ConfigureAwait(false);
+
+                try {
+                    await foreach (var item in client.Client.ConfigurationChanges.CreateConfigurationChangesChannelAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false)) {
+                        if (item == null) {
+                            continue;
+                        }
+                        yield return item;
+                    }
+                }
+                finally {
+                    await client.StreamCompletedAsync().ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+}

--- a/src/DataCore.Adapter.Http.Proxy/Events/EventMessagePushImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/EventMessagePushImpl.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.Events;
+
+namespace DataCore.Adapter.Http.Proxy.Events {
+
+    /// <summary>
+    /// Implements <see cref="IEventMessagePush"/>.
+    /// </summary>
+    internal class EventMessagePushImpl : ProxyAdapterFeature, IEventMessagePush {
+
+        /// <summary>
+        /// Creates a new <see cref="EventMessagePushImpl"/> object.
+        /// </summary>
+        /// <param name="proxy">
+        ///   The owning proxy.
+        /// </param>
+        public EventMessagePushImpl(HttpAdapterProxy proxy) : base(proxy) { }
+
+
+        /// <inheritdoc />
+        public async IAsyncEnumerable<EventMessage> Subscribe(
+            IAdapterCallContext context,
+            CreateEventMessageSubscriptionRequest request,
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            Proxy.ValidateInvocation(context, request);
+
+            var client = GetSignalRClient(context);
+
+            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
+                await client.StreamStartedAsync().ConfigureAwait(false);
+
+                try {
+                    await foreach (var item in client.Client.Events.CreateEventMessageChannelAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false)) {
+                        if (item == null) {
+                            continue;
+                        }
+                        yield return item;
+                    }
+                }
+                finally {
+                    await client.StreamCompletedAsync().ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+}

--- a/src/DataCore.Adapter.Http.Proxy/Events/EventMessagePushWithTopicsImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/EventMessagePushWithTopicsImpl.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.Events;
+
+namespace DataCore.Adapter.Http.Proxy.Events {
+
+    /// <summary>
+    /// Implements <see cref="IEventMessagePushWithTopics"/>.
+    /// </summary>
+    internal class EventMessagePushWithTopicsImpl : ProxyAdapterFeature, IEventMessagePushWithTopics {
+
+        /// <summary>
+        /// Creates a new <see cref="EventMessagePushWithTopicsImpl"/> object.
+        /// </summary>
+        /// <param name="proxy">
+        ///   The owning proxy.
+        /// </param>
+        public EventMessagePushWithTopicsImpl(HttpAdapterProxy proxy) : base(proxy) { }
+
+
+        /// <inheritdoc />
+        public async IAsyncEnumerable<EventMessage> Subscribe(
+            IAdapterCallContext context,
+            CreateEventMessageTopicSubscriptionRequest request,
+            IAsyncEnumerable<EventMessageSubscriptionUpdate> channel,
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            Proxy.ValidateInvocation(context, request);
+
+            var client = GetSignalRClient(context);
+
+            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
+                await client.StreamStartedAsync().ConfigureAwait(false);
+
+                try {
+                    await foreach (var item in client.Client.Events.CreateEventMessageTopicChannelAsync(AdapterId, request, channel, ctSource.Token).ConfigureAwait(false)) {
+                        if (item == null) {
+                            continue;
+                        }
+                        yield return item;
+                    }
+                }
+                finally {
+                    await client.StreamCompletedAsync().ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+}

--- a/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
+++ b/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -62,6 +65,8 @@ namespace DataCore.Adapter.Http.Proxy {
         /// the remote adapter does not support <see cref="Adapter.RealTimeData.ISnapshotTagValuePush"/>.
         /// </summary>
         private readonly TimeSpan _snapshotRefreshInterval;
+
+        private readonly ConcurrentDictionary<string, SignalRClientWrapper> _signalRClients = new ConcurrentDictionary<string, SignalRClientWrapper>(StringComparer.Ordinal);
 
         /// <summary>
         /// The proxy's logger.
@@ -177,6 +182,52 @@ namespace DataCore.Adapter.Http.Proxy {
 
 
         /// <summary>
+        /// Gets or creates the <see cref="SignalRClientWrapper"/> for the specified 
+        /// <see cref="IAdapterCallContext"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/>.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="SignalRClientWrapper"/> for the <paramref name="context"/>.
+        /// </returns>
+        internal SignalRClientWrapper GetSignalRClient(IAdapterCallContext context) {
+            var getKeys = Options.SignalROptions?.ConnectionIdentityFactory;
+            if (getKeys == null) {
+                getKeys = ctx => new[] { context.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value ?? context.User?.Identity?.Name ?? string.Empty };
+            }
+            
+            var key = Convert.ToBase64String(SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(string.Join(",", getKeys.Invoke(context)))));
+            
+            return _signalRClients.GetOrAdd(key, k => {
+                var client = new SignalRClientWrapper(
+                    k,
+                    new AspNetCore.SignalR.Client.AdapterSignalRClient(Options.SignalROptions!.ConnectionFactory.Invoke(new Uri(_client.HttpClient.BaseAddress, AspNetCore.SignalR.Client.AdapterSignalRClient.DefaultHubRoute), context)),
+                    Options.SignalROptions.TimeToLive <= TimeSpan.Zero
+                        ? TimeSpan.FromSeconds(30)
+                        : Options.SignalROptions.TimeToLive
+                );
+
+                client.Disposed += OnSignalRClientDisposed;
+
+                return client;
+            });
+        }
+
+
+        /// <summary>
+        /// Removes a disposed <see cref="SignalRClientWrapper"/> from the <see cref="_signalRClients"/> 
+        /// dictionary.
+        /// </summary>
+        /// <param name="client">
+        ///   The disposed <see cref="SignalRClientWrapper"/>.
+        /// </param>
+        private void OnSignalRClientDisposed(SignalRClientWrapper client) {
+            _signalRClients.TryRemove(client.Key, out _);
+        }
+
+
+        /// <summary>
         /// Initialises the proxy.
         /// </summary>
         /// <param name="cancellationToken">
@@ -192,7 +243,32 @@ namespace DataCore.Adapter.Http.Proxy {
 
             RemoteDescriptor = descriptor;
 
-            ProxyAdapterFeature.AddFeaturesToProxy(this, descriptor.Features);
+            var canUseSignalR = Options.CompatibilityVersion < CompatibilityVersion.Version_3_0
+                ? Options.SignalROptions != null
+                : Options.SignalROptions != null && (await client.HostInfo.GetAvailableApisAsync(null, cancellationToken).ConfigureAwait(false)).Any(x => x.Enabled && "SignalR".Equals(x.Name, StringComparison.OrdinalIgnoreCase));
+
+            var v3OrLaterFeatures = new[] { 
+                typeof(Adapter.Extensions.ICustomFunctions)
+            };
+
+            var requiresSignalRFeatures = new[] {
+                typeof(IConfigurationChanges),
+                typeof(Adapter.Events.IEventMessagePush),
+                typeof(Adapter.Events.IEventMessagePushWithTopics),
+                typeof(Adapter.RealTimeData.ISnapshotTagValuePush)
+            };
+
+            ProxyAdapterFeature.AddFeaturesToProxy(this, descriptor.Features, type => {
+                if (requiresSignalRFeatures.Contains(type)) {
+                    return canUseSignalR;
+                }
+
+                if (Options.CompatibilityVersion >= CompatibilityVersion.Version_3_0) {
+                    return true;
+                }
+
+                return !v3OrLaterFeatures.Contains(type);
+            });
 
             if (!this.TryGetFeature<Adapter.RealTimeData.ISnapshotTagValuePush>(out _) && _snapshotRefreshInterval > TimeSpan.Zero && this.TryGetFeature<Adapter.RealTimeData.IReadSnapshotTagValues>(out var readSnapshot)) {
                 // We are able to simulate tag value push functionality via polling.
@@ -232,7 +308,12 @@ namespace DataCore.Adapter.Http.Proxy {
             }
 
             if (RemoteDescriptor.HasFeature<IHealthCheck>()) {
-                BackgroundTaskService.QueueBackgroundWorkItem(RunPollingRemoteHealthSubscriptionAsync);
+                if (canUseSignalR) {
+                    BackgroundTaskService.QueueBackgroundWorkItem(RunPushRemoteHealthSubscriptionAsync);
+                }
+                else {
+                    BackgroundTaskService.QueueBackgroundWorkItem(RunPollingRemoteHealthSubscriptionAsync);
+                }
             }
         }
 
@@ -266,6 +347,24 @@ namespace DataCore.Adapter.Http.Proxy {
                     await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
                     OnHealthStatusChanged();
                 } while (!cancellationToken.IsCancellationRequested);
+            }
+        }
+
+
+        /// <summary>
+        /// Long-running task that tells the adapter to recompute the overall health status of the 
+        /// adapter when a status change is received from the remote adapter via push notification.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///   The cancellation token that will fire when the task should end.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task"/> that will monitor for changes in the remote adapter health.
+        /// </returns>
+        private async Task RunPushRemoteHealthSubscriptionAsync(CancellationToken cancellationToken) {
+            var client = GetSignalRClient(new DefaultAdapterCallContext());
+            await foreach (var item in client.Client.Adapters.CreateAdapterHealthChannelAsync(RemoteDescriptor.Id, cancellationToken).ConfigureAwait(false)) {
+                OnHealthStatusChanged();
             }
         }
 
@@ -336,6 +435,27 @@ namespace DataCore.Adapter.Http.Proxy {
             );
 
             return results;
+        }
+
+
+        /// <inheritdoc/>
+        protected override async ValueTask DisposeAsyncCore() {
+            await base.DisposeAsyncCore().ConfigureAwait(false);
+            foreach (var item in _signalRClients.Values) {
+                item.Dispose();
+            }
+        }
+
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing) {
+            base.Dispose(disposing);
+
+            if (disposing) {
+                foreach (var item in _signalRClients.Values) {
+                    item.Dispose();
+                }
+            }
         }
 
     }

--- a/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
+++ b/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxy.cs
@@ -69,7 +69,7 @@ namespace DataCore.Adapter.Http.Proxy {
         /// <summary>
         /// Specifies if the proxy can use SignalR connections.
         /// </summary>
-        private bool _canUseSignalR;
+        internal bool CanUseSignalR { get; private set; }
 
         /// <summary>
         /// The active SignalR clients.
@@ -243,7 +243,7 @@ namespace DataCore.Adapter.Http.Proxy {
                 throw new ArgumentNullException(nameof(context));
             }
             
-            if (!_canUseSignalR) {
+            if (!CanUseSignalR) {
                 client = null;
                 return false;
             }
@@ -282,7 +282,7 @@ namespace DataCore.Adapter.Http.Proxy {
 
             RemoteDescriptor = descriptor;
 
-            _canUseSignalR = Options.CompatibilityVersion < CompatibilityVersion.Version_3_0
+            CanUseSignalR = Options.CompatibilityVersion < CompatibilityVersion.Version_3_0
                 ? Options.SignalROptions != null
                 : Options.SignalROptions != null && (await client.HostInfo.GetAvailableApisAsync(null, cancellationToken).ConfigureAwait(false)).Any(x => x.Enabled && "SignalR".Equals(x.Name, StringComparison.OrdinalIgnoreCase));
 
@@ -299,7 +299,7 @@ namespace DataCore.Adapter.Http.Proxy {
 
             ProxyAdapterFeature.AddFeaturesToProxy(this, descriptor.Features, type => {
                 if (requiresSignalRFeatures.Contains(type)) {
-                    return _canUseSignalR;
+                    return CanUseSignalR;
                 }
 
                 if (Options.CompatibilityVersion >= CompatibilityVersion.Version_3_0) {
@@ -347,7 +347,7 @@ namespace DataCore.Adapter.Http.Proxy {
             }
 
             if (RemoteDescriptor.HasFeature<IHealthCheck>()) {
-                if (_canUseSignalR) {
+                if (CanUseSignalR) {
                     BackgroundTaskService.QueueBackgroundWorkItem(RunPushRemoteHealthSubscriptionAsync);
                 }
                 else {

--- a/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxyOptions.cs
+++ b/src/DataCore.Adapter.Http.Proxy/HttpAdapterProxyOptions.cs
@@ -23,6 +23,27 @@ namespace DataCore.Adapter.Http.Proxy {
         public CompatibilityVersion CompatibilityVersion { get; set; } = CompatibilityVersion.Latest;
 
         /// <summary>
+        ///The SignalR options for the proxy.
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   If <see cref="SignalROptions"/> is <see langword="null"/>, SignalR functionality 
+        ///   will be disabled.
+        /// </para>
+        /// 
+        /// <para>
+        ///   When <see cref="CompatibilityVersion"/> is <see cref="CompatibilityVersion.Version_3_0"/> 
+        ///   or higher, SignalR capabilities will only be enabled if the remote host spcifies 
+        ///   that the adapter SignalR API is enabled. If a lower <see cref="CompatibilityVersion"/> 
+        ///   is specified, SignalR capabilities will always be enabled when a <see cref="SignalROptions"/> 
+        ///   is specified.
+        /// </para>
+        /// 
+        /// </remarks>
+        public SignalROptions? SignalROptions { get; set; }
+
+        /// <summary>
         /// The interval to use between re-polling the health status of the remote adapter. 
         /// Ignored if the remote adapter does not support <see cref="Adapter.Diagnostics.IHealthCheck"/>.
         /// </summary>

--- a/src/DataCore.Adapter.Http.Proxy/ProxyAdapterFeature.cs
+++ b/src/DataCore.Adapter.Http.Proxy/ProxyAdapterFeature.cs
@@ -135,5 +135,17 @@ namespace DataCore.Adapter.Http.Proxy {
             return Proxy.GetClient();
         }
 
+
+        /// <summary>
+        /// Gets the <see cref="SignalRClientWrapper"/> to use for SignalR-specific functionality.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/> for the caller
+        /// </param>
+        /// <returns>
+        ///   The <see cref="SignalRClientWrapper"/> for the calling <paramref name="context"/>.
+        /// </returns>
+        internal SignalRClientWrapper GetSignalRClient(IAdapterCallContext context) => Proxy.GetSignalRClient(context);
+
     }
 }

--- a/src/DataCore.Adapter.Http.Proxy/README.md
+++ b/src/DataCore.Adapter.Http.Proxy/README.md
@@ -99,3 +99,33 @@ async Task<IAdapter> CreateProxy(IHttpClientFactory factory) {
 
 The `ClaimsPrincipal` that is passed to the callback delegate is passed through from the `IAdapterCallContext` that is specified when an adapter feature method is called.
 
+
+# Enabling SignalR Functionality
+
+By default, the HTTP proxy cannot enable any features that use long-running subscriptions (such as snapshot tag value and event message subscriptions). However, if the remote host has the adapter SignalR API enabled, the HTTP proxy can enable these features via SignalR connections.
+
+SignalR functionality is enabled by configuring the `SignalROptions` property on the `HttpAdapterProxyOptions` class:
+
+```csharp
+var options = new HttpAdapterProxyOptions() {
+    Id = "some-id",
+    Name = "some-name",
+    RemoteId = "{SOME_ADAPTER_ID}",
+    SignalROptions = new SignalROptions {
+        TimeToLive = TimeSpan.FromSeconds(30),
+        ConnectionFactory = (Uri url, IAdapterCallContext context) => new HubConnectionBuilder()
+            .WithUrl(url)
+            .WithAutomaticReconnect()
+            .AddJsonProtocol(options => {
+                options.PayloadSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+            })
+            .Build()
+    }
+};
+```
+
+The proxy creates a separate connection for each calling identity. By default, a connection is uniquely identified using the `ClaimTypes.NameIdentifier` claim for the calling user, falling back to the `ClaimTypes.Name` claim. You can assign a delegate to the `SignalROptions.ConnectionIdentityFactory` property to customise the identity for a given caller.
+
+The `SignalROptions.TimeToLive` property defines the time that a connection will remain open for when there are no active subscriptions for the connection.
+
+If `HttpAdapterProxyOptions.SignalROptions` is null, SignalR capabilities are disabled. If the `HttpAdapterProxyOptions.CompatibilityVersion` property is set to `Version_3_0` or higher, the proxy will make an HTTP API call to the remote host to confirm if the SignalR API is available before enabling features that require SignalR. For lower compatibility versions, specifying a non-null `HttpAdapterProxyOptions.SignalROptions` value will assume that the SignalR API is available.

--- a/src/DataCore.Adapter.Http.Proxy/README.md
+++ b/src/DataCore.Adapter.Http.Proxy/README.md
@@ -36,18 +36,14 @@ var readRaw = proxy.Features.Get<IReadRawTagValues>();
 
 var now = DateTime.UtcNow;
 
-var rawChannel = readRaw.ReadRawTagValues(null, new ReadRawTagValuesRequest() {
+await foreach (ver item in readRaw.ReadRawTagValues(context, new ReadRawTagValuesRequest() {
     Tags = new[] { "Sensor_001", "Sensor_002" },
     UtcStartTime = now.Subtract(TimeSpan.FromDays(7)),
     UtcEndTime = now,
     SampleCount = 0, // i.e. all raw values inside the time range
     BoundaryType = RawDataBoundaryType.Inside
-}, cancellationToken);
-
-while (await rawChannel.WaitToReadAsync()) {
-    if (rawChannel.TryRead(out var val)) {
-        DoSomethingWithValue(val);
-    }
+}, cancellationToken)) {
+    DoSomethingWithValue(item);
 }
 ```
 

--- a/src/DataCore.Adapter.Http.Proxy/README.md
+++ b/src/DataCore.Adapter.Http.Proxy/README.md
@@ -36,7 +36,7 @@ var readRaw = proxy.Features.Get<IReadRawTagValues>();
 
 var now = DateTime.UtcNow;
 
-await foreach (ver item in readRaw.ReadRawTagValues(context, new ReadRawTagValuesRequest() {
+await foreach (var item in readRaw.ReadRawTagValues(context, new ReadRawTagValuesRequest() {
     Tags = new[] { "Sensor_001", "Sensor_002" },
     UtcStartTime = now.Subtract(TimeSpan.FromDays(7)),
     UtcEndTime = now,

--- a/src/DataCore.Adapter.Http.Proxy/README.md
+++ b/src/DataCore.Adapter.Http.Proxy/README.md
@@ -1,4 +1,4 @@
-﻿# DataCore.Adapter.AspNetCoreHttp.Proxy
+﻿# DataCore.Adapter.Http.Proxy
 
 Proxy adapter that connects to a remote adapter via HTTP.
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.RealTimeData;
+
+namespace DataCore.Adapter.Http.Proxy.RealTimeData {
+
+    /// <summary>
+    /// Implements <see cref="ISnapshotTagValuePush"/>.
+    /// </summary>
+    internal class SnapshotTagValuePushImpl : ProxyAdapterFeature, ISnapshotTagValuePush {
+
+        /// <summary>
+        /// Creates a new <see cref="SnapshotTagValuePushImpl"/> object.
+        /// </summary>
+        /// <param name="proxy">
+        ///   The owning proxy.
+        /// </param>
+        public SnapshotTagValuePushImpl(HttpAdapterProxy proxy) : base(proxy) { }
+
+
+        /// <inheritdoc />
+        public async IAsyncEnumerable<TagValueQueryResult> Subscribe(
+            IAdapterCallContext context, 
+            CreateSnapshotTagValueSubscriptionRequest request, 
+            IAsyncEnumerable<TagValueSubscriptionUpdate> channel,
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            Proxy.ValidateInvocation(context, request);
+
+            var client = GetSignalRClient(context);
+
+            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
+                await client.StreamStartedAsync().ConfigureAwait(false);
+
+                try {
+                    await foreach (var item in client.Client.TagValues.CreateSnapshotTagValueChannelAsync(AdapterId, request, channel, ctSource.Token).ConfigureAwait(false)) {
+                        if (item == null) {
+                            continue;
+                        }
+                        yield return item;
+                    }
+                }
+                finally {
+                    await client.StreamCompletedAsync().ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+}

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
@@ -33,22 +33,43 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
         ) {
             Proxy.ValidateInvocation(context, request, channel);
 
-            var client = GetClient();
-
             using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                const int maxItems = 5000;
-                var items = (await channel.ToEnumerable(maxItems, ctSource.Token).ConfigureAwait(false)).ToArray();
-                if (items.Length >= maxItems) {
-                    Logger.LogInformation("The maximum number of items that can be written to the remote adapter ({MaxItems}) was read from the channel. Any remaining items will be ignored.", maxItems);
+                if (Proxy.CanUseSignalR) {
+                    var client = GetSignalRClient(context);
+                    await client.StreamStartedAsync().ConfigureAwait(false);
+                    try {
+                        await foreach (var item in client.Client.TagValues.WriteHistoricalTagValuesAsync(AdapterId, request, channel, ctSource.Token).ConfigureAwait(false)) {
+                            if (item == null) {
+                                continue;
+                            }
+                            yield return item;
+                        }
+                    }
+                    finally {
+                        await client.StreamCompletedAsync().ConfigureAwait(false);
+                    }
                 }
+                else {
+                    var client = GetClient();
 
-                var req = new WriteTagValuesRequestExtended() {
-                    Values = items,
-                    Properties = request.Properties
-                };
+                    const int maxItems = 5000;
+                    var items = (await channel.ToEnumerable(maxItems, ctSource.Token).ConfigureAwait(false)).ToArray();
+                    if (items.Length >= maxItems) {
+                        Logger.LogInformation("The maximum number of items that can be written to the remote adapter ({MaxItems}) was read from the channel. Any remaining items will be ignored.", maxItems);
+                    }
 
-                await foreach (var item in client.TagValues.WriteHistoricalValuesAsync(AdapterId, req, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
+                    var req = new WriteTagValuesRequestExtended() {
+                        Values = items,
+                        Properties = request.Properties
+                    };
+
+                    await foreach (var item in client.TagValues.WriteHistoricalValuesAsync(AdapterId, req, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
+                        if (item == null) {
+                            continue;
+                        }
+                        yield return item;
+                    }
+
                 }
             }
         }

--- a/src/DataCore.Adapter.Http.Proxy/SignalRClientWrapper.cs
+++ b/src/DataCore.Adapter.Http.Proxy/SignalRClientWrapper.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Timers;
+
+using DataCore.Adapter.AspNetCore.SignalR.Client;
+
+using Timer = System.Timers.Timer;
+
+namespace DataCore.Adapter.Http.Proxy {
+
+    /// <summary>
+    /// Wraps an <see cref="AdapterSignalRClient"/> so that the client can be automatically 
+    /// disposed after a period where there are no active streaming calls.
+    /// </summary>
+    internal class SignalRClientWrapper : IDisposable {
+
+        /// <summary>
+        /// Flags if the object has been disposed
+        /// </summary>
+        private bool _disposed;
+
+        /// <summary>
+        /// The SignalR API client.
+        /// </summary>
+        private readonly AdapterSignalRClient _client;
+
+        /// <summary>
+        /// The identifier for the client wrapper.
+        /// </summary>
+        public string Key { get; }
+
+        /// <summary>
+        /// The SignalR API client.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">
+        ///   Thw wrapper has been disposed.
+        /// </exception>
+        public AdapterSignalRClient Client {
+            get {
+                if (_disposed) {
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
+                return _client;
+            }
+        }
+
+        /// <summary>
+        /// The timer that will fire when the wrapper should check if it should dispose of the client.
+        /// </summary>
+        private readonly Timer _timer;
+
+        /// <summary>
+        /// Lock for performing client dispose checks.
+        /// </summary>
+        private readonly Nito.AsyncEx.AsyncLock _lock = new Nito.AsyncEx.AsyncLock();
+
+        /// <summary>
+        /// The number of streams currently active on the client.
+        /// </summary>
+        private int _activeStreamCount;
+
+        /// <summary>
+        /// Raised when the <see cref="SignalRClientWrapper"/> is disposed.
+        /// </summary>
+        public event Action<SignalRClientWrapper>? Disposed;
+
+
+        /// <summary>
+        /// Creates a new <see cref="SignalRClientWrapper"/> object.
+        /// </summary>
+        /// <param name="key">
+        ///   The key for the client wrapper.
+        /// </param>
+        /// <param name="client">
+        ///   The SignalR API client to wrap.
+        /// </param>
+        /// <param name="timeToLive">
+        ///   The time-to-live for the client when it is idle.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="key"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="client"/> is <see langword="null"/>.
+        /// </exception>
+        public SignalRClientWrapper(string key, AdapterSignalRClient client, TimeSpan timeToLive) {
+            Key = key ?? throw new ArgumentNullException(nameof(key));
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _timer = new Timer() {
+                AutoReset = false,
+                Interval = timeToLive.TotalMilliseconds
+            };
+            _timer.Elapsed += OnTimerElapsed;
+        }
+
+
+        /// <summary>
+        /// Handles <see cref="Timer.Elapsed"/> events.
+        /// </summary>
+        /// <param name="sender">
+        ///   The timer.
+        /// </param>
+        /// <param name="args">
+        ///   The event arguments.
+        /// </param>
+        private void OnTimerElapsed(object sender, ElapsedEventArgs args) {
+            if (_disposed) {
+                return;
+            }
+
+            using (_lock.Lock()) {
+                if (_activeStreamCount < 1) {
+                    Dispose();
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Informs the wrapper that a streaming operation has started.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will increment the number of active streams and stop 
+        ///   the time-to-live timer.
+        /// </returns>
+        internal async ValueTask StreamStartedAsync() {
+            if (_disposed) {
+                return;
+            }
+
+            using (await _lock.LockAsync().ConfigureAwait(false)) {
+                if (_disposed) {
+                    return;
+                }
+                ++_activeStreamCount;
+                if (_timer.Enabled) {
+                    _timer.Enabled = false;
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Informs the wrapper that a streaming operation has ended.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will decrement the number of active streams and 
+        ///   enable the time-to-live timer if no more active streams remain.
+        /// </returns>
+        internal async ValueTask StreamCompletedAsync() {
+            if (_disposed) {
+                return;
+            }
+
+            using (await _lock.LockAsync().ConfigureAwait(false)) {
+                if (_disposed) {
+                    return;
+                }
+                --_activeStreamCount;
+                if (_activeStreamCount < 1) {
+                    _timer.Enabled = true;
+                }
+            }
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+
+            using (_lock.Lock()) {
+                _timer.Dispose();
+                _client.Dispose();
+                _disposed = true;
+            }
+
+            Disposed?.Invoke(this);
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.Http.Proxy/SignalROptions.cs
+++ b/src/DataCore.Adapter.Http.Proxy/SignalROptions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace DataCore.Adapter.Http.Proxy {
+
+    /// <summary>
+    /// SignalR options for an <see cref="HttpAdapterProxy"/>.
+    /// </summary>
+    public class SignalROptions {
+
+        /// <summary>
+        /// A delegate that is used to uniquely identify a SignalR connection for a given 
+        /// <see cref="IAdapterCallContext"/>.
+        /// </summary>
+        public ConnectionIdentityFactory? ConnectionIdentityFactory { get; set; }
+
+        /// <summary>
+        /// A delegate that can be used to create SignalR connections for features that require 
+        /// long-running subscriptions.
+        /// </summary>
+        [Required]
+        public ConnectionFactory ConnectionFactory { get; set; } = default!;
+
+        /// <summary>
+        /// The time-to-live for a SignalR connection when there are no active streams ongoing.
+        /// </summary>
+        public TimeSpan TimeToLive { get; set; } = TimeSpan.FromSeconds(30);
+
+    }
+}

--- a/test/DataCore.Adapter.Tests/AdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterTests.cs
@@ -63,11 +63,11 @@ namespace DataCore.Adapter.Tests {
                 }
 
                 _ = Task.Run(async () => {
-                    await Task.Delay(1000, ct);
+                    await Task.Delay(200, ct);
                     await EmitTestEvent(TestContext, adapter, ct).ConfigureAwait(false);
                 });
 
-                using (var ctSource = new CancellationTokenSource(10000)) {
+                using (var ctSource = new CancellationTokenSource(2000)) {
                     var val = await feature.Subscribe(context, new CreateEventMessageSubscriptionRequest() { SubscriptionType = EventMessageSubscriptionType.Passive }, ctSource.Token).FirstOrDefaultAsync(ctSource.Token);
                     Assert.IsNotNull(val);
                 }

--- a/test/DataCore.Adapter.Tests/AdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterTests.cs
@@ -63,11 +63,11 @@ namespace DataCore.Adapter.Tests {
                 }
 
                 _ = Task.Run(async () => {
-                    await Task.Delay(200, ct);
+                    await Task.Delay(1000, ct);
                     await EmitTestEvent(TestContext, adapter, ct).ConfigureAwait(false);
                 });
 
-                using (var ctSource = new CancellationTokenSource(2000)) {
+                using (var ctSource = new CancellationTokenSource(10000)) {
                     var val = await feature.Subscribe(context, new CreateEventMessageSubscriptionRequest() { SubscriptionType = EventMessageSubscriptionType.Passive }, ctSource.Token).FirstOrDefaultAsync(ctSource.Token);
                     Assert.IsNotNull(val);
                 }

--- a/test/DataCore.Adapter.Tests/HttpProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/HttpProxyTests.cs
@@ -1,6 +1,7 @@
 ﻿#if NETCOREAPP
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Extensions;
@@ -63,6 +64,16 @@ namespace DataCore.Adapter.Tests {
             }
 
             return ActivatorUtilities.CreateInstance<HttpAdapterProxy>(serviceProvider, nameof(HttpProxyTests), options);
+        }
+
+
+        protected override async Task BeforeAdapterTestAsync(HttpAdapterProxy adapter, IAdapterCallContext context, CancellationToken cancellationToken) {
+            await base.BeforeAdapterTestAsync(adapter, context, cancellationToken).ConfigureAwait(false);
+            // If SignalR functionality is available, pre-start the connection for the supplied
+            // call context to help avoid timeout issues in some tests.
+            if (adapter.TryGetSignalRClient(context, out var client)) {
+                await client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            }
         }
 
 

--- a/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
@@ -1,6 +1,8 @@
 ﻿#if NETCOREAPP
 
 using System;
+using System.Threading.Tasks;
+using System.Threading;
 
 using DataCore.Adapter.AspNetCore.SignalR.Proxy;
 
@@ -27,6 +29,13 @@ namespace DataCore.Adapter.Tests {
                     return AddProtocol(builder).Build();
                 }
             });
+        }
+
+
+        protected override async Task BeforeAdapterTestAsync(SignalRAdapterProxy adapter, IAdapterCallContext context, CancellationToken cancellationToken) {
+            await base.BeforeAdapterTestAsync(adapter, context, cancellationToken).ConfigureAwait(false);
+            // Pre-start the connection to help avoid timeout issues in some tests.
+            await adapter.GetClient().GetHubConnection(true, cancellationToken).ConfigureAwait(false);
         }
 
 


### PR DESCRIPTION
This PR allows the HTTP adapter proxy to use SignalR connections for long-running subscription features (snapshot values, event messages, etc).