### PR TITLE
Remove validation of requests from proxy feature implementations

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/AssetModel/AssetModelBrowseImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/AssetModel/AssetModelBrowseImpl.cs
@@ -27,13 +27,9 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.AssetModel.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.AssetModel.BrowseAssetModelNodesAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.AssetModel.BrowseAssetModelNodesAsync(AdapterId, request, cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
@@ -44,13 +40,9 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.AssetModel.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.AssetModel.GetAssetModelNodesAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.AssetModel.GetAssetModelNodesAsync(AdapterId, request, cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/AssetModel/AssetModelSearchImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/AssetModel/AssetModelSearchImpl.cs
@@ -30,13 +30,9 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.AssetModel.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.AssetModel.FindAssetModelNodesAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.AssetModel.FindAssetModelNodesAsync(AdapterId, request, cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Diagnostics/ConfigurationChangesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Diagnostics/ConfigurationChangesImpl.cs
@@ -30,13 +30,9 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.ConfigurationChanges.CreateConfigurationChangesChannelAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.ConfigurationChanges.CreateConfigurationChangesChannelAsync(AdapterId, request, cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
     }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushImpl.cs
@@ -30,16 +30,12 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Events.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in GetClient().Events.CreateEventMessageChannelAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in GetClient().Events.CreateEventMessageChannelAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushWithTopicsImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushWithTopicsImpl.cs
@@ -29,17 +29,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Events {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in GetClient().Events.CreateEventMessageTopicChannelAsync(
-                    AdapterId,
-                    request,
-                    channel,
-                    cancellationToken
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in GetClient().Events.CreateEventMessageTopicChannelAsync(
+                AdapterId,
+                request,
+                channel,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
@@ -29,18 +29,14 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Events.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.Events.ReadEventMessagesAsync(
-                    AdapterId,
-                    request,
-                    cancellationToken
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.Events.ReadEventMessagesAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
     }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
@@ -27,14 +27,10 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Events.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach(var item in client.Events.ReadEventMessagesAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+
+            await foreach (var item in client.Events.ReadEventMessagesAsync(AdapterId, request, cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
 
         }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/WriteEventMessagesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/WriteEventMessagesImpl.cs
@@ -30,19 +30,15 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = GetClient();
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.Events.WriteEventMessagesAsync(
-                    AdapterId,
-                    request,
-                    channel,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.Events.WriteEventMessagesAsync(
+                AdapterId,
+                request,
+                channel,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
     }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
@@ -35,12 +35,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context);
             var client = Proxy.GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.Extensions.GetDescriptorAsync(Proxy.RemoteDescriptor.Id, featureUri!, ctSource.Token).ConfigureAwait(false);
-            }
+            return await client.Extensions.GetDescriptorAsync(Proxy.RemoteDescriptor.Id, featureUri!, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -50,23 +46,15 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context);
             var client = Proxy.GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.Extensions.GetOperationsAsync(Proxy.RemoteDescriptor.Id, featureUri!, ctSource.Token).ConfigureAwait(false);
-            }
+            return await client.Extensions.GetOperationsAsync(Proxy.RemoteDescriptor.Id, featureUri!, cancellationToken).ConfigureAwait(false);
         }
 
 
         /// <inheritdoc/>
         protected override async Task<InvocationResponse> InvokeInternal(IAdapterCallContext context, InvocationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
             var client = Proxy.GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.Extensions.InvokeExtensionAsync(Proxy.RemoteDescriptor.Id, request, ctSource.Token).ConfigureAwait(false);
-            }
+            return await client.Extensions.InvokeExtensionAsync(Proxy.RemoteDescriptor.Id, request, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -77,13 +65,9 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
             var client = Proxy.GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.Extensions.InvokeStreamingExtensionAsync(Proxy.RemoteDescriptor.Id, request, ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.Extensions.InvokeStreamingExtensionAsync(Proxy.RemoteDescriptor.Id, request, cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
@@ -96,13 +80,9 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
             var client = Proxy.GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.Extensions.InvokeDuplexStreamingExtensionAsync(Proxy.RemoteDescriptor.Id, request, channel, ctSource.Token)) {
-                    yield return item;
-                }
+            await foreach (var item in client.Extensions.InvokeDuplexStreamingExtensionAsync(Proxy.RemoteDescriptor.Id, request, channel, cancellationToken)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Extensions/CustomFunctionsImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Extensions/CustomFunctionsImpl.cs
@@ -26,16 +26,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
             GetCustomFunctionsRequest request, 
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.CustomFunctions.GetFunctionsAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.CustomFunctions.GetFunctionsAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -45,16 +37,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
             GetCustomFunctionRequest request, 
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.CustomFunctions.GetFunctionAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.CustomFunctions.GetFunctionAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -64,16 +48,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Extensions {
             CustomFunctionInvocationRequest request, 
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.CustomFunctions.InvokeFunctionAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.CustomFunctions.InvokeFunctionAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
     }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -29,17 +29,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadPlotTagValuesAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadPlotTagValuesAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -28,18 +28,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.GetSupportedDataFunctionsAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.GetSupportedDataFunctionsAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
@@ -50,18 +45,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadProcessedTagValuesAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadProcessedTagValuesAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
         

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -28,18 +28,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadRawTagValuesAsync(
-                    AdapterId,
-                    request,
-                    cancellationToken
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadRawTagValuesAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -29,18 +29,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadSnapshotTagValuesAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadSnapshotTagValuesAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
     }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
@@ -25,34 +25,24 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValueAnnotations.ReadAnnotationsAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValueAnnotations.ReadAnnotationsAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
         /// <inheritdoc/>
         public async Task<TagValueAnnotationExtended?> ReadAnnotation(IAdapterCallContext context, ReadAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.TagValueAnnotations.ReadAnnotationAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.TagValueAnnotations.ReadAnnotationAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false);
         }
     }
 }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -27,18 +27,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadTagValuesAtTimesAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadTagValuesAtTimesAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
@@ -37,19 +37,14 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.CreateSnapshotTagValueChannelAsync(
-                    AdapterId,
-                    request,
-                    channel,
-                    cancellationToken
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.CreateSnapshotTagValueChannelAsync(
+                AdapterId,
+                request,
+                channel,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
         

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
@@ -28,19 +28,14 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.WriteHistoricalTagValuesAsync(
-                    AdapterId,
-                    request,
-                    channel,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.WriteHistoricalTagValuesAsync(
+                AdapterId,
+                request,
+                channel,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
     }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
@@ -28,19 +28,14 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.WriteSnapshotTagValuesAsync(
-                    AdapterId,
-                    request,
-                    channel,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.WriteSnapshotTagValuesAsync(
+                AdapterId,
+                request,
+                channel,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
     }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
@@ -20,35 +20,20 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> CreateAnnotation(IAdapterCallContext context, CreateAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.TagValueAnnotations.CreateAnnotationAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false);
-            }
+            return await client.TagValueAnnotations.CreateAnnotationAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> UpdateAnnotation(IAdapterCallContext context, UpdateAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.TagValueAnnotations.UpdateAnnotationAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false);
-            }
+            return await client.TagValueAnnotations.UpdateAnnotationAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> DeleteAnnotation(IAdapterCallContext context, DeleteAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.TagValueAnnotations.DeleteAnnotationAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false);
-            }
+            return await client.TagValueAnnotations.DeleteAnnotationAsync(AdapterId, request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Tags/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Tags/TagSearchImpl.cs
@@ -29,18 +29,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Tags.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagSearch.FindTagsAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagSearch.FindTagsAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
@@ -52,18 +47,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Tags.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagSearch.GetTagsAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagSearch.GetTagsAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
@@ -75,18 +65,13 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Tags.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagSearch.GetTagPropertiesAsync(
-                    AdapterId,
-                    request,
-                    ctSource.Token
-                ).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagSearch.GetTagPropertiesAsync(
+                AdapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelBrowseImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelBrowseImpl.cs
@@ -27,8 +27,6 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-            
             var client = CreateClient<AssetModelBrowserService.AssetModelBrowserServiceClient>();
             var grpcRequest = new BrowseAssetModelNodesRequest() {
                 AdapterId = AdapterId,
@@ -42,15 +40,13 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var grpcResponse = client.BrowseAssetModelNodes(grpcRequest, GetCallOptions(context, ctSource.Token));
+            var grpcResponse = client.BrowseAssetModelNodes(grpcRequest, GetCallOptions(context, cancellationToken));
 
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
-                    if (grpcResponse.ResponseStream.Current == null) {
-                        continue;
-                    }
-                    yield return grpcResponse.ResponseStream.Current.ToAdapterAssetModelNode();
+            while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                if (grpcResponse.ResponseStream.Current == null) {
+                    continue;
                 }
+                yield return grpcResponse.ResponseStream.Current.ToAdapterAssetModelNode();
             }
         }
 
@@ -62,8 +58,6 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<AssetModelBrowserService.AssetModelBrowserServiceClient>();
             var grpcRequest = new GetAssetModelNodesRequest() {
                 AdapterId = AdapterId
@@ -75,15 +69,13 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var grpcResponse = client.GetAssetModelNodes(grpcRequest, GetCallOptions(context, ctSource.Token));
+            var grpcResponse = client.GetAssetModelNodes(grpcRequest, GetCallOptions(context, cancellationToken));
 
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
-                    if (grpcResponse.ResponseStream.Current == null) {
-                        continue;
-                    }
-                    yield return grpcResponse.ResponseStream.Current.ToAdapterAssetModelNode();
+            while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                if (grpcResponse.ResponseStream.Current == null) {
+                    continue;
                 }
+                yield return grpcResponse.ResponseStream.Current.ToAdapterAssetModelNode();
             }
         }
 

--- a/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelSearchImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelSearchImpl.cs
@@ -30,8 +30,6 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<AssetModelBrowserService.AssetModelBrowserServiceClient>();
             var grpcRequest = new FindAssetModelNodesRequest() {
                 AdapterId = AdapterId,
@@ -46,15 +44,13 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var grpcResponse = client.FindAssetModelNodes(grpcRequest, GetCallOptions(context, ctSource.Token));
+            var grpcResponse = client.FindAssetModelNodes(grpcRequest, GetCallOptions(context, cancellationToken));
 
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
-                    if (grpcResponse.ResponseStream.Current == null) {
-                        continue;
-                    }
-                    yield return grpcResponse.ResponseStream.Current.ToAdapterAssetModelNode();
+            while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                if (grpcResponse.ResponseStream.Current == null) {
+                    continue;
                 }
+                yield return grpcResponse.ResponseStream.Current.ToAdapterAssetModelNode();
             }
         }
 

--- a/src/DataCore.Adapter.Grpc.Proxy/Diagnostics/ConfigurationChangesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Diagnostics/ConfigurationChangesImpl.cs
@@ -27,8 +27,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<ConfigurationChangesService.ConfigurationChangesServiceClient>();
 
             var grpcRequest = new CreateConfigurationChangePushChannelRequest() {
@@ -45,13 +43,12 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
             using (var grpcChannel = client.CreateConfigurationChangesPushChannel(
                grpcRequest,
-               GetCallOptions(context, ctSource.Token)
+               GetCallOptions(context, cancellationToken)
             )) {
                 // Read event messages.
-                while (await grpcChannel.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+                while (await grpcChannel.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcChannel.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushImpl.cs
@@ -29,8 +29,6 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<EventsService.EventsServiceClient>();
 
             var grpcRequest = new CreateEventPushChannelRequest() {
@@ -46,13 +44,12 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
             using (var grpcChannel = client.CreateEventPushChannel(
                grpcRequest,
-               GetCallOptions(context, ctSource.Token)
+               GetCallOptions(context, cancellationToken)
             )) {
                 // Read event messages.
-                while (await grpcChannel.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+                while (await grpcChannel.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcChannel.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.netfx.cs
@@ -134,15 +134,12 @@ namespace DataCore.Adapter.Grpc.Proxy.Events {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = CreateClient<EventsService.EventsServiceClient>();
 
-            using var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken);
-            using var handler = CreateInnerHandler(context, client, request, ctSource.Token);
+            using var handler = CreateInnerHandler(context, client, request, cancellationToken);
 
             try {
-                await foreach (var item in handler.Subscribe(context, request, channel, ctSource.Token).ConfigureAwait(false)) {
+                await foreach (var item in handler.Subscribe(context, request, channel, cancellationToken).ConfigureAwait(false)) {
                     yield return item;
                 }
             }

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.netstandard.cs
@@ -23,8 +23,6 @@ namespace DataCore.Adapter.Grpc.Proxy.Events {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = CreateClient<EventsService.EventsServiceClient>();
 
             var createSubscriptionMessage = new CreateEventTopicPushChannelMessage() {
@@ -40,8 +38,7 @@ namespace DataCore.Adapter.Grpc.Proxy.Events {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcStream = client.CreateEventTopicPushChannel(GetCallOptions(context, ctSource.Token))) {
+            using (var grpcStream = client.CreateEventTopicPushChannel(GetCallOptions(context, cancellationToken))) {
 
                 // Create the subscription.
                 await grpcStream.RequestStream.WriteAsync(new CreateEventTopicPushChannelRequest() {
@@ -69,10 +66,10 @@ namespace DataCore.Adapter.Grpc.Proxy.Events {
                             Update = msg
                         }).ConfigureAwait(false);
                     }
-                }, ctSource.Token);
+                }, cancellationToken);
 
                 // Stream the results.
-                while (await grpcStream.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcStream.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
@@ -27,8 +27,6 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<EventsService.EventsServiceClient>();
             var grpcRequest = new GetEventMessagesForTimeRangeRequest() {
                 AdapterId = AdapterId,
@@ -49,9 +47,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.GetEventMessagesForTimeRange(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.GetEventMessagesForTimeRange(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
@@ -27,8 +27,6 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<EventsService.EventsServiceClient>();
             var grpcRequest = new GetEventMessagesUsingCursorPositionRequest() {
                 AdapterId = AdapterId,
@@ -43,9 +41,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.GetEventMessagesUsingCursorPosition(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.GetEventMessagesUsingCursorPosition(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.netstandard.cs
@@ -17,12 +17,9 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = CreateClient<EventsService.EventsServiceClient>();
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcStream = client.WriteEventMessages(GetCallOptions(context, ctSource.Token))) {
+            using (var grpcStream = client.WriteEventMessages(GetCallOptions(context, cancellationToken))) {
 
                 // Create the subscription.
                 var initMessage = new WriteEventMessageInitMessage() {
@@ -51,9 +48,9 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
                     finally {
                         await grpcStream.RequestStream.CompleteAsync().ConfigureAwait(false);
                     }
-                }, ctSource.Token);
+                }, cancellationToken);
 
-                while (await grpcStream.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     yield return grpcStream.ResponseStream.Current.ToAdapterWriteEventMessageResult();
                 }
             }

--- a/src/DataCore.Adapter.Grpc.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
@@ -37,15 +37,12 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context);
-
             var client = Proxy.CreateClient<ExtensionFeaturesService.ExtensionFeaturesServiceClient>();
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
             using (var response = client.GetDescriptorAsync(new GetExtensionDescriptorRequest() {
                 AdapterId = Proxy.RemoteDescriptor.Id,
                 FeatureUri = featureUri?.ToString() ?? string.Empty
-            }, Proxy.GetCallOptions(context, ctSource.Token))) {
+            }, Proxy.GetCallOptions(context, cancellationToken))) {
                 var result = await response.ResponseAsync.ConfigureAwait(false);
                 return result.ToAdapterFeatureDescriptor();
             }
@@ -58,15 +55,12 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context);
-
             var client = Proxy.CreateClient<ExtensionFeaturesService.ExtensionFeaturesServiceClient>();
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
             using (var response = client.GetOperationsAsync(new GetExtensionOperationsRequest() {
                 AdapterId = Proxy.RemoteDescriptor.Id,
                 FeatureUri = featureUri?.ToString() ?? string.Empty
-            }, Proxy.GetCallOptions(context, ctSource.Token))) {
+            }, Proxy.GetCallOptions(context, cancellationToken))) {
                 var result = await response.ResponseAsync.ConfigureAwait(false);
                 return result.Operations.Select(x => x.ToAdapterExtensionOperatorDescriptor()).ToArray();
             }
@@ -75,8 +69,6 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions {
 
         /// <inheritdoc/>
         protected override async Task<Adapter.Extensions.InvocationResponse> InvokeInternal(IAdapterCallContext context, Adapter.Extensions.InvocationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context);
-
             var client = Proxy.CreateClient<ExtensionFeaturesService.ExtensionFeaturesServiceClient>();
             var req = new InvokeExtensionRequest() {
                 AdapterId = Proxy.RemoteDescriptor.Id,
@@ -87,8 +79,7 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions {
                 req.Arguments.Add(item.ToGrpcVariant());
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var response = client.InvokeExtensionAsync(req, Proxy.GetCallOptions(context, ctSource.Token))) {
+            using (var response = client.InvokeExtensionAsync(req, Proxy.GetCallOptions(context, cancellationToken))) {
                 var result = await response.ResponseAsync.ConfigureAwait(false);
                 return new InvocationResponse() {
                     Results = result.Results.Select(x => x.ToAdapterVariant()).ToArray()

--- a/src/DataCore.Adapter.Grpc.Proxy/Extensions/CustomFunctionsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Extensions/CustomFunctionsImpl.cs
@@ -24,14 +24,12 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions.Features {
 
         /// <inheritdoc/>
         public async Task<IEnumerable<Adapter.Extensions.CustomFunctionDescriptor>> GetFunctionsAsync(
-            IAdapterCallContext context, 
+            IAdapterCallContext context,
             Adapter.Extensions.GetCustomFunctionsRequest request,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<CustomFunctionsService.CustomFunctionsServiceClient>();
-            var grpcRequest = new GetCustomFunctionsRequest() { 
+            var grpcRequest = new GetCustomFunctionsRequest() {
                 AdapterId = AdapterId,
                 PageSize = request.PageSize,
                 Page = request.Page,
@@ -46,24 +44,21 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var grpcResponse = await client.GetCustomFunctionsAsync(grpcRequest, GetCallOptions(context, ctSource.Token)).ConfigureAwait(false);
-                if (grpcResponse == null) {
-                    return Array.Empty<Adapter.Extensions.CustomFunctionDescriptor>();
-                }
-
-                return grpcResponse.Functions.Select(x => x.ToAdapterCustomFunctionDescriptor()).ToArray();
+            var grpcResponse = await client.GetCustomFunctionsAsync(grpcRequest, GetCallOptions(context, cancellationToken)).ConfigureAwait(false);
+            if (grpcResponse == null) {
+                return Array.Empty<Adapter.Extensions.CustomFunctionDescriptor>();
             }
+
+            return grpcResponse.Functions.Select(x => x.ToAdapterCustomFunctionDescriptor()).ToArray();
         }
 
 
         /// <inheritdoc/>
         public async Task<Adapter.Extensions.CustomFunctionDescriptorExtended?> GetFunctionAsync(
-            IAdapterCallContext context, 
-            Adapter.Extensions.GetCustomFunctionRequest request, 
+            IAdapterCallContext context,
+            Adapter.Extensions.GetCustomFunctionRequest request,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
             var client = CreateClient<CustomFunctionsService.CustomFunctionsServiceClient>();
             var grpcRequest = new GetCustomFunctionRequest() {
                 AdapterId = AdapterId,
@@ -76,21 +71,17 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var grpcResponse = await client.GetCustomFunctionAsync(grpcRequest, GetCallOptions(context, ctSource.Token)).ConfigureAwait(false);
-                if (string.IsNullOrWhiteSpace(grpcResponse?.Function?.Function?.Id)) {
-                    return null;
-                }
-
-                return grpcResponse!.Function.ToAdapterCustomFunctionDescriptorExtended();
+            var grpcResponse = await client.GetCustomFunctionAsync(grpcRequest, GetCallOptions(context, cancellationToken)).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(grpcResponse?.Function?.Function?.Id)) {
+                return null;
             }
+
+            return grpcResponse!.Function.ToAdapterCustomFunctionDescriptorExtended();
         }
 
 
         /// <inheritdoc/>
         public async Task<CustomFunctionInvocationResponse> InvokeFunctionAsync(IAdapterCallContext context, CustomFunctionInvocationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<CustomFunctionsService.CustomFunctionsServiceClient>();
             var grpcRequest = new InvokeCustomFunctionRequest() {
                 AdapterId = AdapterId,
@@ -104,12 +95,10 @@ namespace DataCore.Adapter.Grpc.Proxy.Extensions.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var grpcResponse = await client.InvokeCustomFunctionAsync(grpcRequest, GetCallOptions(context, ctSource.Token)).ConfigureAwait(false);
-                return new CustomFunctionInvocationResponse() {
-                    Body = grpcResponse.Body.ToJsonElement()
-                };
-            }
+            var grpcResponse = await client.InvokeCustomFunctionAsync(grpcRequest, GetCallOptions(context, cancellationToken)).ConfigureAwait(false);
+            return new CustomFunctionInvocationResponse() {
+                Body = grpcResponse.Body.ToJsonElement()
+            };
         }
 
     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -27,8 +27,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadPlotTagValuesRequest() {
                 AdapterId = AdapterId,
@@ -43,9 +41,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.ReadPlotTagValues(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.ReadPlotTagValues(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -28,8 +28,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new GetSupportedDataFunctionsRequest() {
                 AdapterId = AdapterId
@@ -39,9 +37,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 grpcRequest.Properties.Add(request.Properties);
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.GetSupportedDataFunctions(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.GetSupportedDataFunctions(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }
@@ -58,8 +55,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadProcessedTagValuesRequest() {
                 AdapterId = AdapterId,
@@ -75,9 +70,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.ReadProcessedTagValues(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.ReadProcessedTagValues(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -27,8 +27,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadRawTagValuesRequest() {
                 AdapterId = AdapterId,
@@ -44,9 +42,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.ReadRawTagValues(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.ReadRawTagValues(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -30,8 +30,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadSnapshotTagValuesRequest() {
                 AdapterId = AdapterId
@@ -43,9 +41,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.ReadSnapshotTagValues(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.ReadSnapshotTagValues(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
@@ -28,8 +28,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new ReadAnnotationsRequest() {
                 AdapterId = AdapterId,
@@ -44,9 +42,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.ReadAnnotations(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.ReadAnnotations(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }
@@ -58,8 +55,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc/>
         public async Task<TagValueAnnotationExtended?> ReadAnnotation(IAdapterCallContext context, Adapter.RealTimeData.ReadAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new ReadAnnotationRequest() {
                 AdapterId = AdapterId,
@@ -67,8 +62,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 AnnotationId = request.AnnotationId
             };
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.ReadAnnotationAsync(grpcRequest, GetCallOptions(context, ctSource.Token))) {
+            using (var grpcResponse = client.ReadAnnotationAsync(grpcRequest, GetCallOptions(context, cancellationToken))) {
                 var result = await grpcResponse.ResponseAsync.ConfigureAwait(false);
 
                 return result.ToAdapterTagValueAnnotation();

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -28,8 +28,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadTagValuesAtTimesRequest() {
                 AdapterId = AdapterId
@@ -42,9 +40,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.ReadTagValuesAtTimes(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.ReadTagValuesAtTimes(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netfx.cs
@@ -136,15 +136,12 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             
-            using var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken);
-            using var handler = CreateInnerHandler(context, client, request, ctSource.Token);
+            using var handler = CreateInnerHandler(context, client, request, cancellationToken);
 
             try {
-                await foreach (var item in handler.Subscribe(context, request, channel, ctSource.Token).ConfigureAwait(false)) {
+                await foreach (var item in handler.Subscribe(context, request, channel, cancellationToken).ConfigureAwait(false)) {
                     yield return item;
                 }
             }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netstandard.cs
@@ -23,8 +23,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
 
             var createSubscriptionMessage = new CreateSnapshotPushChannelMessage() {
@@ -42,8 +40,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcStream = client.CreateSnapshotPushChannel(GetCallOptions(context, ctSource.Token))) {
+            using (var grpcStream = client.CreateSnapshotPushChannel(GetCallOptions(context, cancellationToken))) {
 
                 // Create the subscription.
                 await grpcStream.RequestStream.WriteAsync(new CreateSnapshotPushChannelRequest() {
@@ -71,10 +68,10 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                             Update = msg
                         }).ConfigureAwait(false);
                     }
-                }, ctSource.Token);
+                }, cancellationToken);
 
                 // Stream the results.
-                while (await grpcStream.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcStream.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.netfx.cs
@@ -17,30 +17,26 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var callOptions = GetCallOptions(context, ctSource.Token);
+            var callOptions = GetCallOptions(context, cancellationToken);
 
-                await foreach (var item in channel.ConfigureAwait(false)) {
-                    var grpcRequest = new WriteTagValuesRequest() {
-                        AdapterId = AdapterId
-                    };
+            await foreach (var item in channel.ConfigureAwait(false)) {
+                var grpcRequest = new WriteTagValuesRequest() {
+                    AdapterId = AdapterId
+                };
 
-                    if (request.Properties != null) {
-                        foreach (var prop in request.Properties) {
-                            grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
-                        }
+                if (request.Properties != null) {
+                    foreach (var prop in request.Properties) {
+                        grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
                     }
+                }
 
-                    grpcRequest.Values.Add(item.ToGrpcWriteTagValueItem());
+                grpcRequest.Values.Add(item.ToGrpcWriteTagValueItem());
 
-                    var grpcResponse = await client.WriteFixedHistoricalTagValuesAsync(grpcRequest, callOptions).ConfigureAwait(false);
-                    foreach (var result in grpcResponse.Results) {
-                        yield return result.ToAdapterWriteTagValueResult();
-                    }
+                var grpcResponse = await client.WriteFixedHistoricalTagValuesAsync(grpcRequest, callOptions).ConfigureAwait(false);
+                foreach (var result in grpcResponse.Results) {
+                    yield return result.ToAdapterWriteTagValueResult();
                 }
             }
         }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.netstandard.cs
@@ -19,12 +19,9 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcStream = client.WriteHistoricalTagValues(GetCallOptions(context, ctSource.Token))) {
+            using (var grpcStream = client.WriteHistoricalTagValues(GetCallOptions(context, cancellationToken))) {
                 // Create the subscription.
                 var initMessage = new WriteTagValueInitMessage() {
                     AdapterId = Proxy.RemoteDescriptor.Id
@@ -52,9 +49,9 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                     finally {
                         await grpcStream.RequestStream.CompleteAsync().ConfigureAwait(false);
                     }
-                }, ctSource.Token);
+                }, cancellationToken);
 
-                while (await grpcStream.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     yield return grpcStream.ResponseStream.Current.ToAdapterWriteTagValueResult();
                 }
             }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.netfx.cs
@@ -17,30 +17,26 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var callOptions = GetCallOptions(context, ctSource.Token);
+            var callOptions = GetCallOptions(context, cancellationToken);
 
-                await foreach (var item in channel.ConfigureAwait(false)) {
-                    var grpcRequest = new WriteTagValuesRequest() { 
-                        AdapterId = AdapterId
-                    };
+            await foreach (var item in channel.ConfigureAwait(false)) {
+                var grpcRequest = new WriteTagValuesRequest() {
+                    AdapterId = AdapterId
+                };
 
-                    if (request.Properties != null) {
-                        foreach (var prop in request.Properties) {
-                            grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
-                        }
+                if (request.Properties != null) {
+                    foreach (var prop in request.Properties) {
+                        grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
                     }
+                }
 
-                    grpcRequest.Values.Add(item.ToGrpcWriteTagValueItem());
+                grpcRequest.Values.Add(item.ToGrpcWriteTagValueItem());
 
-                    var grpcResponse = await client.WriteFixedSnapshotTagValuesAsync(grpcRequest, callOptions).ConfigureAwait(false);
-                    foreach (var result in grpcResponse.Results) {
-                        yield return result.ToAdapterWriteTagValueResult();
-                    }
+                var grpcResponse = await client.WriteFixedSnapshotTagValuesAsync(grpcRequest, callOptions).ConfigureAwait(false);
+                foreach (var result in grpcResponse.Results) {
+                    yield return result.ToAdapterWriteTagValueResult();
                 }
             }
         }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.netstandard.cs
@@ -19,12 +19,9 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcStream = client.WriteSnapshotTagValues(GetCallOptions(context, ctSource.Token))) {
+            using (var grpcStream = client.WriteSnapshotTagValues(GetCallOptions(context, cancellationToken))) {
                 // Create the subscription.
                 var initMessage = new WriteTagValueInitMessage() {
                     AdapterId = Proxy.RemoteDescriptor.Id
@@ -52,9 +49,9 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                     finally {
                         await grpcStream.RequestStream.CompleteAsync().ConfigureAwait(false);
                     }
-                }, ctSource.Token);
+                }, cancellationToken);
 
-                while (await grpcStream.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     yield return grpcStream.ResponseStream.Current.ToAdapterWriteTagValueResult();
                 }
             }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
@@ -21,8 +21,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<Adapter.RealTimeData.WriteTagValueAnnotationResult> CreateAnnotation(IAdapterCallContext context, Adapter.RealTimeData.CreateAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new CreateAnnotationRequest() {
                 AdapterId = AdapterId,
@@ -36,8 +34,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.CreateAnnotationAsync(grpcRequest, GetCallOptions(context, ctSource.Token))) {
+            using (var grpcResponse = client.CreateAnnotationAsync(grpcRequest, GetCallOptions(context, cancellationToken))) {
                 var result = await grpcResponse.ResponseAsync.ConfigureAwait(false);
 
                 return result.ToAdapterWriteTagValueAnnotationResult();
@@ -47,8 +44,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<Adapter.RealTimeData.WriteTagValueAnnotationResult> UpdateAnnotation(IAdapterCallContext context, Adapter.RealTimeData.UpdateAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new UpdateAnnotationRequest() {
                 AdapterId = AdapterId,
@@ -63,8 +58,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.UpdateAnnotationAsync(grpcRequest, GetCallOptions(context, ctSource.Token))) {
+            using (var grpcResponse = client.UpdateAnnotationAsync(grpcRequest, GetCallOptions(context, cancellationToken))) {
                 var result = await grpcResponse.ResponseAsync.ConfigureAwait(false);
 
                 return result.ToAdapterWriteTagValueAnnotationResult();
@@ -74,8 +68,6 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
         /// <inheritdoc />
         public async Task<Adapter.RealTimeData.WriteTagValueAnnotationResult> DeleteAnnotation(IAdapterCallContext context, Adapter.RealTimeData.DeleteAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new DeleteAnnotationRequest() {
                 AdapterId = AdapterId,
@@ -89,8 +81,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.DeleteAnnotationAsync(grpcRequest, GetCallOptions(context, ctSource.Token))) {
+            using (var grpcResponse = client.DeleteAnnotationAsync(grpcRequest, GetCallOptions(context, cancellationToken))) {
                 var result = await grpcResponse.ResponseAsync.ConfigureAwait(false);
 
                 return result.ToAdapterWriteTagValueAnnotationResult();

--- a/src/DataCore.Adapter.Grpc.Proxy/Tags/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Tags/TagSearchImpl.cs
@@ -27,8 +27,6 @@ namespace DataCore.Adapter.Grpc.Proxy.Tags.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagSearchService.TagSearchServiceClient>();
             var grpcRequest = new FindTagsRequest() {
                 AdapterId = AdapterId,
@@ -51,9 +49,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Tags.Features {
                 }
             }
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.FindTags(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.FindTags(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }
@@ -70,17 +67,14 @@ namespace DataCore.Adapter.Grpc.Proxy.Tags.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagSearchService.TagSearchServiceClient>();
             var grpcRequest = new GetTagsRequest() {
                 AdapterId = AdapterId
             };
             grpcRequest.Tags.AddRange(request.Tags);
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.GetTags(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.GetTags(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }
@@ -97,8 +91,6 @@ namespace DataCore.Adapter.Grpc.Proxy.Tags.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = CreateClient<TagSearchService.TagSearchServiceClient>();
             var grpcRequest = new GetTagPropertiesRequest() {
                 AdapterId = AdapterId,
@@ -106,9 +98,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Tags.Features {
                 Page = request.Page
             };
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken))
-            using (var grpcResponse = client.GetTagProperties(grpcRequest, GetCallOptions(context, ctSource.Token))) {
-                while (await grpcResponse.ResponseStream.MoveNext(ctSource.Token).ConfigureAwait(false)) {
+            using (var grpcResponse = client.GetTagProperties(grpcRequest, GetCallOptions(context, cancellationToken))) {
+                while (await grpcResponse.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
                     if (grpcResponse.ResponseStream.Current == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Http.Proxy/AssetModel/AssetModelBrowseImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/AssetModel/AssetModelBrowseImpl.cs
@@ -26,14 +26,9 @@ namespace DataCore.Adapter.Http.Proxy.AssetModel {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.AssetModel.BrowseNodesAsync(AdapterId, request, context.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.AssetModel.BrowseNodesAsync(AdapterId, request, context.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
@@ -44,14 +39,9 @@ namespace DataCore.Adapter.Http.Proxy.AssetModel {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.AssetModel.GetNodesAsync(AdapterId, request, context.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.AssetModel.GetNodesAsync(AdapterId, request, context.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.Http.Proxy/AssetModel/AssetModelSearchImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/AssetModel/AssetModelSearchImpl.cs
@@ -29,14 +29,9 @@ namespace DataCore.Adapter.Http.Proxy.AssetModel {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.AssetModel.FindNodesAsync(AdapterId, request, context.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.AssetModel.FindNodesAsync(AdapterId, request, context.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.Http.Proxy/Diagnostics/ConfigurationChangesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Diagnostics/ConfigurationChangesImpl.cs
@@ -28,24 +28,19 @@ namespace DataCore.Adapter.Http.Proxy.Diagnostics {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetSignalRClient(context);
+            await client.StreamStartedAsync().ConfigureAwait(false);
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await client.StreamStartedAsync().ConfigureAwait(false);
-
-                try {
-                    await foreach (var item in client.Client.ConfigurationChanges.CreateConfigurationChangesChannelAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false)) {
-                        if (item == null) {
-                            continue;
-                        }
-                        yield return item;
+            try {
+                await foreach (var item in client.Client.ConfigurationChanges.CreateConfigurationChangesChannelAsync(AdapterId, request, cancellationToken).ConfigureAwait(false)) {
+                    if (item == null) {
+                        continue;
                     }
+                    yield return item;
                 }
-                finally {
-                    await client.StreamCompletedAsync().ConfigureAwait(false);
-                }
+            }
+            finally {
+                await client.StreamCompletedAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Proxy/Events/EventMessagePushImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/EventMessagePushImpl.cs
@@ -28,24 +28,19 @@ namespace DataCore.Adapter.Http.Proxy.Events {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetSignalRClient(context);
+            await client.StreamStartedAsync().ConfigureAwait(false);
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await client.StreamStartedAsync().ConfigureAwait(false);
-
-                try {
-                    await foreach (var item in client.Client.Events.CreateEventMessageChannelAsync(AdapterId, request, ctSource.Token).ConfigureAwait(false)) {
-                        if (item == null) {
-                            continue;
-                        }
-                        yield return item;
+            try {
+                await foreach (var item in client.Client.Events.CreateEventMessageChannelAsync(AdapterId, request, cancellationToken).ConfigureAwait(false)) {
+                    if (item == null) {
+                        continue;
                     }
+                    yield return item;
                 }
-                finally {
-                    await client.StreamCompletedAsync().ConfigureAwait(false);
-                }
+            }
+            finally {
+                await client.StreamCompletedAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Proxy/Events/EventMessagePushWithTopicsImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/EventMessagePushWithTopicsImpl.cs
@@ -29,24 +29,19 @@ namespace DataCore.Adapter.Http.Proxy.Events {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetSignalRClient(context);
+            await client.StreamStartedAsync().ConfigureAwait(false);
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await client.StreamStartedAsync().ConfigureAwait(false);
-
-                try {
-                    await foreach (var item in client.Client.Events.CreateEventMessageTopicChannelAsync(AdapterId, request, channel, ctSource.Token).ConfigureAwait(false)) {
-                        if (item == null) {
-                            continue;
-                        }
-                        yield return item;
+            try {
+                await foreach (var item in client.Client.Events.CreateEventMessageTopicChannelAsync(AdapterId, request, channel, cancellationToken).ConfigureAwait(false)) {
+                    if (item == null) {
+                        continue;
                     }
+                    yield return item;
                 }
-                finally {
-                    await client.StreamCompletedAsync().ConfigureAwait(false);
-                }
+            }
+            finally {
+                await client.StreamCompletedAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
@@ -27,14 +27,9 @@ namespace DataCore.Adapter.Http.Proxy.Events {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.Events.ReadEventMessagesAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.Events.ReadEventMessagesAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
@@ -26,14 +26,9 @@ namespace DataCore.Adapter.Http.Proxy.Events {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.Events.ReadEventMessagesAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.Events.ReadEventMessagesAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Proxy/Events/WriteEventMessagesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/WriteEventMessagesImpl.cs
@@ -26,48 +26,44 @@ namespace DataCore.Adapter.Http.Proxy.Events {
 
         /// <inheritdoc />
         public async IAsyncEnumerable<WriteEventMessageResult> WriteEventMessages(
-            IAdapterCallContext context, 
+            IAdapterCallContext context,
             WriteEventMessagesRequest request,
-            IAsyncEnumerable<WriteEventMessageItem> channel, 
+            IAsyncEnumerable<WriteEventMessageItem> channel,
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                if (Proxy.CanUseSignalR) {
-                    var client = GetSignalRClient(context);
-                    await client.StreamStartedAsync().ConfigureAwait(false);
-                    try {
-                        await foreach (var item in client.Client.Events.WriteEventMessagesAsync(AdapterId, request, channel, ctSource.Token).ConfigureAwait(false)) {
-                            if (item == null) {
-                                continue;
-                            }
-                            yield return item;
-                        }
-                    }
-                    finally {
-                        await client.StreamCompletedAsync().ConfigureAwait(false);
-                    }
-                }
-                else {
-                    var client = GetClient();
-
-                    var items = (await channel.ToEnumerable(1000, ctSource.Token).ConfigureAwait(false)).ToArray();
-
-                    var req = new WriteEventMessagesRequestExtended() {
-                        Events = items,
-                        Properties = request.Properties
-                    };
-
-                    await foreach (var item in client.Events.WriteEventMessagesAsync(AdapterId, req, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
+            if (Proxy.CanUseSignalR) {
+                var client = GetSignalRClient(context);
+                await client.StreamStartedAsync().ConfigureAwait(false);
+                try {
+                    await foreach (var item in client.Client.Events.WriteEventMessagesAsync(AdapterId, request, channel, cancellationToken).ConfigureAwait(false)) {
                         if (item == null) {
                             continue;
                         }
                         yield return item;
                     }
-
                 }
+                finally {
+                    await client.StreamCompletedAsync().ConfigureAwait(false);
+                }
+            }
+            else {
+                var client = GetClient();
+
+                var items = (await channel.ToEnumerable(1000, cancellationToken).ConfigureAwait(false)).ToArray();
+
+                var req = new WriteEventMessagesRequestExtended() {
+                    Events = items,
+                    Properties = request.Properties
+                };
+
+                await foreach (var item in client.Events.WriteEventMessagesAsync(AdapterId, req, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
+                    if (item == null) {
+                        continue;
+                    }
+                    yield return item;
+                }
+
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Proxy/Events/WriteEventMessagesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Events/WriteEventMessagesImpl.cs
@@ -57,7 +57,7 @@ namespace DataCore.Adapter.Http.Proxy.Events {
                     Properties = request.Properties
                 };
 
-                await foreach (var item in client.Events.WriteEventMessagesAsync(AdapterId, req, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
+                await foreach (var item in client.Events.WriteEventMessagesAsync(AdapterId, req, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
                     if (item == null) {
                         continue;
                     }

--- a/src/DataCore.Adapter.Http.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Extensions/AdapterExtensionFeatureImpl.cs
@@ -32,18 +32,13 @@ namespace DataCore.Adapter.Http.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context);
-
             var client = Proxy.GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) { 
-                return await client.Extensions.GetDescriptorAsync(
-                    Proxy.RemoteDescriptor.Id,
-                    featureUri!,
-                    context?.ToRequestMetadata(),
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.Extensions.GetDescriptorAsync(
+                Proxy.RemoteDescriptor.Id,
+                featureUri!,
+                context?.ToRequestMetadata(),
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
 
@@ -53,35 +48,25 @@ namespace DataCore.Adapter.Http.Proxy.Extensions {
             Uri? featureUri,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context);
-
             var client = Proxy.GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.Extensions.GetOperationsAsync(
-                    Proxy.RemoteDescriptor.Id,
-                    featureUri!,
-                    context?.ToRequestMetadata(),
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.Extensions.GetOperationsAsync(
+                Proxy.RemoteDescriptor.Id,
+                featureUri!,
+                context?.ToRequestMetadata(),
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
 
         /// <inheritdoc/>
         protected override async Task<InvocationResponse> InvokeInternal(IAdapterCallContext context, InvocationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = Proxy.GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.Extensions.InvokeExtensionAsync(
-                    Proxy.RemoteDescriptor.Id,
-                    request,
-                    context?.ToRequestMetadata(),
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.Extensions.InvokeExtensionAsync(
+                Proxy.RemoteDescriptor.Id,
+                request,
+                context?.ToRequestMetadata(),
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
     }

--- a/src/DataCore.Adapter.Http.Proxy/Extensions/CustomFunctionsImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Extensions/CustomFunctionsImpl.cs
@@ -26,17 +26,13 @@ namespace DataCore.Adapter.Http.Proxy.Extensions {
             GetCustomFunctionsRequest request,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.CustomFunctions.GetFunctionsAsync(
-                    AdapterId,
-                    request,
-                    context?.ToRequestMetadata(),
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.CustomFunctions.GetFunctionsAsync(
+                AdapterId,
+                request,
+                context?.ToRequestMetadata(),
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
 
@@ -46,17 +42,13 @@ namespace DataCore.Adapter.Http.Proxy.Extensions {
             GetCustomFunctionRequest request,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.CustomFunctions.GetFunctionAsync(
-                    AdapterId,
-                    request,
-                    context?.ToRequestMetadata(),
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.CustomFunctions.GetFunctionAsync(
+                AdapterId,
+                request,
+                context?.ToRequestMetadata(),
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
 
@@ -66,17 +58,13 @@ namespace DataCore.Adapter.Http.Proxy.Extensions {
             CustomFunctionInvocationRequest request,
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.CustomFunctions.InvokeFunctionAsync(
-                    AdapterId,
-                    request,
-                    context?.ToRequestMetadata(),
-                    ctSource.Token
-                ).ConfigureAwait(false);
-            }
+            return await client.CustomFunctions.InvokeFunctionAsync(
+                AdapterId,
+                request,
+                context?.ToRequestMetadata(),
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
     }

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -29,14 +29,9 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadPlotTagValuesAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadPlotTagValuesAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -30,14 +30,9 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.GetSupportedDataFunctionsAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.GetSupportedDataFunctionsAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
@@ -48,14 +43,9 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadProcessedTagValuesAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadProcessedTagValuesAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -30,14 +30,9 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadRawTagValuesAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadRawTagValuesAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -30,14 +30,9 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadSnapshotTagValuesAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadSnapshotTagValuesAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
@@ -24,26 +24,16 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValueAnnotations.ReadAnnotationsAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValueAnnotations.ReadAnnotationsAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
         /// <inheritdoc/>
         public async Task<TagValueAnnotationExtended?> ReadAnnotation(IAdapterCallContext context, ReadAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.TagValueAnnotations.ReadAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false);
-            }
+            return await client.TagValueAnnotations.ReadAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -30,14 +30,9 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await foreach (var item in client.TagValues.ReadTagValuesAtTimesAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            await foreach (var item in client.TagValues.ReadTagValuesAtTimesAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
@@ -29,24 +29,19 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetSignalRClient(context);
+            await client.StreamStartedAsync().ConfigureAwait(false);
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                await client.StreamStartedAsync().ConfigureAwait(false);
-
-                try {
-                    await foreach (var item in client.Client.TagValues.CreateSnapshotTagValueChannelAsync(AdapterId, request, channel, ctSource.Token).ConfigureAwait(false)) {
-                        if (item == null) {
-                            continue;
-                        }
-                        yield return item;
+            try {
+                await foreach (var item in client.Client.TagValues.CreateSnapshotTagValueChannelAsync(AdapterId, request, channel, cancellationToken).ConfigureAwait(false)) {
+                    if (item == null) {
+                        continue;
                     }
+                    yield return item;
                 }
-                finally {
-                    await client.StreamCompletedAsync().ConfigureAwait(false);
-                }
+            }
+            finally {
+                await client.StreamCompletedAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
@@ -31,46 +31,42 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request, channel);
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                if (Proxy.CanUseSignalR) {
-                    var client = GetSignalRClient(context);
-                    await client.StreamStartedAsync().ConfigureAwait(false);
-                    try { 
-                        await foreach (var item in client.Client.TagValues.WriteSnapshotTagValuesAsync(AdapterId, request, channel, ctSource.Token).ConfigureAwait(false)) {
-                            if (item == null) {
-                                continue;
-                            }
-                            yield return item;
-                        }
-                    }
-                    finally {
-                        await client.StreamCompletedAsync().ConfigureAwait(false);
-                    }
-                }
-                else {
-                    var client = GetClient();
-
-                    const int maxItems = 5000;
-                    var items = (await channel.ToEnumerable(maxItems, ctSource.Token).ConfigureAwait(false)).ToArray();
-                    if (items.Length >= maxItems) {
-                        Logger.LogInformation("The maximum number of items that can be written to the remote adapter ({MaxItems}) was read from the channel. Any remaining items will be ignored.", maxItems);
-                    }
-
-                    var req = new WriteTagValuesRequestExtended() {
-                        Values = items,
-                        Properties = request.Properties
-                    };
-
-                    await foreach (var item in client.TagValues.WriteSnapshotValuesAsync(AdapterId, req, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
+            if (Proxy.CanUseSignalR) {
+                var client = GetSignalRClient(context);
+                await client.StreamStartedAsync().ConfigureAwait(false);
+                try {
+                    await foreach (var item in client.Client.TagValues.WriteSnapshotTagValuesAsync(AdapterId, request, channel, cancellationToken).ConfigureAwait(false)) {
                         if (item == null) {
                             continue;
                         }
                         yield return item;
                     }
-
                 }
+                finally {
+                    await client.StreamCompletedAsync().ConfigureAwait(false);
+                }
+            }
+            else {
+                var client = GetClient();
+
+                const int maxItems = 5000;
+                var items = (await channel.ToEnumerable(maxItems, cancellationToken).ConfigureAwait(false)).ToArray();
+                if (items.Length >= maxItems) {
+                    Logger.LogInformation("The maximum number of items that can be written to the remote adapter ({MaxItems}) was read from the channel. Any remaining items will be ignored.", maxItems);
+                }
+
+                var req = new WriteTagValuesRequestExtended() {
+                    Values = items,
+                    Properties = request.Properties
+                };
+
+                await foreach (var item in client.TagValues.WriteSnapshotValuesAsync(AdapterId, req, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                    if (item == null) {
+                        continue;
+                    }
+                    yield return item;
+                }
+
             }
         }
     }

--- a/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
@@ -19,35 +19,21 @@ namespace DataCore.Adapter.Http.Proxy.RealTimeData {
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> CreateAnnotation(IAdapterCallContext context, CreateAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.TagValueAnnotations.CreateAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false);
-            }
+            return await client.TagValueAnnotations.CreateAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> UpdateAnnotation(IAdapterCallContext context, UpdateAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
+            return await client.TagValueAnnotations.UpdateAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false);
 
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.TagValueAnnotations.UpdateAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false);
-            }
         }
 
         /// <inheritdoc />
         public async Task<WriteTagValueAnnotationResult> DeleteAnnotation(IAdapterCallContext context, DeleteAnnotationRequest request, CancellationToken cancellationToken) {
-            Proxy.ValidateInvocation(context, request);
-
             var client = GetClient();
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                return await client.TagValueAnnotations.DeleteAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false);
-            }
+            return await client.TagValueAnnotations.DeleteAnnotationAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/DataCore.Adapter.Http.Proxy/Tags/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Tags/TagSearchImpl.cs
@@ -28,13 +28,9 @@ namespace DataCore.Adapter.Http.Proxy.Tags {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var client = GetClient();
-                await foreach (var item in client.TagSearch.FindTagsAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            var client = GetClient();
+            await foreach (var item in client.TagSearch.FindTagsAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
@@ -46,13 +42,9 @@ namespace DataCore.Adapter.Http.Proxy.Tags {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            Proxy.ValidateInvocation(context, request);
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var client = GetClient();
-                await foreach (var item in client.TagSearch.GetTagsAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            var client = GetClient();
+            await foreach (var item in client.TagSearch.GetTagsAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 
@@ -65,12 +57,9 @@ namespace DataCore.Adapter.Http.Proxy.Tags {
             CancellationToken cancellationToken
         ) {
             Proxy.ValidateInvocation(context, request);
-
-            using (var ctSource = Proxy.CreateCancellationTokenSource(cancellationToken)) {
-                var client = GetClient();
-                await foreach (var item in client.TagSearch.GetTagPropertiesAsync(AdapterId, request, context?.ToRequestMetadata(), ctSource.Token).ConfigureAwait(false)) {
-                    yield return item;
-                }
+            var client = GetClient();
+            await foreach (var item in client.TagSearch.GetTagPropertiesAsync(AdapterId, request, context?.ToRequestMetadata(), cancellationToken).ConfigureAwait(false)) {
+                yield return item;
             }
         }
 


### PR DESCRIPTION
Implements #255.

`AdapterCore` now validates all calls to adapter features via its wrapper classes. This PR removes the explicit request validation from the SignalR, gRPC and HTTP proxy feature implementations so that validation is only performed once.