### PR TITLE
Restart proxy health checks on reconnect

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
@@ -1,16 +1,17 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using DataCore.Adapter.AspNetCore.SignalR.Client;
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.Proxy;
 
 using IntelligentPlant.BackgroundTasks;
+
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
 
@@ -110,6 +111,16 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// Additional hub connections created for extension features.
         /// </summary>
         private readonly ConcurrentDictionary<string, Lazy<Task<HubConnection>>> _extensionConnections = new ConcurrentDictionary<string, Lazy<Task<HubConnection>>>();
+
+        /// <summary>
+        /// The last health check result that was received from the remote adapter.
+        /// </summary>
+        private HealthCheckResult? _lastRemoteHealthCheckResult;
+
+        /// <summary>
+        /// Lock for reading/writing <see cref="_lastRemoteHealthCheckResult"/>.
+        /// </summary>
+        private readonly Nito.AsyncEx.AsyncReaderWriterLock _lastRemoteHealthCheckResultLock = new Nito.AsyncEx.AsyncReaderWriterLock();
 
 
         /// <summary>
@@ -214,6 +225,10 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
             };
             connection.Reconnected += id => {
                 OnHealthStatusChanged();
+                if (RemoteDescriptor.HasFeature<IHealthCheck>()) {
+                    // Adapter supports health check subscriptions.
+                    BackgroundTaskService.QueueBackgroundWorkItem(RunRemoteHealthSubscriptionAsync);
+                }
                 return Task.CompletedTask;
             };
             connection.Reconnecting += err => {
@@ -271,7 +286,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
 
             if (RemoteDescriptor.HasFeature<IHealthCheck>()) {
                 // Adapter supports health check subscriptions.
-                BackgroundTaskService.QueueBackgroundWorkItem(RunRemoteHealthSubscription);
+                BackgroundTaskService.QueueBackgroundWorkItem(RunRemoteHealthSubscriptionAsync);
             }
         }
 
@@ -301,9 +316,22 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <returns>
         ///   A <see cref="Task"/> that will monitor for changes in the remote adapter health.
         /// </returns>
