### PR TITLE
Fix netfx gRPC snapshot tag value subscriptions

### DIFF
--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netfx.cs
@@ -48,7 +48,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
         ) {
             var options = new SnapshotTagValuePushOptions() { 
                 OnTagSubscriptionsAdded = async (instance, tags, _) => await OnTagsAddedAsync((SnapshotTagValuePush) instance, context, client, tags, request, cancellationToken).ConfigureAwait(false),
-                OnTagSubscriptionsRemoved = async (instance, tags, _) => await OnTagsRemovedAsync((SnapshotTagValuePush) instance, tags).ConfigureAwait(false)
+                OnTagSubscriptionsRemoved = async (instance, tags, _) => await OnTagsRemovedAsync((SnapshotTagValuePush) instance, tags).ConfigureAwait(false),
+                IsTopicMatch = (subscribed, actual, ct) => new ValueTask<bool>(subscribed.Id.Equals(actual.Id, StringComparison.OrdinalIgnoreCase) || subscribed.Name.Equals(actual.Name, StringComparison.OrdinalIgnoreCase))
             };
             var result = new SnapshotTagValuePush(options, BackgroundTaskService, Logger);
 


### PR DESCRIPTION
Local subscription manager needs to match subscribers for received tag values by tag ID or tag name rather than just tag ID. This is because we don't know if the local subscriber has given us the ID or name of a remote tag when the call to subscribe to the tag is made.

An alternative approach could be to assign a custom tag resolver method to the local subscription manager, but this would only work when the remote adapter supported `ITagInfo`.