### PR TITLE
Add locking when modifying SignalR connection state

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/AdaptersClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/AdaptersClient.cs
@@ -54,7 +54,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
         ) {
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<AdapterDescriptor>(
                 "FindAdapters", 
                 request,
@@ -85,7 +85,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(adapterId));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<AdapterDescriptorExtended>(
                 "GetAdapter", 
                 adapterId, 
@@ -114,7 +114,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(adapterId));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<HealthCheckResult>(
                 "CheckAdapterHealth",
                 adapterId,
@@ -145,7 +145,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(adapterId));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<HealthCheckResult>(
                 "CreateAdapterHealthChannel",
                 adapterId,

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/AssetModelBrowserClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/AssetModelBrowserClient.cs
@@ -72,7 +72,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<AssetModelNode>(
                 "BrowseAssetModelNodes",
                 adapterId,
@@ -120,7 +120,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<AssetModelNode>(
                 "GetAssetModelNodes",
                 adapterId,
@@ -168,7 +168,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<AssetModelNode>(
                 "FindAssetModelNodes",
                 adapterId,

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/ConfigurationChangesClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/ConfigurationChangesClient.cs
@@ -68,7 +68,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<ConfigurationChange>(
                 "CreateConfigurationChangesChannel",
                 adapterId,

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/CustomFunctionsClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/CustomFunctionsClient.cs
@@ -69,7 +69,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<IEnumerable<CustomFunctionDescriptor>>(
                 "GetCustomFunctions",
                 adapterId,
@@ -114,7 +114,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<CustomFunctionDescriptorExtended>(
                 "GetCustomFunction",
                 adapterId,
@@ -158,7 +158,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<CustomFunctionInvocationResponse>(
                 "InvokeCustomFunction",
                 adapterId,

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/EventsClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/EventsClient.cs
@@ -69,7 +69,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(adapterId));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<EventMessage>(
                 "CreateEventMessageChannel",
                 adapterId,
@@ -116,7 +116,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentNullException(nameof(channel));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
 
 #pragma warning disable CS0618 // Type or member is obsolete
             if (_client.CompatibilityLevel != CompatibilityLevel.AspNetCore2) {
@@ -289,7 +289,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<EventMessage>(
                 "ReadEventMessagesForTimeRange",
                 adapterId,
@@ -337,7 +337,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<EventMessageWithCursorPosition>(
                 "ReadEventMessagesUsingCursor",
                 adapterId,
@@ -391,7 +391,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentNullException(nameof(channel));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
 #pragma warning disable CS0618 // Type or member is obsolete
             if (_client.CompatibilityLevel != CompatibilityLevel.AspNetCore2) {
                 // We are using ASP.NET Core 3.0+ so we can use bidirectional streaming.

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/ExtensionFeaturesClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/ExtensionFeaturesClient.cs
@@ -71,7 +71,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentNullException(nameof(featureUri));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<FeatureDescriptor>(
                 "GetDescriptor",
                 adapterId,
@@ -114,7 +114,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentNullException(nameof(featureUri));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<IEnumerable<ExtensionFeatureOperationDescriptor>>(
                 "GetExtensionOperations",
                 adapterId,
@@ -158,7 +158,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<InvocationResponse>(
                 "InvokeExtension",
                 adapterId,
@@ -203,7 +203,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<InvocationResponse>(
                 "InvokeStreamingExtension",
                 adapterId,
@@ -260,7 +260,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentNullException(nameof(channel));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             if (_client.CompatibilityLevel != CompatibilityLevel.AspNetCore2) {
                 // We are using ASP.NET Core 3.0+ so we can use bidirectional streaming.
                 await foreach (var item in connection.StreamAsync<InvocationResponse>(

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/HostInfoClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/HostInfoClient.cs
@@ -41,7 +41,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
         ///   A task that will return information about the remote host.
         /// </returns>
         public async Task<HostInfo> GetHostInfoAsync(CancellationToken cancellationToken = default) {
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<HostInfo>(
                 "GetHostInfo",
                 cancellationToken

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagSearchClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagSearchClient.cs
@@ -73,7 +73,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<TagDefinition>(
                 "FindTags",
                 adapterId,
@@ -121,7 +121,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach(var item in connection.StreamAsync<TagDefinition>(
                 "GetTags",
                 adapterId,
@@ -169,7 +169,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<AdapterProperty>(
                 "GetTagProperties",
                 adapterId,

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagValueAnnotationsClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagValueAnnotationsClient.cs
@@ -64,7 +64,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<TagValueAnnotationExtended>(
                 "ReadAnnotation",
                 adapterId,
@@ -109,7 +109,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<TagValueAnnotationQueryResult>(
                 "ReadAnnotations",
                 adapterId,
@@ -151,7 +151,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<WriteTagValueAnnotationResult>(
                 "CreateAnnotation",
                 adapterId,
@@ -191,7 +191,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<WriteTagValueAnnotationResult>(
                 "UpdateAnnotation",
                 adapterId,
@@ -231,7 +231,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             return await connection.InvokeAsync<WriteTagValueAnnotationResult>(
                 "DeleteAnnotation",
                 adapterId,

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagValuesClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagValuesClient.cs
@@ -73,7 +73,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentNullException(nameof(channel));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
 
 #pragma warning disable CS0618 // Type or member is obsolete
             if (_client.CompatibilityLevel != CompatibilityLevel.AspNetCore2) {
@@ -244,7 +244,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<TagValueQueryResult>(
                 "ReadSnapshotTagValues",
                 adapterId,
@@ -291,7 +291,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<TagValueQueryResult>(
                 "ReadRawTagValues",
                 adapterId,
@@ -338,7 +338,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<TagValueQueryResult>(
                 "ReadPlotTagValues",
                 adapterId,
@@ -385,7 +385,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<TagValueQueryResult>(
                 "ReadTagValuesAtTimes",
                 adapterId,
@@ -427,7 +427,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<DataFunctionDescriptor>(
                 "GetSupportedDataFunctionsWithRequest",
                 adapterId,
@@ -465,7 +465,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(adapterId));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<DataFunctionDescriptor>(
                 "GetSupportedDataFunctions",
                 adapterId,
@@ -511,7 +511,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
             }
             AdapterSignalRClient.ValidateObject(request);
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
             await foreach (var item in connection.StreamAsync<ProcessedTagValueQueryResult>(
                 "ReadProcessedTagValues",
                 adapterId,
@@ -568,7 +568,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentNullException(nameof(channel));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
 #pragma warning disable CS0618 // Type or member is obsolete
             if (_client.CompatibilityLevel != CompatibilityLevel.AspNetCore2) {
                 // We are using ASP.NET Core 3.0+ so we can use bidirectional streaming.
@@ -673,7 +673,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 throw new ArgumentNullException(nameof(channel));
             }
 
-            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            var connection = await _client.GetHubConnectionAsync(cancellationToken).ConfigureAwait(false);
 #pragma warning disable CS0618 // Type or member is obsolete
             if (_client.CompatibilityLevel != CompatibilityLevel.AspNetCore2) {
                 // We are using ASP.NET Core 3.0+ so we can use bidirectional streaming.

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/DataCore.Adapter.AspNetCore.SignalR.Client.csproj
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/DataCore.Adapter.AspNetCore.SignalR.Client.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.1' ">

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/SignalRAdapterProxy.cs
@@ -300,8 +300,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
         /// <inheritdoc/>
         protected override async Task StopAsync(CancellationToken cancellationToken) {
             if (_client.IsValueCreated) {
-                var connection = await _client.Value.GetHubConnection(false, cancellationToken).ConfigureAwait(false);
-                await connection.StopAsync(cancellationToken).ConfigureAwait(false);
+                await _client.Value.StopAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -403,8 +402,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy {
             }
 
             if (_client.IsValueCreated) {
-                var hubConnection = await _client.Value.GetHubConnection(false, cancellationToken).ConfigureAwait(false);
-                var state = hubConnection.State;
+                var state = _client.Value.ConnectionState;
                
                 switch (state) {
                     case HubConnectionState.Connected:

--- a/test/DataCore.Adapter.Tests/HttpProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/HttpProxyTests.cs
@@ -64,16 +64,6 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected override async Task BeforeAdapterTestAsync(HttpAdapterProxy adapter, IAdapterCallContext context, CancellationToken cancellationToken) {
-            await base.BeforeAdapterTestAsync(adapter, context, cancellationToken).ConfigureAwait(false);
-            // If SignalR functionality is available, pre-start the connection for the supplied
-            // call context to help avoid timeout issues in some tests.
-            if (adapter.TryGetSignalRClient(context, out var client)) {
-                await client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-
         [TestMethod]
         public Task HttpProxyShouldNotEnableSnapshotPushWhenRepollingIntervalIsZero() {
             return RunAdapterTest((adapter, ctx, ct) => {

--- a/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
+++ b/test/DataCore.Adapter.Tests/SignalRProxyTests.cs
@@ -33,13 +33,6 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected override async Task BeforeAdapterTestAsync(SignalRAdapterProxy adapter, IAdapterCallContext context, CancellationToken cancellationToken) {
-            await base.BeforeAdapterTestAsync(adapter, context, cancellationToken).ConfigureAwait(false);
-            // Pre-start the connection to help avoid timeout issues in some tests.
-            await adapter.GetClient().GetHubConnection(true, cancellationToken).ConfigureAwait(false);
-        }
-
-
         protected abstract IHubConnectionBuilder AddProtocol(IHubConnectionBuilder builder);
 
     }


### PR DESCRIPTION
Calls that start or stop the SignalR connection now use a lock to ensure that only one such call can be ongoing.

`AdapterSignalRClient.GetHubConnection` has been made internal. A public `ConnectionState` property and a `StopAsync` method have been added to allow the SignalR proxy adapter to have access to the same functionality as before.