-        private async Task RunRemoteHealthSubscription(CancellationToken cancellationToken) {
-            await foreach (var item in _client.Value.Adapters.CreateAdapterHealthChannelAsync(_remoteAdapterId, cancellationToken).ConfigureAwait(false)) {
-                OnHealthStatusChanged();
+        private async Task RunRemoteHealthSubscriptionAsync(CancellationToken cancellationToken) {
+            try {
+                await foreach (var item in _client.Value.Adapters.CreateAdapterHealthChannelAsync(_remoteAdapterId, cancellationToken).ConfigureAwait(false)) {
+                    using (await _lastRemoteHealthCheckResultLock.WriterLockAsync(cancellationToken).ConfigureAwait(false)) {
+                        _lastRemoteHealthCheckResult = CreateRemoteAdapterHealthCheckResult(item);
+                    }
+                    OnHealthStatusChanged();
+                }
+            }
+            catch {
+                if (!cancellationToken.IsCancellationRequested) {
+                    using (await _lastRemoteHealthCheckResultLock.WriterLockAsync(cancellationToken).ConfigureAwait(false)) {
+                        _lastRemoteHealthCheckResult = null;
+                    }
+                    OnHealthStatusChanged();
+                }
             }
         }
 
@@ -334,14 +362,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
                     .CheckAdapterHealthAsync(RemoteDescriptor.Id, cancellationToken)
                     .ConfigureAwait(false);
 
-                return new HealthCheckResult(
-                    Resources.HealthCheck_DisplayName_RemoteAdapter,
-                    result.Status,
-                    result.Description,
-                    result.Error,
-                    result.Data,
-                    result.InnerResults
-                );
+                return CreateRemoteAdapterHealthCheckResult(result);
             }
             catch (Exception e) {
                 return HealthCheckResult.Unhealthy(
@@ -351,6 +372,27 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
             }
         }
 
+
+        /// <summary>
+        /// Converts a <see cref="HealthCheckResult"/> received from a remote adapter into a local 
+        /// <see cref="HealthCheckResult"/> for the proxy.
+        /// </summary>
+        /// <param name="result">
+        ///   The <see cref="HealthCheckResult"/> received from the remote adapter.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="HealthCheckResult"/> for use in the local proxy.
+        /// </returns>
+        private static HealthCheckResult CreateRemoteAdapterHealthCheckResult(HealthCheckResult result) {
+            return new HealthCheckResult(
+                    Resources.HealthCheck_DisplayName_RemoteAdapter,
+                    result.Status,
+                    result.Description,
+                    result.Error,
+                    result.Data,
+                    result.InnerResults
+                );
+        }
 
 
         /// <inheritdoc/>
@@ -366,21 +408,26 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
                
                 switch (state) {
                     case HubConnectionState.Connected:
+                        using (await _lastRemoteHealthCheckResultLock.ReaderLockAsync(cancellationToken).ConfigureAwait(false)) {
+                            if (_lastRemoteHealthCheckResult != null) {
+                                results.Add(HealthCheckResult.Composite(
+                                    Resources.HealthCheck_DisplayName_Connection,
+                                    new[] { _lastRemoteHealthCheckResult.Value },
+                                    string.Format(context?.CultureInfo, Resources.HealthCheck_HubConnectionStatusDescription, state.ToString())
+                                ));
+                                break;
+                            }
+                        }
+
                         results.Add(
                             HealthCheckResult.Composite(
                                 Resources.HealthCheck_DisplayName_Connection,
                                 new[] {
                                     await CheckRemoteHealthAsync(cancellationToken).ConfigureAwait(false)
                                 },
-                                string.Format(context?.CultureInfo, Resources.HealthCheck_HubConnectionStatusDescription, state.ToString())
+                                string.Format(context?.CultureInfo, Resources.HealthCheck_HubConnectionStatusDescriptionNoInnerResults, state.ToString())
                             )
                         );
-                        break;
-                    case HubConnectionState.Disconnected:
-                        results.Add(HealthCheckResult.Unhealthy(
-                            Resources.HealthCheck_DisplayName_Connection,
-                            string.Format(context?.CultureInfo, Resources.HealthCheck_HubConnectionStatusDescriptionNoInnerResults, state.ToString())
-                        ));
                         break;
                     default:
                         results.Add(HealthCheckResult.Degraded(
@@ -388,44 +435,6 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
                             string.Format(context?.CultureInfo, Resources.HealthCheck_HubConnectionStatusDescriptionNoInnerResults, state.ToString())
                         ));
                         break;
-                }
-            }
-
-            foreach (var item in _extensionConnections) {
-                var healthCheckName = string.Format(context?.CultureInfo, Resources.HeathCheck_DisplayName_ExtensionConnection, item.Key);
-                var format = Resources.HealthCheck_ExtensionHubConnectionStatusDescription;
-
-                if (!item.Value.IsValueCreated || !item.Value.Value.IsCompleted) {
-                    var description = string.Format(
-                        context?.CultureInfo, 
-                        format, 
-                        Resources.HealthCheck_UnknownConnectionState
-                    );
-                    results.Add(HealthCheckResult.Degraded(healthCheckName, description));
-                    continue;
-                }
-
-                try {
-                    var hubConnection = await item.Value.Value.WithCancellation(cancellationToken).ConfigureAwait(false);
-
-                    var state = hubConnection.State;
-                    var description = string.Format(context?.CultureInfo, format, state.ToString());
-
-                    switch (state) {
-                        case HubConnectionState.Connected:
-                            results.Add(HealthCheckResult.Healthy(healthCheckName, description));
-                            break;
-                        case HubConnectionState.Disconnected:
-                            results.Add(HealthCheckResult.Unhealthy(healthCheckName, description));
-                            break;
-                        default:
-                            results.Add(HealthCheckResult.Degraded(healthCheckName, description));
-                            break;
-                    }
-                }
-                catch (Exception e) {
-                    var description = string.Format(context?.CultureInfo, format, Resources.HealthCheck_UnknownConnectionState);
-                    results.Add(HealthCheckResult.Unhealthy(healthCheckName, description, e.Message));
                 }
             }
 

--- a/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationBuilderExtensions.cs
+++ b/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationBuilderExtensions.cs
@@ -376,6 +376,53 @@ namespace Microsoft.Extensions.DependencyInjection {
 
 
         /// <summary>
+        /// Registers a singleton App Store Connect adapter using the specified direct constructor 
+        /// arguments in addition to those provided by the <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The adapter implementation type.
+        /// </typeparam>
+        /// <param name="builder">
+        ///   The <see cref="IAdapterConfigurationBuilder"/>.
+        /// </param>
+        /// <param name="additionalConstructorParameters">
+        ///   A callback that will return direct constructor arguments to use in addition to those 
+        ///   supplied by the <see cref="IServiceProvider"/>.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IAdapterConfigurationBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///
+        /// <para>
+        ///   This overload registers the adapter using an implementation factory that calls 
+        ///   <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/>.
+        /// </para>
+        /// 
+        /// <para>
+        ///   To register an adapter using a custom implementation factory, call 
+        ///   <see cref="AddAdapter{T}(IAdapterConfigurationBuilder, Func{IServiceProvider, T})"/>.
+        /// </para>
+        ///
+        /// </remarks>
+        public static IAdapterConfigurationBuilder AddAdapter<T>(
+            this IAdapterConfigurationBuilder builder,
+            Func<IServiceProvider, object[]> additionalConstructorParameters
+        ) where T : class, IAdapter {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Services.AddSingleton<IAdapter, T>(sp => ActivatorUtilities.CreateInstance<T>(sp, additionalConstructorParameters.Invoke(sp)));
+
+            return builder;
+        }
+
+
+        /// <summary>
         /// Registers a singleton App Store Connect adapter using the specified implementation 
         /// factory.
         /// </summary>


### PR DESCRIPTION
This PR adds logic to the SignalR and gRPC proxies so that health check subscriptions on the remote adapter are automatically restarted when a connection to the remote host is dropped and reconnected.