### PR TITLE
Fix CS1591 warnings

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagSearchHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagSearchHub.cs
@@ -139,6 +139,18 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         }
 
 
+        /// <summary>
+        /// Gets the schema for creating or updating tags on the specified adapter.
+        /// </summary>
+        /// <param name="adapterId">
+        ///   The adapter ID.
+        /// </param>
+        /// <param name="request">
+        ///   The request.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="System.Text.Json.JsonElement"/> describing the tag creation JSON schema.
+        /// </returns>
         public async Task<System.Text.Json.JsonElement> GetTagSchema(string adapterId, GetTagSchemaRequest request) {
             var cancellationToken = Context.ConnectionAborted;
 
@@ -152,6 +164,18 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         }
 
 
+        /// <summary>
+        /// Creates a tag on the specified adapter.
+        /// </summary>
+        /// <param name="adapterId">
+        ///   The adapter ID.
+        /// </param>
+        /// <param name="request">
+        ///   The request.
+        /// </param>
+        /// <returns>
+        ///   The created tag.
+        /// </returns>
         public async Task<TagDefinition> CreateTag(string adapterId, CreateTagRequest request) {
             var cancellationToken = Context.ConnectionAborted;
 
@@ -174,6 +198,18 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         }
 
 
+        /// <summary>
+        /// Updates a tag on the specified adapter.
+        /// </summary>
+        /// <param name="adapterId">
+        ///   The adapter ID.
+        /// </param>
+        /// <param name="request">
+        ///   The request.
+        /// </param>
+        /// <returns>
+        ///   The updated tag.
+        /// </returns>
         public async Task<TagDefinition> UpdateTag(string adapterId, UpdateTagRequest request) {
             var cancellationToken = Context.ConnectionAborted;
 
@@ -196,6 +232,18 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         }
 
 
+        /// <summary>
+        /// Deletes a tag on the specified adapter.
+        /// </summary>
+        /// <param name="adapterId">
+        ///   The adapter ID.
+        /// </param>
+        /// <param name="request">
+        ///   The request.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the tag was deleted, or <see langword="false"/> otherwise.
+        /// </returns>
         public async Task<bool> DeleteTag(string adapterId, DeleteTagRequest request) {
             var cancellationToken = Context.ConnectionAborted;
 

--- a/src/DataCore.Adapter.Core/Json/AdapterJsonContext.cs
+++ b/src/DataCore.Adapter.Core/Json/AdapterJsonContext.cs
@@ -94,6 +94,6 @@ namespace DataCore.Adapter.Json {
     [JsonSerializable(typeof(Tags.TagDefinitionFields))]
     [JsonSerializable(typeof(Tags.TagIdentifier))]
     [JsonSerializable(typeof(Tags.TagSummary))]
-    public partial class AdapterJsonContext : JsonSerializerContext { }
+    internal partial class AdapterJsonContext : JsonSerializerContext { }
 
 }

--- a/src/DataCore.Adapter/RealTimeData/Utilities/PlotValue.cs
+++ b/src/DataCore.Adapter/RealTimeData/Utilities/PlotValue.cs
@@ -2,19 +2,47 @@
 using System.Linq;
 
 namespace DataCore.Adapter.RealTimeData.Utilities {
+
+    /// <summary>
+    /// A sample that has been selected from a time bucket in a plot data query.
+    /// </summary>
     public readonly struct PlotValue {
 
+        /// <summary>
+        /// The selected sample.
+        /// </summary>
         public readonly TagValueExtended Sample { get; }
 
+        /// <summary>
+        /// The criteria that were used to select the sample.
+        /// </summary>
         public readonly string[]? Criteria { get; }
 
 
+        /// <summary>
+        /// Creates a new <see cref="PlotValue"/> instance.
+        /// </summary>
+        /// <param name="sample">
+        ///   The selected sample.
+        /// </param>
+        /// <param name="criteria">
+        ///   The criteria that were used to select the sample.
+        /// </param>
         public PlotValue(TagValueExtended sample, IEnumerable<string>? criteria) {
             Sample = sample;
             Criteria = criteria?.ToArray();
         }
 
 
+        /// <summary>
+        /// Creates a new <see cref="PlotValue"/> instance.
+        /// </summary>
+        /// <param name="sample">
+        ///   The selected sample.
+        /// </param>
+        /// <param name="criteria">
+        ///   The criteria that were used to select the sample.
+        /// </param>
         public PlotValue(TagValueExtended sample, params string[] criteria) {
             Sample = sample;
             Criteria = criteria;


### PR DESCRIPTION
This PR fixes CS1591 warnings (missing XML documentation) by addng comments to some undocumented types and also by changing `AdapterJsonContext` from `public` to `internal` so that CS1591 is not raised for generated code as described [here](https://github.com/dotnet/runtime/issues/61379). Since the `AdapterJsonContext` is already added to a `JsonSerializerOptions` instance via an extension method, this change will not be problematic.