### PR TITLE
Enable named floating point literals

### DIFF
--- a/src/DataCore.Adapter.Core/Common/Variant.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.cs
@@ -1151,39 +1151,39 @@ namespace DataCore.Adapter.Common {
                 case VariantType.Boolean:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<bool>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetBoolean();
+                        : valueElement.Deserialize<bool>(options);
                 case VariantType.Byte:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<byte>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetByte();
+                        : valueElement.Deserialize<byte>(options);
                 case VariantType.DateTime:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<DateTime>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetDateTime();
+                        : valueElement.Deserialize<DateTime>(options);
                 case VariantType.ExtensionObject:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<EncodedObject>(valueElement, arrayDimensions!, options))
-                        : JsonSerializer.Deserialize<EncodedObject>(valueElement.GetRawText(), options)!;
+                        : valueElement.Deserialize<EncodedObject>(options)!;
                 case VariantType.Double:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<double>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetDouble();
+                        : valueElement.Deserialize<double>(options);
                 case VariantType.Float:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<float>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetSingle();
+                        : valueElement.Deserialize<float>(options);
                 case VariantType.Int16:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<short>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetInt16();
+                        : valueElement.Deserialize<short>(options);
                 case VariantType.Int32:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<int>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetInt32();
+                        : valueElement.Deserialize<int>(options);
                 case VariantType.Int64:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<long>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetInt64();
+                        : valueElement.Deserialize<long>(options);
                 case VariantType.Json:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<JsonElement>(valueElement, arrayDimensions!, options))
@@ -1191,11 +1191,11 @@ namespace DataCore.Adapter.Common {
                 case VariantType.SByte:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<sbyte>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetSByte();
+                        : valueElement.Deserialize<sbyte>(options);
                 case VariantType.String:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<string>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetString();
+                        : valueElement.Deserialize<string>(options);
                 case VariantType.TimeSpan:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<TimeSpan>(valueElement, arrayDimensions!, options))
@@ -1205,15 +1205,15 @@ namespace DataCore.Adapter.Common {
                 case VariantType.UInt16:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<ushort>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetUInt16();
+                        : valueElement.Deserialize<ushort>(options);
                 case VariantType.UInt32:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<uint>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetUInt32();
+                        : valueElement.Deserialize<uint>(options);
                 case VariantType.UInt64:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<ulong>(valueElement, arrayDimensions!, options))
-                        : valueElement.GetUInt64();
+                        : valueElement.Deserialize<ulong>(options);
                 case VariantType.Url:
                     return isArray
                         ? new Variant(JsonExtensions.ReadArray<Uri>(valueElement, arrayDimensions!, options))

--- a/src/DataCore.Adapter.Core/Json/JsonExtensions.cs
+++ b/src/DataCore.Adapter.Core/Json/JsonExtensions.cs
@@ -29,6 +29,8 @@ namespace DataCore.Adapter.Json {
                 throw new ArgumentNullException(nameof(options));
             }
 
+            // We need to be able to read/write "NaN" etc.
+            options.NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals;
             options.AddContext<AdapterJsonContext>();
 
             return options;

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -7,6 +7,7 @@ using DataCore.Adapter.AssetModel;
 using DataCore.Adapter.Common;
 using DataCore.Adapter.Diagnostics;
 using DataCore.Adapter.Events;
+using DataCore.Adapter.Json;
 using DataCore.Adapter.RealTimeData;
 using DataCore.Adapter.Tags;
 
@@ -19,6 +20,7 @@ namespace DataCore.Adapter.Tests {
 
         private static JsonSerializerOptions GetOptions() {
             var result = new JsonSerializerOptions();
+            result.AddDataCoreAdapterContext();
 
             return result;
         }
@@ -110,6 +112,9 @@ namespace DataCore.Adapter.Tests {
         [DataTestMethod]
         [DataRow(double.MinValue)]
         [DataRow(double.MaxValue)]
+        [DataRow(double.NaN)]
+        [DataRow(double.PositiveInfinity)]
+        [DataRow(double.NegativeInfinity)]
         [DataRow(double.MinValue, double.MaxValue)]
         public void Variant_DoubleShouldRoundTrip(params double[] values) {
             var options = GetOptions();
@@ -125,6 +130,9 @@ namespace DataCore.Adapter.Tests {
         [DataTestMethod]
         [DataRow(float.MinValue)]
         [DataRow(float.MaxValue)]
+        [DataRow(float.NaN)]
+        [DataRow(float.PositiveInfinity)]
+        [DataRow(float.NegativeInfinity)]
         [DataRow(float.MinValue, float.MaxValue)]
         public void Variant_FloatShouldRoundTrip(params float[] values) {
             var options = GetOptions();


### PR DESCRIPTION
Closes #266 

Sets `JsonSerializerOptions.NumberHandling` to `JsonNumberHandling.AllowNamedFloatingPointLiterals`.

Deserialize variant values using `JsonElement.Deserialize<T>()` rather than `GetDouble()`, `GetBoolean()` etc.