### PR TITLE
Plot value selection

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageVersion Include="Castle.Core" Version="5.1.0" />
     <PackageVersion Include="CsvHelper" Version="28.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.21.7" />
+    <PackageVersion Include="Google.Protobuf" Version="3.21.9" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.49.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.3" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.49.0" />

--- a/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
@@ -76,9 +76,12 @@ namespace DataCore.Adapter.AspNetCoreExample {
             // the FeatureAuthorizationHandler class and call AddAdapterFeatureAuthorization
             // above to register your handler.
 
-            services.AddGrpc();
+            services
+                .AddGrpc()
+                .AddDataCoreAdapterGrpc();
 
-            services.AddMvc()
+            services
+                .AddMvc()
                 .AddJsonOptions(options => {
                     options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
                     options.JsonSerializerOptions.WriteIndented = true;

--- a/examples/MinimalApiExample/Program.cs
+++ b/examples/MinimalApiExample/Program.cs
@@ -33,7 +33,8 @@ builder.Services
     .AddDataCoreAdapterSignalR();
 
 builder.Services
-    .AddGrpc();
+    .AddGrpc()
+    .AddDataCoreAdapterGrpc();
 
 builder.Services
     .AddHealthChecks()

--- a/src/DataCore.Adapter.Core/RealTimeData/ProcessedTagValueQueryResult.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/ProcessedTagValueQueryResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Text.Json.Serialization;
 
 using DataCore.Adapter.Tags;
@@ -8,6 +9,7 @@ namespace DataCore.Adapter.RealTimeData {
     /// <summary>
     /// Describes a value returned by a tag value query for processed data.
     /// </summary>
+    [DebuggerDisplay("Tag = {TagName}, Function = {DataFunction}, Value = {Value}")]
     public class ProcessedTagValueQueryResult : TagValueQueryResult {
 
         /// <summary>

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValueQueryResult.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValueQueryResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Text.Json.Serialization;
 
 using DataCore.Adapter.Tags;
@@ -9,6 +10,7 @@ namespace DataCore.Adapter.RealTimeData {
     /// <summary>
     /// Describes a value returned by a tag value query.
     /// </summary>
+    [DebuggerDisplay("Tag = {TagName}, Value = {Value}")]
     public class TagValueQueryResult : TagDataContainer {
 
         /// <summary>

--- a/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
@@ -331,8 +331,8 @@ namespace DataCore.Adapter.RealTimeData {
         internal TagValueBuilder WithBucketProperties(TagValueBucket bucket) {
             if (bucket != null) {
                 return WithProperties(
-                    AdapterProperty.Create(CommonTagPropertyNames.BucketStart, bucket.UtcBucketStart),
-                    AdapterProperty.Create(CommonTagPropertyNames.BucketEnd, bucket.UtcBucketEnd)
+                    AdapterProperty.Create(CommonTagValuePropertyNames.BucketStart, bucket.UtcBucketStart),
+                    AdapterProperty.Create(CommonTagValuePropertyNames.BucketEnd, bucket.UtcBucketEnd)
                 );
             }
 

--- a/src/DataCore.Adapter/RealTimeData/Utilities/AggregationHelper.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/AggregationHelper.cs
@@ -602,7 +602,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                         .WithBucketProperties(bucket)
                         .WithProperties(
                             CreateXPoweredByProperty(),
-                            AdapterProperty.Create(CommonTagPropertyNames.Average, goodQualitySamples.First().GetValueOrDefault(double.NaN))
+                            AdapterProperty.Create(CommonTagValuePropertyNames.Average, goodQualitySamples.First().GetValueOrDefault(double.NaN))
                          )
                         .Build()
                 };
@@ -618,7 +618,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                     .WithBucketProperties(bucket)
                     .WithProperties(
                         CreateXPoweredByProperty(),
-                        AdapterProperty.Create(CommonTagPropertyNames.Average, avg)
+                        AdapterProperty.Create(CommonTagValuePropertyNames.Average, avg)
                     )
                     .Build()
             };
@@ -665,8 +665,8 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                         .WithBucketProperties(bucket)
                         .WithProperties(
                             CreateXPoweredByProperty(),
-                            AdapterProperty.Create(CommonTagPropertyNames.Average, goodQualitySamples.First().GetValueOrDefault(double.NaN)),
-                            AdapterProperty.Create(CommonTagPropertyNames.Variance, 0d)
+                            AdapterProperty.Create(CommonTagValuePropertyNames.Average, goodQualitySamples.First().GetValueOrDefault(double.NaN)),
+                            AdapterProperty.Create(CommonTagValuePropertyNames.Variance, 0d)
                         )
                         .Build()
                 };
@@ -687,11 +687,11 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                     .WithBucketProperties(bucket)
                     .WithProperties(
                         CreateXPoweredByProperty(),
-                        AdapterProperty.Create(CommonTagPropertyNames.Average, avg),
-                        AdapterProperty.Create(CommonTagPropertyNames.Variance, variance),
-                        AdapterProperty.Create(CommonTagPropertyNames.LowerBound, lowerBound),
-                        AdapterProperty.Create(CommonTagPropertyNames.UpperBound, upperBound),
-                        AdapterProperty.Create(CommonTagPropertyNames.Sigma, sigma)
+                        AdapterProperty.Create(CommonTagValuePropertyNames.Average, avg),
+                        AdapterProperty.Create(CommonTagValuePropertyNames.Variance, variance),
+                        AdapterProperty.Create(CommonTagValuePropertyNames.LowerBound, lowerBound),
+                        AdapterProperty.Create(CommonTagValuePropertyNames.UpperBound, upperBound),
+                        AdapterProperty.Create(CommonTagValuePropertyNames.Sigma, sigma)
                     )
                     .Build()
             };
@@ -1257,7 +1257,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         ///   A new <see cref="AdapterProperty"/> object.
         /// </returns>
         internal static AdapterProperty CreateXPoweredByProperty() {
-            return AdapterProperty.Create(CommonTagPropertyNames.XPoweredBy, s_xPoweredByPropertyValue.Value);
+            return AdapterProperty.Create(CommonTagValuePropertyNames.XPoweredBy, s_xPoweredByPropertyValue.Value);
         }
 
 

--- a/src/DataCore.Adapter/RealTimeData/Utilities/CommonTagValuePropertyNames.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/CommonTagValuePropertyNames.cs
@@ -4,7 +4,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
     /// <summary>
     /// Defines common tag property names.
     /// </summary>
-    public static class CommonTagPropertyNames {
+    public static class CommonTagValuePropertyNames {
 
         /// <summary>
         /// Values calculated using <see cref="AggregationHelper"/> will contain a property with 
@@ -21,6 +21,11 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         /// Describes the end time for a tag value bucket used in an aggregation calculation.
         /// </summary>
         public const string BucketEnd = "Bucket-End";
+
+        /// <summary>
+        /// Describes the criteria that were used to select or compute a sample.
+        /// </summary>
+        public const string Criteria = "Criteria";
 
         /// <summary>
         /// Specifies the average value used in variance and standard deviation calculations.

--- a/src/DataCore.Adapter/RealTimeData/Utilities/PlotHelper.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/PlotHelper.cs
@@ -505,7 +505,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         /// <para>
         ///   For numeric tags (i.e. tags where <see cref="VariantExtensions.IsNumericType(VariantType)"/> 
         ///   is <see langword="true"/> for <see cref="TagSummary.DataType"/> on <paramref name="tag"/>),
-        ///   the following values are selected from the bucket (if available):
+        ///   the following values are selected from the bucket:
         /// </para>
         /// 
         /// <list type="bullet">
@@ -518,10 +518,15 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         /// </list>
         /// 
         /// <para>
-        ///   For non-numeric tags, every change in text value or quality in the bucket is returned. 
-        ///   The boundary sample from the previous bucket is used to determine the initial value 
-        ///   and quality state.
+        ///   For non-numeric tags, the following values are selected from the bucket:
         /// </para>
+        /// 
+        /// <list type="bullet">
+        ///   <item>The first sample</item>
+        ///   <item>The last sample</item>
+        ///   <item>Any sample that represents a change in value or quality from the previous sample</item>
+        ///   <item>The sample immediately before any sample that represents a change in value or quality</item>
+        /// </list>
         /// 
         /// </remarks>
         /// <seealso cref="PlotValueSelector"/>

--- a/src/DataCore.Adapter/RealTimeData/Utilities/PlotHelper.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/PlotHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -96,12 +97,80 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         /// </para>
         /// 
         /// </remarks>
-        public static async IAsyncEnumerable<TagValueQueryResult> GetPlotValues(
+        public static IAsyncEnumerable<TagValueQueryResult> GetPlotValues(
             TagSummary tag, 
             DateTime utcStartTime, 
             DateTime utcEndTime, 
             TimeSpan bucketSize, 
             IAsyncEnumerable<TagValueQueryResult> rawData,
+            CancellationToken cancellationToken = default
+        ) {
+            return GetPlotValues(tag, utcStartTime, utcEndTime, bucketSize, rawData, null, cancellationToken);
+        }
+
+
+        /// <summary>
+        /// Creates a visualization-friendly data set for a single tag that is suitable for trending.
+        /// </summary>
+        /// <param name="tag">
+        ///   The tag definition.
+        /// </param>
+        /// <param name="utcStartTime">
+        ///   The UTC start time for the plot data set.
+        /// </param>
+        /// <param name="utcEndTime">
+        ///   The UTC end time for the plot data set.
+        /// </param>
+        /// <param name="bucketSize">
+        ///   The bucket size to use when calculating the plot data set.
+        /// </param>
+        /// <param name="rawData">
+        ///   An <see cref="IAsyncEnumerable{T}"/> that will provide the raw data to use in the calculations.
+        /// </param>
+        /// <param name="valueSelector">
+        ///   A delegate that will select the samples to return from each time bucket. 
+        ///   If <see langword="null"/>, <see cref="DefaultPlotValueSelector"/> will be used.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   An <see cref="IAsyncEnumerable{T}"/> that will emit a set of trend-friendly samples.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="tag"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="utcStartTime"/> is greater than or equal to <paramref name="utcEndTime"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="bucketSize"/> is less than or equal to <see cref="TimeSpan.Zero"/>.
+        /// </exception>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   The plot function works by collecting raw values into buckets. Each bucket covers the 
+        ///   same period of time. The method reads from <paramref name="rawData"/> and adds samples 
+        ///   to the bucket, until it encounters a sample that has a time stamp that is after the 
+        ///   bucket's end time. The function then takes the earliest, latest, minimum and maximum 
+        ///   values in the bucket, as well as the first non-good value in the bucket, and adds them 
+        ///   to the result data set.
+        /// </para>
+        /// 
+        /// <para>
+        ///   It is important then to note that method is not guaranteed to give evenly-spaced time 
+        ///   stamps in the resulting data set, but instead returns a data set that 
+        ///   gives a reasonable approximation of the tag when visualized.
+        /// </para>
+        /// 
+        /// </remarks>
+        public static async IAsyncEnumerable<TagValueQueryResult> GetPlotValues(
+            TagSummary tag,
+            DateTime utcStartTime,
+            DateTime utcEndTime,
+            TimeSpan bucketSize,
+            IAsyncEnumerable<TagValueQueryResult> rawData,
+            PlotValueSelector? valueSelector,
             [EnumeratorCancellation]
             CancellationToken cancellationToken = default
         ) {
@@ -115,7 +184,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
                 throw new ArgumentException(Resources.Error_BucketSizeMustBeGreaterThanZero, nameof(bucketSize));
             }
 
-            await foreach (var item in GetPlotValuesInternal(tag, utcStartTime, utcEndTime, bucketSize, rawData, cancellationToken).ConfigureAwait(false)) {
+            await foreach (var item in GetPlotValuesInternal(tag, utcStartTime, utcEndTime, bucketSize, rawData, valueSelector, cancellationToken).ConfigureAwait(false)) {
                 yield return item;
             }
         }
@@ -304,29 +373,26 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         /// <param name="rawData">
         ///   A channel that will provide the raw data to use in the calculations.
         /// </param>
+        /// <param name="valueSelector">
+        ///   A delegate that will select the samples to return from each time bucket. 
+        ///   If <see langword="null"/>, <see cref="DefaultPlotValueSelector"/> will be used.
+        /// </param>
         /// <param name="cancellationToken">
         ///   The cancellation token for the operation.
         /// </param>
         /// <returns>
         ///   An <see cref="IAsyncEnumerable{T}"/> that will emit the computed values.
         /// </returns>
-        private static async IAsyncEnumerable<TagValueQueryResult> GetPlotValuesInternal(TagSummary tag, DateTime utcStartTime, DateTime utcEndTime, TimeSpan bucketSize, IAsyncEnumerable<TagValueQueryResult> rawData, [EnumeratorCancellation] CancellationToken cancellationToken) {
-            // We will determine the values to return for the plot request by creating aggregation 
-            // buckets that cover a time range that is equal to the bucketSize. For each bucket, we 
-            // will we add up to 5 raw samples into the resulting data set:
-            //
-            // * The earliest value in the bucket.
-            // * The latest value in the bucket.
-            // * The maximum value in the bucket.
-            // * The minimum value in the bucket.
-            // * The first non-good-status value in the bucket.
-            //
-            // If a sample meets more than one of the above conditions, it will only be added to the 
-            // result once.
-
+        private static async IAsyncEnumerable<TagValueQueryResult> GetPlotValuesInternal(
+            TagSummary tag, 
+            DateTime utcStartTime, 
+            DateTime utcEndTime, 
+            TimeSpan bucketSize, 
+            IAsyncEnumerable<TagValueQueryResult> rawData, 
+            PlotValueSelector? valueSelector,
+            [EnumeratorCancellation] CancellationToken cancellationToken
+        ) {
             var bucket = new TagValueBucket(utcStartTime, utcStartTime.Add(bucketSize), utcStartTime, utcEndTime);
-
-            TagValueExtended lastValuePreviousBucket = null!;
 
             await foreach (var val in rawData.WithCancellation(cancellationToken).ConfigureAwait(false)) {
                 if (val == null) {
@@ -343,14 +409,23 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
 
                 if (val.Value.UtcSampleTime >= bucket.UtcBucketEnd) {
                     if (bucket.RawSampleCount > 0) {
-                        foreach (var calculatedValue in CalculateAndEmitBucketSamples(tag, bucket, lastValuePreviousBucket)) {
+                        foreach (var calculatedValue in CalculateAndEmitBucketSamples(tag, bucket, valueSelector)) {
                             yield return calculatedValue;
                         }
-                        lastValuePreviousBucket = bucket.RawSamples.Last();
                     }
 
                     do {
+                        // Start boundary value for the next bucket is the last raw sample in the
+                        // current bucket, or the start boundary value for the current bucket if
+                        // the current bucket is empty.
+                        var startBoundaryValue = bucket.RawSampleCount > 0 
+                            ? bucket.RawSamples.Last() 
+                            : bucket.StartBoundary.ClosestValue;
+
                         bucket = new TagValueBucket(bucket.UtcBucketEnd, bucket.UtcBucketEnd.Add(bucketSize), utcStartTime, utcEndTime);
+                        if (startBoundaryValue != null) {
+                            bucket.UpdateStartBoundaryValue(startBoundaryValue);
+                        }
                     } while (bucket.UtcBucketEnd < val.Value.UtcSampleTime);
                 }
 
@@ -358,7 +433,7 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
             }
 
             if (bucket.RawSampleCount > 0) { 
-                foreach (var calculatedValue in CalculateAndEmitBucketSamples(tag, bucket, lastValuePreviousBucket)) {
+                foreach (var calculatedValue in CalculateAndEmitBucketSamples(tag, bucket, valueSelector)) {
                     yield return calculatedValue;
                 }
             }
@@ -374,8 +449,9 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         /// <param name="bucket">
         ///   The bucket.
         /// </param>
-        /// <param name="lastValuePreviousBucket">
-        ///   The last value that was added to the previous bucket for the same tag.
+        /// <param name="valueSelector">
+        ///   A delegate that will select the samples from the <paramref name="bucket"/> to return. 
+        ///   If <see langword="null"/>, <see cref="DefaultPlotValueSelector"/> will be used.
         /// </param>
         /// <returns>
         ///   An <see cref="IEnumerable{T}"/> that contains the samples.
@@ -383,62 +459,146 @@ namespace DataCore.Adapter.RealTimeData.Utilities {
         /// <remarks>
         ///   Assumes that the <paramref name="bucket"/> contains at least one sample.
         /// </remarks>
-        private static IEnumerable<TagValueQueryResult> CalculateAndEmitBucketSamples(TagSummary tag, TagValueBucket bucket, TagValueExtended lastValuePreviousBucket) {
-            var significantValues = new HashSet<TagValueExtended>();
+        private static IEnumerable<TagValueQueryResult> CalculateAndEmitBucketSamples(
+            TagSummary tag, 
+            TagValueBucket bucket, 
+            PlotValueSelector? valueSelector
+        ) {
+            var significantValues = valueSelector == null
+                ? DefaultPlotValueSelector(tag, bucket)
+                : valueSelector.Invoke(tag, bucket);
+
+            foreach (var value in significantValues) {
+                var builder = new TagValueBuilder(value.Sample)
+                    .WithBucketProperties(bucket);
+
+                if (value.Criteria != null) {
+                    builder.WithProperty(CommonTagValuePropertyNames.Criteria, string.Join(", ", value.Criteria));
+                }
+
+                builder.WithProperties(AggregationHelper.CreateXPoweredByProperty());
+
+                yield return TagValueQueryResult.Create(
+                    tag.Id, 
+                    tag.Name, 
+                    builder.Build()
+                );
+            }
+        }
+
+
+        /// <summary>
+        /// Default delegate for selecting the samples to return from a <see cref="TagValueBucket"/> 
+        /// in a plot query.
+        /// </summary>
+        /// <param name="tag">
+        ///   The tag that the plot values are being selected for.
+        /// </param>
+        /// <param name="bucket">
+        ///   The <see cref="TagValueBucket"/>.
+        /// </param>
+        /// <returns>
+        ///   The selected samples.
+        /// </returns>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   For numeric tags (i.e. tags where <see cref="VariantExtensions.IsNumericType(VariantType)"/> 
+        ///   is <see langword="true"/> for <see cref="TagSummary.DataType"/> on <paramref name="tag"/>),
+        ///   the following values are selected from the bucket (if available):
+        /// </para>
+        /// 
+        /// <list type="bullet">
+        ///   <item>The first sample</item>
+        ///   <item>The last sample</item>
+        ///   <item>The midpoint sample (i.e. the sample with the timestamp closest to the middle of the bucket's time range)</item>
+        ///   <item>The sample with the maximum numeric value and good quality</item>
+        ///   <item>The sample with the minimum numeric value and good quality</item>
+        ///   <item>The first sample with non-good quality</item>
+        /// </list>
+        /// 
+        /// <para>
+        ///   For non-numeric tags, every change in text value or quality in the bucket is returned. 
+        ///   The boundary sample from the previous bucket is used to determine the initial value 
+        ///   and quality state.
+        /// </para>
+        /// 
+        /// </remarks>
+        /// <seealso cref="PlotValueSelector"/>
+        public static IEnumerable<PlotValue> DefaultPlotValueSelector(TagSummary tag, TagValueBucket bucket) {
+            if (bucket == null || bucket.RawSampleCount < 1) {
+                return Array.Empty<PlotValue>();
+            }
 
             if (tag.DataType.IsNumericType()) {
-                var numericValues = bucket.RawSamples.ToDictionary(x => x, x => x.GetValueOrDefault(double.NaN));
+                // The tag is numeric, so we can select a representative number of samples.
 
-                significantValues.Add(bucket.RawSamples.First());
-                significantValues.Add(bucket.RawSamples.Last());
-                significantValues.Add(bucket.RawSamples.Aggregate((a, b) => {
-                    var nValA = numericValues[a];
-                    var nValB = numericValues[b];
-                    return nValA <= nValB
-                        ? a
-                        : b;
-                })); // min
-                significantValues.Add(bucket.RawSamples.Aggregate((a, b) => {
-                    var nValA = numericValues[a];
-                    var nValB = numericValues[b];
-                    return nValA >= nValB
-                        ? a
-                        : b;
-                })); // max
+                var selectedValues = new ConcurrentDictionary<TagValueExtended, List<string>>();
+
+                // First value
+                selectedValues.GetOrAdd(bucket.RawSamples.First(), _ => new List<string>()).Add("first");
+
+                // Last value
+                selectedValues.GetOrAdd(bucket.RawSamples.Last(), _ => new List<string>()).Add("last");
+
+                // For the midpoint value we need to find the sample with the timestamp that is
+                // closest to the midpoint of the bucket.
+                var midpointTime = bucket.UtcBucketStart.AddSeconds((bucket.UtcBucketEnd - bucket.UtcBucketStart).TotalSeconds / 2);
+                var midpointDiffs = bucket.RawSamples.Where(x => x.Status == TagValueStatus.Good).Select(x => new {
+                    Sample = x,
+                    MidpointDiff = Math.Abs((midpointTime - x.UtcSampleTime).TotalSeconds)
+                }).ToArray();
+
+                if (midpointDiffs.Length > 0) {
+                    // Midpoint value
+                    selectedValues.GetOrAdd(midpointDiffs.Aggregate((a, b) => a.MidpointDiff <= b.MidpointDiff ? a : b).Sample, _ => new List<string>()).Add("midpoint");
+                }
+
+                // For maximum/minimum values we need to aggregate based on the numeric values of
+                // the samples. We will do this by converting the numeric value of each sample to
+                // double. If the sample doesn't have a numeric value (e.g. it is text when it is
+                // expected to be int) we will treat it as if it was double.NaN.
+                var numericValues = bucket.RawSamples.Where(x => x.Status == TagValueStatus.Good).Select(x => new {
+                    Sample = x,
+                    NumericValue = x.GetValueOrDefault(double.NaN)
+                }).ToArray();
+
+                if (numericValues.Length > 0) {
+                    // Maximum value
+                    selectedValues.GetOrAdd(numericValues.Aggregate((a, b) => a.NumericValue >= b.NumericValue ? a : b).Sample, _ => new List<string>()).Add("max");
+
+                    // Minimum value
+                    selectedValues.GetOrAdd(numericValues.Aggregate((a, b) => a.NumericValue <= b.NumericValue ? a : b).Sample, _ => new List<string>()).Add("min");
+                }
+
+                // First non-good value.
+                var exceptionValue = bucket.RawSamples.FirstOrDefault(x => x.Status != TagValueStatus.Good);
+                if (exceptionValue != null) {
+                    selectedValues.GetOrAdd(exceptionValue, _ = new List<string>()).Add("non-good");
+                }
+
+                return selectedValues.OrderBy(x => x.Key.UtcSampleTime).Select(x => new PlotValue(x.Key, x.Value));
             }
             else {
                 // The tag is not numeric, so we have to add each text value change or quality status 
                 // change in the bucket.
-                var currentState = lastValuePreviousBucket?.GetValueOrDefault<string>();
-                var currentQuality = lastValuePreviousBucket?.Status;
+                var currentState = bucket.StartBoundary.ClosestValue?.GetValueOrDefault<string>();
+                var currentQuality = bucket.StartBoundary.ClosestValue?.Status;
 
-                foreach (var item in bucket.RawSamples) {
+                var changes = bucket.RawSamples.Aggregate(new List<TagValueExtended>(), (list, item) => {
                     var tVal = item.GetValueOrDefault<string>();
-                    if (currentState != null && 
-                        string.Equals(currentState, tVal, StringComparison.Ordinal) && 
-                        currentQuality == item.Status) {
-                        continue;
+                    if (currentState == null ||
+                        !string.Equals(currentState, tVal, StringComparison.Ordinal) ||
+                        currentQuality != item.Status) {
+                        list.Add(item);
+                        currentState = tVal;
+                        currentQuality = item.Status;
                     }
-                    currentState = tVal;
-                    currentQuality = item.Status;
-                    significantValues.Add(item);
-                }
-            }
+                    
+                    return list;
+                });
 
-            var exceptionValue = bucket.RawSamples.FirstOrDefault(x => x.Status != TagValueStatus.Good);
-            if (exceptionValue != null) {
-                significantValues.Add(exceptionValue);
-            }
-
-            foreach (var value in significantValues.OrderBy(x => x.UtcSampleTime)) {
-                yield return TagValueQueryResult.Create(
-                    tag.Id, 
-                    tag.Name, 
-                    new TagValueBuilder(value)
-                        .WithBucketProperties(bucket)
-                        .WithProperties(AggregationHelper.CreateXPoweredByProperty())
-                        .Build()
-                );
+                return changes.OrderBy(x => x.UtcSampleTime).Select(x => new PlotValue(x, "change"));
             }
         }
 

--- a/src/DataCore.Adapter/RealTimeData/Utilities/PlotValue.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/PlotValue.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace DataCore.Adapter.RealTimeData.Utilities {
+    public readonly struct PlotValue {
+
+        public readonly TagValueExtended Sample { get; }
+
+        public readonly string[]? Criteria { get; }
+
+
+        public PlotValue(TagValueExtended sample, IEnumerable<string>? criteria) {
+            Sample = sample;
+            Criteria = criteria?.ToArray();
+        }
+
+
+        public PlotValue(TagValueExtended sample, params string[] criteria) {
+            Sample = sample;
+            Criteria = criteria;
+        }
+
+    }
+}

--- a/src/DataCore.Adapter/RealTimeData/Utilities/PlotValueSelector.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/PlotValueSelector.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+using DataCore.Adapter.Tags;
+
+namespace DataCore.Adapter.RealTimeData.Utilities {
+
+    /// <summary>
+    /// Selects the significant values to return from a <see cref="TagValueBucket"/> for a plot 
+    /// (best-fit) query being processed by <see cref="PlotHelper"/>.
+    /// </summary>
+    /// <param name="tag">
+    ///   The tag that the plot values are being selected for.
+    /// </param>
+    /// <param name="bucket">
+    ///   The <see cref="TagValueBucket"/> to select the values from.
+    /// </param>
+    /// <returns>
+    ///   A collection of <see cref="PlotValue"/> instances representing the values selected from 
+    ///   the <paramref name="bucket"/>.
+    /// </returns>
+    /// <seealso cref="PlotHelper.DefaultPlotValueSelector"/>
+    public delegate IEnumerable<PlotValue> PlotValueSelector(TagSummary tag, TagValueBucket bucket);
+
+}

--- a/test/DataCore.Adapter.Tests/AggregationTests.cs
+++ b/test/DataCore.Adapter.Tests/AggregationTests.cs
@@ -206,7 +206,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Good, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -276,7 +276,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Good, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -340,7 +340,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Uncertain, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -402,7 +402,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(TagValueStatus.Bad, val.Value.Status);
             Assert.AreEqual(start, val.Value.UtcSampleTime);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -461,7 +461,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Good, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -520,7 +520,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Good, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -629,7 +629,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Good, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -678,7 +678,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Uncertain, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -732,7 +732,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Uncertain, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -781,7 +781,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Uncertain, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -835,7 +835,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Uncertain, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -884,7 +884,7 @@ namespace DataCore.Adapter.Tests {
             Assert.AreEqual(expectedSampleTime, val.Value.UtcSampleTime);
             Assert.AreEqual(TagValueStatus.Uncertain, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -934,7 +934,7 @@ namespace DataCore.Adapter.Tests {
             // Value should have uncertain status because it has been extrapolated.
             Assert.AreEqual(TagValueStatus.Uncertain, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -983,7 +983,7 @@ namespace DataCore.Adapter.Tests {
             // Value should have uncertain status because it has been extrapolated.
             Assert.AreEqual(TagValueStatus.Uncertain, val.Value.Status);
 
-            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagPropertyNames.XPoweredBy)));
+            Assert.IsTrue(val.Value.Properties.Any(p => p.Name.Equals(CommonTagValuePropertyNames.XPoweredBy)));
         }
 
 
@@ -1398,25 +1398,25 @@ namespace DataCore.Adapter.Tests {
                 VariantType.Double
             );
 
-            var end = DateTime.UtcNow;
+            var end = DateTime.Parse("2022-11-02T17:20:00Z", null, System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal);
             var start = end.AddSeconds(-60);
             var interval = TimeSpan.FromSeconds(20);
 
             var rawValues = new[] {
                 // Bucket 1: 0-20s
                 new TagValueBuilder().WithUtcSampleTime(start).WithValue(70).Build(), // earliest
-                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(7)).WithValue(100).Build(), // max
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(7)).WithValue(100).Build(), // max + midpoint
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(14)).WithValue(0).Build(), // min
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(15)).WithValue(100).Build(),
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(19)).WithValue(100).Build(), // latest
                 // Bucket 2: 20-40s
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(21)).WithValue(1.883).Build(), // earliest + min
-                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(27)).WithValue(77.765).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(27)).WithValue(77.765).Build(), // midpoint
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(39)).WithValue(77.766).Build(), // latest + max
                 // Bucket 3: 40-60s
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(41)).WithValue(88).Build(), // earliest
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(47)).WithValue(13).Build(),
-                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(49)).WithValue(35).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(49)).WithValue(35).Build(), // midpoint
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(53)).WithValue(116).Build(), // max
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(55)).WithValue(0.8867).Build(),
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(56)).WithValue(23).Build(),
@@ -1432,7 +1432,7 @@ namespace DataCore.Adapter.Tests {
                 plotValues.Add(val);
             }
 
-            Assert.AreEqual(9, plotValues.Count);
+            Assert.AreEqual(11, plotValues.Count);
         }
 
 
@@ -1453,7 +1453,7 @@ namespace DataCore.Adapter.Tests {
             var rawValues = new[] {
                 // Bucket 1: 0-20s
                 new TagValueBuilder().WithUtcSampleTime(start).WithValue(70).Build(), // earliest
-                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(7)).WithValue(100).Build(), // max
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(7)).WithValue(100).Build(), // max + midpoint
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(14)).WithValue(0).Build(), // min
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(15)).WithValue(100).Build(),
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(19)).WithValue(100).Build(), // latest
@@ -1461,7 +1461,7 @@ namespace DataCore.Adapter.Tests {
                 // Bucket 3: 40-60s
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(41)).WithValue(88).Build(), // earliest
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(47)).WithValue(13).Build(),
-                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(49)).WithValue(35).Build(),
+                new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(49)).WithValue(35).Build(), // midpoint
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(53)).WithValue(116).Build(), // max
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(55)).WithValue(0.8867).Build(),
                 new TagValueBuilder().WithUtcSampleTime(start.AddSeconds(56)).WithValue(23).Build(),
@@ -1477,7 +1477,7 @@ namespace DataCore.Adapter.Tests {
                 plotValues.Add(val);
             }
             
-            Assert.AreEqual(7, plotValues.Count);
+            Assert.AreEqual(8, plotValues.Count);
         }
 
     }


### PR DESCRIPTION
This PR modifies the default value selection behaviour in `PlotHelper` and also adds an overload to `PlotHelper.GetPlotValues` that allows a value selector to be specified.

For numeric tags, the default value selection behaviour for each time bucket is now:

- First value
- Last value
- Midpoint value (i.e. sample with timestamp closest to the middle of the bucket's time window)
- Minimum good-quality value
- Maximum good-quality value
- First non-good quality value

For non-numeric tags, the default value selection behaviour for each time bucket is now:

- First value
- Last value
- Any sample that represents a change in value or quality
- Any sample immediately prior to a change in value or quality