### PR TITLE
CVE-2022-3171 mitigation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageVersion Include="Castle.Core" Version="5.1.0" />
     <PackageVersion Include="CsvHelper" Version="28.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.21.5" />
+    <PackageVersion Include="Google.Protobuf" Version="3.21.9" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.47.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.3" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.47.0" />

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
   "Minor": 5,
-  "Patch": 0,
+  "Patch": 1,
   "PreRelease": ""
 }


### PR DESCRIPTION
Mitigation for Google.Protobuf vulnerability (https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-h4h5-3hr4-j3g2)