### PR TITLE
Allow adapters to skip request validation

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AdapterCallContextExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterCallContextExtensions.cs
@@ -1,0 +1,135 @@
+﻿using System;
+
+namespace DataCore.Adapter {
+
+    /// <summary>
+    /// Extensions for <see cref="IAdapterCallContext"/>.
+    /// </summary>
+    public static class AdapterCallContextExtensions {
+
+        /// <summary>
+        /// Sets an entry in the <see cref="IAdapterCallContext.Items"/> dictionary.
+        /// </summary>
+        /// <typeparam name="TKey">
+        ///   The key type.
+        /// </typeparam>
+        /// <typeparam name="TValue">
+        ///   The value type.
+        /// </typeparam>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/>.
+        /// </param>
+        /// <param name="key">
+        ///   The key.
+        /// </param>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="context"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="key"/> is <see langword="null"/>.
+        /// </exception>
+        public static void SetItem<TKey, TValue>(this IAdapterCallContext context, TKey key, TValue? value) {
+            if (context == null) {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (key == null) {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            context.Items[key] = value;
+        }
+
+
+        /// <summary>
+        /// Tries to get an entry from the <see cref="IAdapterCallContext.Items"/> dictionary.
+        /// </summary>
+        /// <typeparam name="TKey">
+        ///   The key type.
+        /// </typeparam>
+        /// <typeparam name="TValue">
+        ///   The value type.
+        /// </typeparam>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/>.
+        /// </param>
+        /// <param name="key">
+        ///   The key.
+        /// </param>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the <paramref name="key"/> was found in the <see cref="IAdapterCallContext.Items"/> 
+        ///   dictionary and the value is an instance of <typeparamref name="TValue"/>, or <see langword="false"/> 
+        ///   otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="context"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="key"/> is <see langword="null"/>.
+        /// </exception>
+        public static bool TryGetItem<TKey, TValue>(this IAdapterCallContext context, TKey key, out TValue? value) {
+            if (context == null) {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (key == null) {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            value = default;
+            if (!context.Items.TryGetValue(key, out var val) || !(val is TValue valActual)) {
+                return false;
+            }
+
+            value = valActual;
+            return true;
+        }
+
+
+        /// <summary>
+        /// Specifies if <see cref="AdapterFeatureWrapper{TFeature}"/> instances should validate 
+        /// request objects prior to invoking methods on their wrapped features that use this 
+        /// <see cref="IAdapterCallContext"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/>.
+        /// </param>
+        /// <param name="enabled">
+        ///   <see langword="true"/> to require request validation or <see langword="false"/> 
+        ///   otherwise.
+        /// </param>
+        /// <remarks>
+        ///   It may be desirable to disable request validation at the <see cref="AdapterFeatureWrapper{TFeature}"/> 
+        ///   level if the request object has already been validated (for example, by an ASP.NET 
+        ///   Core route handler).
+        /// </remarks>
+        public static void ValidateRequests(this IAdapterCallContext context, bool enabled) { 
+            if (context == null) {
+                return;
+            }
+
+            context.SetItem("adapter:validate-request-objects", enabled);
+        }
+
+
+        /// <summary>
+        /// Checks if calls to <see cref="AdapterFeatureWrapper{TFeature}"/> that use this <see cref="IAdapterCallContext"/> 
+        /// should validate request objects prior to invoking the inner feature.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> to require request validation or <see langword="false"/> 
+        ///   otherwise.
+        /// </returns>
+        internal static bool ShouldValidateRequests(this IAdapterCallContext context) => context?.Items == null || !context.TryGetItem<string, bool>("adapter:validate-request-objects", out var value) || value;
+
+    }
+}

--- a/src/DataCore.Adapter.Abstractions/AdapterCallContextExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterCallContextExtensions.cs
@@ -109,7 +109,7 @@ namespace DataCore.Adapter {
         ///   level if the request object has already been validated (for example, by an ASP.NET 
         ///   Core route handler).
         /// </remarks>
-        public static void ValidateRequests(this IAdapterCallContext context, bool enabled) { 
+        public static void UseRequestValidation(this IAdapterCallContext context, bool enabled) { 
             if (context == null) {
                 return;
             }

--- a/src/DataCore.Adapter.Abstractions/AdapterCallContextExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterCallContextExtensions.cs
@@ -8,6 +8,12 @@ namespace DataCore.Adapter {
     public static class AdapterCallContextExtensions {
 
         /// <summary>
+        /// The name of the entry in <see cref="IAdapterCallContext.Items"/> that controls if 
+        /// requests should be validated at the adapter level.
+        /// </summary>
+        public const string ValidateRequestsItemName = "adapter:validate-request-objects";
+
+        /// <summary>
         /// Sets an entry in the <see cref="IAdapterCallContext.Items"/> dictionary.
         /// </summary>
         /// <typeparam name="TKey">
@@ -114,7 +120,51 @@ namespace DataCore.Adapter {
                 return;
             }
 
-            context.SetItem("adapter:validate-request-objects", enabled);
+            context.SetItem(ValidateRequestsItemName, enabled);
+        }
+
+
+        /// <summary>
+        /// Tries to specify if <see cref="AdapterFeatureWrapper{TFeature}"/> instances should 
+        /// validate request objects prior to invoking methods on their wrapped features that 
+        /// use this <see cref="IAdapterCallContext"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/>.
+        /// </param>
+        /// <param name="enabled">
+        ///   <see langword="true"/> to require request validation or <see langword="false"/> 
+        ///   otherwise.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the request validation flag was successfully set, or 
+        ///   <see langword="false"/> otherwise.
+        /// </returns>
+        /// <remarks>
+        ///   
+        /// <para>
+        ///   It may be desirable to disable request validation at the <see cref="AdapterFeatureWrapper{TFeature}"/> 
+        ///   level if the request object has already been validated (for example, by an ASP.NET 
+        ///   Core route handler).
+        /// </para>
+        /// 
+        /// <para>
+        ///   If the flag that controls request validation has already been set (either positively 
+        ///   or negatively), this method will always return <see langword="false"/>.
+        /// </para>
+        /// 
+        /// </remarks>
+        public static bool TryUseRequestValidation(this IAdapterCallContext context, bool enabled) {
+            if (context?.Items == null) {
+                return false;
+            }
+
+            if (context.Items.ContainsKey(ValidateRequestsItemName)) {
+                return false;
+            }
+
+            context.SetItem(ValidateRequestsItemName, enabled);
+            return true;
         }
 
 
@@ -129,7 +179,7 @@ namespace DataCore.Adapter {
         ///   <see langword="true"/> to require request validation or <see langword="false"/> 
         ///   otherwise.
         /// </returns>
-        internal static bool ShouldValidateRequests(this IAdapterCallContext context) => context?.Items == null || !context.TryGetItem<string, bool>("adapter:validate-request-objects", out var value) || value;
+        internal static bool ShouldValidateRequests(this IAdapterCallContext context) => context?.Items == null || !context.TryGetItem<string, bool>(ValidateRequestsItemName, out var value) || value;
 
     }
 }

--- a/src/DataCore.Adapter.Abstractions/AdapterCore.FeatureManagement.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterCore.FeatureManagement.cs
@@ -70,7 +70,10 @@ namespace DataCore.Adapter {
 
             AdapterFeatureWrapper? wrapper = null;
 
-            if (featureType.Equals(typeof(AssetModel.IAssetModelBrowse))) {
+            if (feature is AdapterFeatureWrapper afw) {
+                wrapper = afw;
+            }
+            else if (featureType.Equals(typeof(AssetModel.IAssetModelBrowse))) {
                 wrapper = new AssetModel.AssetModelBrowseWrapper(this, (AssetModel.IAssetModelBrowse) feature);
             }
             else if (featureType.Equals(typeof(AssetModel.IAssetModelSearch))) {

--- a/src/DataCore.Adapter.Abstractions/AdapterCore.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterCore.cs
@@ -139,6 +139,8 @@ namespace DataCore.Adapter {
             // initially in a cancelled state.
             _stopTokenSource = new CancellationTokenSource();
             _stopTokenSource.Cancel();
+
+            Enable();
         }
 
 

--- a/src/DataCore.Adapter.Abstractions/AdapterFeatureWrapperT.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterFeatureWrapperT.cs
@@ -212,7 +212,12 @@ namespace DataCore.Adapter {
             OnOperationStarted(operationName);
 
             try {
-                Adapter.ValidateInvocation(context, request!);
+                if (context.ShouldValidateRequests()) {
+                    Adapter.ValidateInvocation(context, request!);
+                }
+                else {
+                    Adapter.ValidateInvocation(context);
+                }
             }
             catch (Exception e) {
                 OnOperationFaulted(operationName, stopwatch.GetElapsedTime().TotalMilliseconds, e);
@@ -324,7 +329,12 @@ namespace DataCore.Adapter {
             OnOperationStarted(operationName);
 
             try {
-                Adapter.ValidateInvocation(context, request!);
+                if (context.ShouldValidateRequests()) {
+                    Adapter.ValidateInvocation(context, request!);
+                }
+                else {
+                    Adapter.ValidateInvocation(context);
+                }
             }
             catch (Exception e) {
                 OnOperationFaulted(operationName, stopwatch.GetElapsedTime().TotalMilliseconds, e);
@@ -482,7 +492,12 @@ namespace DataCore.Adapter {
             OnOperationStarted(operationName);
 
             try {
-                Adapter.ValidateInvocation(context, request!);
+                if (context.ShouldValidateRequests()) {
+                    Adapter.ValidateInvocation(context, request!, inStream);
+                }
+                else {
+                    Adapter.ValidateInvocation(context, inStream);
+                }
             }
             catch (Exception e) {
                 OnOperationFaulted(operationName, stopwatch.GetElapsedTime().TotalMilliseconds, e);

--- a/src/DataCore.Adapter.Abstractions/AssemblyAttributes.cs
+++ b/src/DataCore.Adapter.Abstractions/AssemblyAttributes.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
-// Allow DataCore.Adapter to call internal extension methods.
+// Allow selected assemblies to access internals
 [assembly: InternalsVisibleTo("DataCore.Adapter")]
+[assembly: InternalsVisibleTo("DataCore.Adapter.Tests")]

--- a/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
@@ -50,20 +50,11 @@ namespace DataCore.Adapter.AspNetCore {
         /// <param name="httpContext">
         ///   The <see cref="HttpContext"/> to use.
         /// </param>
-        /// <param name="validateRequests">
-        ///   Specifies if adapters need to validate request objects when adapter features are 
-        ///   invoked using this call context. Specify <see langword="false"/> if the request 
-        ///   objects have already been validated by the route handler for the 
-        ///   <paramref name="httpContext"/>.
-        /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="httpContext"/> is <see langword="null"/>
         /// </exception>
-        public HttpAdapterCallContext(HttpContext httpContext, bool validateRequests = false) {
+        public HttpAdapterCallContext(HttpContext httpContext) {
             _httpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
-            if (!validateRequests) {
-                this.UseRequestValidation(false);
-            }
         }
 
     }

--- a/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
@@ -62,7 +62,7 @@ namespace DataCore.Adapter.AspNetCore {
         public HttpAdapterCallContext(HttpContext httpContext, bool validateRequests = false) {
             _httpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
             if (!validateRequests) {
-                this.ValidateRequests(false);
+                this.UseRequestValidation(false);
             }
         }
 

--- a/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
@@ -50,11 +50,20 @@ namespace DataCore.Adapter.AspNetCore {
         /// <param name="httpContext">
         ///   The <see cref="HttpContext"/> to use.
         /// </param>
+        /// <param name="validateRequests">
+        ///   Specifies if adapters need to validate request objects when adapter features are 
+        ///   invoked using this call context. Specify <see langword="false"/> if the request 
+        ///   objects have already been validated by the route handler for the 
+        ///   <paramref name="httpContext"/>.
+        /// </param>
         /// <exception cref="ArgumentNullException">
-        /// 
+        ///   <paramref name="httpContext"/> is <see langword="null"/>
         /// </exception>
-        public HttpAdapterCallContext(HttpContext httpContext) {
+        public HttpAdapterCallContext(HttpContext httpContext, bool validateRequests = false) {
             _httpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
+            if (!validateRequests) {
+                this.ValidateRequests(false);
+            }
         }
 
     }

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcAdapterCallContext.cs
@@ -16,7 +16,7 @@ namespace DataCore.Adapter.AspNetCore.Grpc {
         /// <param name="serverCallContext">
         ///   The gRPC server call context.
         /// </param>
-        public GrpcAdapterCallContext(ServerCallContext serverCallContext) : base(serverCallContext?.GetHttpContext()!) { 
+        public GrpcAdapterCallContext(ServerCallContext serverCallContext) : base(serverCallContext?.GetHttpContext()!, true) { 
             if (serverCallContext == null) {
                 throw new ArgumentNullException(nameof(serverCallContext));
             }

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcAdapterCallContext.cs
@@ -16,7 +16,7 @@ namespace DataCore.Adapter.AspNetCore.Grpc {
         /// <param name="serverCallContext">
         ///   The gRPC server call context.
         /// </param>
-        public GrpcAdapterCallContext(ServerCallContext serverCallContext) : base(serverCallContext?.GetHttpContext()!, true) { 
+        public GrpcAdapterCallContext(ServerCallContext serverCallContext) : base(serverCallContext?.GetHttpContext()!) { 
             if (serverCallContext == null) {
                 throw new ArgumentNullException(nameof(serverCallContext));
             }

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AssetModelBrowserController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AssetModelBrowserController.cs
@@ -16,7 +16,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     [Area("app-store-connect")]
     [Route("api/[area]/v2.0/asset-model")]
     // Legacy route for compatibility with v1 of the toolkit
-    [Route("api/data-core/v1.0/asset-model")] 
+    [Route("api/data-core/v1.0/asset-model")]
+    [UseAdapterRequestValidation(false)]
     public class AssetModelBrowserController : ControllerBase {
 
         /// <summary>
@@ -61,6 +62,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/browse")]
         [ProducesResponseType(typeof(IAsyncEnumerable<AssetModelNode>), 200)]
+        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> BrowseNodes(string adapterId, string? start = null, int page = 1, int pageSize = 10, CancellationToken cancellationToken = default) {
             return BrowseNodesPost(adapterId, new BrowseAssetModelNodesRequest() { 
                 ParentId = start,

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/CustomFunctionsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/CustomFunctionsController.cs
@@ -17,6 +17,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     [ApiController]
     [Area("app-store-connect")]
     [Route("api/[area]/v2.0/custom-functions")]
+    [UseAdapterRequestValidation(false)]
     public class CustomFunctionsController : ControllerBase {
 
         /// <summary>
@@ -106,6 +107,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}")]
         [ProducesResponseType(typeof(IEnumerable<CustomFunctionDescriptor>), 200)]
+        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> GetFunctionsAsync(string adapterId, string? id = null, string? name = null, string? description = null, int pageSize = 10, int page = 1, CancellationToken cancellationToken = default) {
             return await GetFunctionsAsync(adapterId, new GetCustomFunctionsRequest() { 
                 Id = id,
@@ -175,6 +177,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/details")]
         [ProducesResponseType(typeof(CustomFunctionDescriptorExtended), 200)]
+        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> GetFunctionAsync(string adapterId, [FromQuery] Uri id, CancellationToken cancellationToken) {
             return await GetFunctionAsync(adapterId, new GetCustomFunctionRequest() { 
                 Id = id

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/EventsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/EventsController.cs
@@ -20,7 +20,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     [Area("app-store-connect")]
     [Route("api/[area]/v2.0/events")]
     // Legacy route for compatibility with v1 of the toolkit
-    [Route("api/data-core/v1.0/events")] 
+    [Route("api/data-core/v1.0/events")]
+    [UseAdapterRequestValidation(false)]
     public class EventsController : ControllerBase {
 
         /// <summary>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
@@ -20,6 +20,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     [Route("api/[area]/v2.0/extensions")]
     // Legacy route for compatibility with v1 of the toolkit
     [Route("api/data-core/v1.0/extensions")]
+    [UseAdapterRequestValidation(false)]
     [Obsolete(ExtensionFeatureConstants.ObsoleteMessage, ExtensionFeatureConstants.ObsoleteError)]
     public class ExtensionFeaturesController : ControllerBase {
 

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagAnnotationsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagAnnotationsController.cs
@@ -17,7 +17,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     [Area("app-store-connect")]
     [Route("api/[area]/v2.0/tag-annotations")]
     // Legacy route for compatibility with v1 of the toolkit
-    [Route("api/data-core/v1.0/tag-annotations")] 
+    [Route("api/data-core/v1.0/tag-annotations")]
+    [UseAdapterRequestValidation(false)]
     public class TagAnnotationsController: ControllerBase {
 
         /// <summary>
@@ -100,6 +101,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/{tagId}/{annotationId}")]
         [ProducesResponseType(typeof(TagValueAnnotationExtended), 200)]
+        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> ReadAnnotation(string adapterId, string tagId, string annotationId, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
             var resolvedFeature = await _adapterAccessor.GetAdapterAndFeature<IReadTagValueAnnotations>(callContext, adapterId, cancellationToken).ConfigureAwait(false);
@@ -153,6 +155,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpPost]
         [Route("{adapterId}/{tagId}/create")]
         [ProducesResponseType(typeof(WriteTagValueAnnotationResult), 200)]
+        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> CreateAnnotation(string adapterId, string tagId, TagValueAnnotation annotation, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
             var resolvedFeature = await _adapterAccessor.GetAdapterAndFeature<IWriteTagValueAnnotations>(callContext, adapterId, cancellationToken).ConfigureAwait(false);
@@ -211,6 +214,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpPut]
         [Route("{adapterId}/{tagId}/{annotationId}")]
         [ProducesResponseType(typeof(WriteTagValueAnnotationResult), 200)]
+        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> UpdateAnnotation(string adapterId, string tagId, string annotationId, TagValueAnnotation annotation, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
             var resolvedFeature = await _adapterAccessor.GetAdapterAndFeature<IWriteTagValueAnnotations>(callContext, adapterId, cancellationToken).ConfigureAwait(false);
@@ -267,6 +271,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpDelete]
         [Route("{adapterId}/{tagId}/{annotationId}")]
         [ProducesResponseType(typeof(WriteTagValueAnnotationResult), 200)]
+        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> DeleteAnnotation(string adapterId, string tagId, string annotationId, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
             var resolvedFeature = await _adapterAccessor.GetAdapterAndFeature<IWriteTagValueAnnotations>(callContext, adapterId, cancellationToken).ConfigureAwait(false);

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
@@ -17,7 +17,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     [Area("app-store-connect")]
     [Route("api/[area]/v2.0/tags")]
     // Legacy route for compatibility with v1 of the toolkit
-    [Route("api/data-core/v1.0/tags")] 
+    [Route("api/data-core/v1.0/tags")]
+    [UseAdapterRequestValidation(false)]
     public class TagSearchController : ControllerBase {
 
         /// <summary>
@@ -100,6 +101,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/properties")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagDefinition>), 200)]
+        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> GetTagProperties(string adapterId, int pageSize = 10, int page = 1, CancellationToken cancellationToken = default) {
             return await GetTagProperties(adapterId, new GetTagPropertiesRequest() {
                 PageSize = pageSize,
@@ -182,6 +184,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [Route("{adapterId}/find")]
         [Route("{adapterId}")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagDefinition>), 200)]
+        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> FindTags(string adapterId, string? name = null, string? description = null, string? units = null, int pageSize = 10, int page = 1, CancellationToken cancellationToken = default) {
             return await FindTags(adapterId, new FindTagsRequest() {
                 Name = name,
@@ -254,6 +257,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/get-by-id")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagDefinition>), 200)]
+        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> GetTags(string adapterId, [FromQuery] string[] tag, CancellationToken cancellationToken) {
             return await GetTags(adapterId, new GetTagsRequest() {
                 Tags = tag
@@ -400,7 +404,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
 
 
         /// <summary>
-        /// Updates an existing tag.
+        /// Deletes an existing tag.
         /// </summary>
         /// <param name="adapterId">
         ///   The adapter ID.

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagValuesController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagValuesController.cs
@@ -21,7 +21,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
     [Area("app-store-connect")]
     [Route("api/[area]/v2.0/tag-values")]
     // Legacy route for compatibility with v1 of the toolkit
-    [Route("api/data-core/v1.0/tag-values")] 
+    [Route("api/data-core/v1.0/tag-values")]
+    [UseAdapterRequestValidation(false)]
     public class TagValuesController: ControllerBase {
 
         /// <summary>
@@ -85,6 +86,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/snapshot")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
+        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadSnapshotValues(string adapterId, [FromQuery] string[] tag = null!, CancellationToken cancellationToken = default) {
             return ReadSnapshotValues(adapterId, new ReadSnapshotTagValuesRequest() { 
                 Tags = tag ?? Array.Empty<string>()
@@ -164,6 +166,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/raw")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
+        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadRawValues(
             string adapterId, 
             [FromQuery] string[] tag = null!, 
@@ -269,6 +272,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/plot")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
+        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadPlotValues(
             string adapterId, 
             [FromQuery] string[] tag = null!, 
@@ -365,6 +369,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/values-at-times")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
+        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadValuesAtTimes(
             string adapterId, 
             [FromQuery] string[] tag = null!,
@@ -458,6 +463,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/processed")]
         [ProducesResponseType(typeof(IAsyncEnumerable<ProcessedTagValueQueryResult>), 200)]
+        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadProcessedValues(
             string adapterId,
             [FromQuery] string[] tag = null!,
@@ -566,6 +572,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [HttpGet]
         [Route("{adapterId}/supported-aggregations")]
         [ProducesResponseType(typeof(IAsyncEnumerable<DataFunctionDescriptor>), 200)]
+        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> GetSupportedDataFunctions(string adapterId, CancellationToken cancellationToken) {
             return GetSupportedDataFunctions(adapterId, new GetSupportedDataFunctionsRequest(), cancellationToken);
         }

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/UseAdapterRequestValidationAttribute.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/UseAdapterRequestValidationAttribute.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace DataCore.Adapter.AspNetCore.Controllers {
+
+    /// <summary>
+    /// Specifies if the controller should enable or disable adapter-level request validation for 
+    /// its call context.
+    /// </summary>
+    /// <remarks>
+    /// 
+    /// <para>
+    ///   All adapters that inherit from <see cref="AdapterCore"/> wrap their features in classes 
+    ///   derived from <see cref="AdapterFeatureWrapper{TFeature}"/> that will validate request 
+    ///   objects passed to the feature's methods.
+    /// </para>
+    /// 
+    /// <para>
+    ///   When a request object is received as route parameter, it has already been validated by 
+    ///   the MVC framework before it reaches the adapter, so there is no need to re-validate. 
+    /// </para>
+    /// 
+    /// <para>
+    ///   If this filter is applied on a controller rather than an individual method, it may be 
+    ///   required to re-enable validation. The most common use case for this is for HTTP GET 
+    ///   routes that accept query string parameters to construct a request object that is then 
+    ///   dispatched to the handler for the equivalent HTTP POST route. An example of this is in 
+    ///   <see cref="TagSearchController"/>, where an HTTP GET route allows for tag searches where 
+    ///   filters are specified as query string parameters, but the request itself is processed by 
+    ///   the HTTP POST route that accepts a <see cref="Tags.FindTagsRequest"/> in the request 
+    ///   body.
+    /// </para>
+    /// 
+    /// <para>
+    ///   Re-enabling adapter-level validation can be done by annotating the method in question 
+    ///   with its own <see cref="UseAdapterRequestValidationAttribute"/>.
+    /// </para>
+    /// 
+    /// </remarks>
+    internal class UseAdapterRequestValidationAttribute : ActionFilterAttribute {
+
+        /// <summary>
+        /// Specifies if the calls to adapter features by the action require adapter-level request 
+        /// validation.
+        /// </summary>
+        public bool RequireValidation { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="UseAdapterRequestValidationAttribute"/> instance.
+        /// </summary>
+        /// <param name="requireValidation">
+        ///   Specifies if the calls to adapter features by the action require adapter-level 
+        ///   request validation.
+        /// </param>
+        public UseAdapterRequestValidationAttribute(bool requireValidation) {
+            RequireValidation = requireValidation;
+        }
+
+
+        /// <inheritdoc/>
+        public override void OnActionExecuting(ActionExecutingContext context) {
+            base.OnActionExecuting(context);
+            if (!RequireValidation && context.ModelState.IsValid && !context.HttpContext.Items.ContainsKey(AdapterCallContextExtensions.ValidateRequestsItemName)) {
+                context.HttpContext.Items[AdapterCallContextExtensions.ValidateRequestsItemName] = false;
+            }
+        }
+
+    }
+}

--- a/src/DataCore.Adapter/AdapterBaseT.cs
+++ b/src/DataCore.Adapter/AdapterBaseT.cs
@@ -185,8 +185,8 @@ namespace DataCore.Adapter {
             Validator.ValidateObject(opts, new ValidationContext(opts), true);
             Options = opts;
             UpdateDescriptor(opts.Name, opts.Description);
-            if (Options.IsEnabled) {
-                Enable();
+            if (!Options.IsEnabled) {
+                Disable();
             }
         }
 
@@ -258,8 +258,8 @@ namespace DataCore.Adapter {
 
             Options = options;
             UpdateDescriptor(options.Name, options.Description);
-            if (Options.IsEnabled) {
-                Enable();
+            if (!Options.IsEnabled) {
+                Disable();
             }
 
             _optionsMonitorSubscription = optionsMonitor.OnChange((opts, name) => {

--- a/test/DataCore.Adapter.Tests/AdapterCallContextTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterCallContextTests.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+using IntelligentPlant.BackgroundTasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DataCore.Adapter.Tests {
+
+    [TestClass]
+    public class AdapterCallContextTests : TestsBase {
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context) {
+            TypeExtensions.AddStandardFeatureDefinition(typeof(ITestFeature));
+        }
+
+
+        [DataTestMethod]
+        [DataRow(null, false)]
+        [DataRow("ABCDEFGHIJKLMNOPQRSTUVWXYZ", false)]
+        [DataRow("Hello", true)]
+        public async Task RequestShouldSkipValidation(string invalidName, bool isValid) {
+            using var adapter = new ExampleAdapter();
+            adapter.AddFeature<ITestFeature>(new TestFeatureWrapper(adapter, new TestFeature()));
+
+            await ((IAdapter) adapter).StartAsync(default);
+
+            var context = ExampleCallContext.ForPrincipal(ClaimsPrincipal.Current);
+            var feature = adapter.GetFeature<ITestFeature>();
+
+            var request = new TestFeatureRequest() { 
+                Name = invalidName
+            };
+
+            context.ValidateRequests(false);
+
+            Assert.AreEqual(isValid, await feature.IsValid(context, request, default));
+        }
+
+
+        [DataTestMethod]
+        [DataRow(null, false)]
+        [DataRow("ABCDEFGHIJKLMNOPQRSTUVWXYZ", false)]
+        [DataRow("Hello", true)]
+        public async Task RequestShouldNotSkipValidation(string name, bool isValid) {
+            using var adapter = new ExampleAdapter();
+            adapter.AddFeature<ITestFeature>(new TestFeatureWrapper(adapter, new TestFeature()));
+
+            await ((IAdapter) adapter).StartAsync(default);
+
+            var context = ExampleCallContext.ForPrincipal(ClaimsPrincipal.Current);
+            var feature = adapter.GetFeature<ITestFeature>();
+
+            var request = new TestFeatureRequest() {
+                Name = name
+            };
+
+            if (isValid) {
+                Assert.IsTrue(await feature.IsValid(context, request, default).ConfigureAwait(false));
+            }
+            else {
+                await Assert.ThrowsExceptionAsync<ValidationException>(() => feature.IsValid(context, request, default)).ConfigureAwait(false);
+            }
+        }
+
+
+        [AdapterFeature("unit-tests:test-feature")]
+        private interface ITestFeature : IAdapterFeature {
+
+            Task<bool> IsValid(IAdapterCallContext context, TestFeatureRequest request, CancellationToken cancellationToken);
+        
+        }
+
+
+        private class TestFeatureRequest {
+
+            [Required]
+            [MaxLength(10)]
+            public string Name { get; set; }
+
+        }
+
+
+        private class TestFeature : ITestFeature {
+
+            IBackgroundTaskService IBackgroundTaskServiceProvider.BackgroundTaskService { get; }
+
+
+            public Task<bool> IsValid(IAdapterCallContext context, TestFeatureRequest request, CancellationToken cancellationToken) {
+                if (request == null) {
+                    return Task.FromResult(false);
+                }
+
+                var validationResults = new List<ValidationResult>();
+                return Task.FromResult(Validator.TryValidateObject(request, new ValidationContext(request), validationResults, true));
+            }
+
+        }
+
+
+        private class TestFeatureWrapper : AdapterFeatureWrapper<ITestFeature>, ITestFeature { 
+        
+            public TestFeatureWrapper(ExampleAdapter adapter, ITestFeature feature) : base(adapter, feature) { }
+
+            public Task<bool> IsValid(IAdapterCallContext context, TestFeatureRequest request, CancellationToken cancellationToken) {
+                return InvokeAsync(context, request, InnerFeature.IsValid, cancellationToken);
+            }
+        }
+
+    }
+
+}

--- a/test/DataCore.Adapter.Tests/AdapterCallContextTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterCallContextTests.cs
@@ -36,7 +36,7 @@ namespace DataCore.Adapter.Tests {
                 Name = invalidName
             };
 
-            context.ValidateRequests(false);
+            context.UseRequestValidation(false);
 
             Assert.AreEqual(isValid, await feature.IsValid(context, request, default));
         }

--- a/test/DataCore.Adapter.Tests/AdapterFeatureDefinitionTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterFeatureDefinitionTests.cs
@@ -22,6 +22,10 @@ namespace DataCore.Adapter.Tests {
         public void ShouldResolveStandardFeatureDescriptorFromUri() {
             foreach (var featureType in TypeExtensions.GetStandardAdapterFeatureTypes()) {
                 var uri = featureType.GetAdapterFeatureUri();
+                if (uri.ToString().StartsWith("unit-tests:")) {
+                    // Feature was added by another unit test.
+                    continue;
+                }
                 Assert.IsTrue(WellKnownFeatures.TryGetFeatureDescriptor(uri, out var descriptor), $"Should have resolved descriptor for {uri}");
                 Assert.IsNotNull(descriptor, $"Decriptor for {uri} should not be null.");
                 Assert.AreEqual(uri, descriptor.Uri);

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -21,27 +21,27 @@ using IntelligentPlant.BackgroundTasks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DataCore.Adapter.Tests {
-    public class ExampleAdapter : IAdapter, ITagInfo, IReadSnapshotTagValues {
+    public class ExampleAdapter : AdapterCore, ITagInfo, IReadSnapshotTagValues {
 
-        private CancellationTokenSource _stopTokenSource;
+        //private CancellationTokenSource _stopTokenSource;
 
-        public IBackgroundTaskService BackgroundTaskService { get; }
+        //public IBackgroundTaskService BackgroundTaskService { get; }
 
-        public AdapterDescriptor Descriptor { get; }
+        //public AdapterDescriptor Descriptor { get; }
 
-        public AdapterTypeDescriptor TypeDescriptor { get; }
+        //public AdapterTypeDescriptor TypeDescriptor { get; }
 
-        public IAdapterFeaturesCollection Features { get; }
+        //public IAdapterFeaturesCollection Features { get; }
 
-        public IEnumerable<AdapterProperty> Properties { get; } = Array.Empty<AdapterProperty>();
+        //public IEnumerable<AdapterProperty> Properties { get; } = Array.Empty<AdapterProperty>();
 
-        public bool IsEnabled { get; set; } = true;
+        //public bool IsEnabled { get; set; } = true;
 
-        public bool IsRunning { get; } = true;
+        //public bool IsRunning { get; } = true;
 
-        public event Func<IAdapter, Task> Started;
+        //public event Func<IAdapter, Task> Started;
 
-        public event Func<IAdapter, Task> Stopped;
+        //public event Func<IAdapter, Task> Stopped;
 
         private readonly SnapshotSubscriptionManager _snapshotSubscriptionManager;
 
@@ -54,33 +54,33 @@ namespace DataCore.Adapter.Tests {
         private readonly CustomFunctions _customFunctions;
 
 
-        public ExampleAdapter() {
-            BackgroundTaskService = new BackgroundTaskServiceWrapper(
-                IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default,
-                () => _stopTokenSource?.Token ?? default
-            );
-            Descriptor = AdapterDescriptor.Create("unit-tests", "Unit Tests Adapter", "Adapter for use in unit tests");
-            TypeDescriptor = this.CreateTypeDescriptor();
-            var features = new AdapterFeaturesCollection();
+        public ExampleAdapter() : base(AdapterDescriptor.Create("unit-tests", "Unit Tests Adapter", "Adapter for use in unit tests")) {
+            //BackgroundTaskService = new BackgroundTaskServiceWrapper(
+            //    IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default,
+            //    () => _stopTokenSource?.Token ?? default
+            //);
+            //Descriptor = AdapterDescriptor.Create("unit-tests", "Unit Tests Adapter", "Adapter for use in unit tests");
+            //TypeDescriptor = this.CreateTypeDescriptor();
+            //var features = new AdapterFeaturesCollection();
             _snapshotSubscriptionManager = new SnapshotSubscriptionManager(this);
             _eventSubscriptionManager = new EventSubscriptionManager();
             _eventTopicSubscriptionManager = new EventTopicSubscriptionManager();
             _assetModelManager = new AssetModelManager(new InMemoryKeyValueStore());
             _customFunctions = new CustomFunctions(TypeDescriptor.Id, BackgroundTaskService);
 
-            features.AddFromProvider(this);
-            features.AddFromProvider(_snapshotSubscriptionManager);
-            features.AddFromProvider(_eventSubscriptionManager);
-            features.AddFromProvider(_eventTopicSubscriptionManager);
-            features.AddFromProvider(_assetModelManager);
-            features.AddFromProvider(_customFunctions);
-            features.AddFromProvider(new PingPongExtension(BackgroundTaskService, AssemblyInitializer.ApplicationServices.GetServices<IObjectEncoder>()));
-            Features = features;
+            AddFeatures(this);
+            AddFeatures(_snapshotSubscriptionManager);
+            AddFeatures(_eventSubscriptionManager);
+            AddFeatures(_eventTopicSubscriptionManager);
+            AddFeatures(_assetModelManager);
+            AddFeatures(_customFunctions);
+            AddFeatures(new PingPongExtension(BackgroundTaskService, AssemblyInitializer.ApplicationServices.GetServices<IObjectEncoder>()));
+            //Features = features;
         }
 
 
-        public async Task StartAsync(CancellationToken cancellationToken = default) {
-            _stopTokenSource = new CancellationTokenSource();
+        protected override async Task StartAsyncCore(CancellationToken cancellationToken = default) {
+            //_stopTokenSource = new CancellationTokenSource();
 
             using var sha = System.Security.Cryptography.SHA256.Create();
 
@@ -100,9 +100,9 @@ namespace DataCore.Adapter.Tests {
                 });
             }, cancellationToken: cancellationToken);
 
-            if (Started != null) {
-                await Started.Invoke(this).ConfigureAwait(false);
-            }
+            //if (Started != null) {
+            //    await Started.Invoke(this).ConfigureAwait(false);
+            //}
         }
 
 
@@ -112,13 +112,14 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        public async Task StopAsync(CancellationToken cancellationToken = default) {
-            _stopTokenSource?.Cancel();
-            _stopTokenSource?.Dispose();
+        protected override Task StopAsyncCore(CancellationToken cancellationToken = default) {
+            //_stopTokenSource?.Cancel();
+            //_stopTokenSource?.Dispose();
 
-            if (Stopped != null) {
-                await Stopped.Invoke(this).ConfigureAwait(false);
-            }
+            //if (Stopped != null) {
+            //    await Stopped.Invoke(this).ConfigureAwait(false);
+            //}
+            return Task.CompletedTask;
         }
 
 
@@ -176,20 +177,20 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        public void AddFeatures(object provider) {
-            ((AdapterFeaturesCollection) Features).AddFromProvider(provider);
-        }
+        //public void AddFeatures(object provider) {
+        //    ((AdapterFeaturesCollection) Features).AddFromProvider(provider);
+        //}
 
 
-        public void Dispose() {
-            _snapshotSubscriptionManager.Dispose();
-        }
+        //protected override void Dispose() {
+        //    _snapshotSubscriptionManager.Dispose();
+        //}
 
 
-        public ValueTask DisposeAsync() {
-            Dispose();
-            return default;
-        }
+        //public ValueTask DisposeAsync() {
+        //    Dispose();
+        //    return default;
+        //}
 
 
         public ValueTask<bool> WriteSnapshotValue(TagValueQueryResult value) {


### PR DESCRIPTION
This PR implements #256.

All `AdapterFeatureWrapper<TFeature>` implementations will skip request validation in their `InvokeAsync`, `ServerStreamAsync` and `DuplexStreamAsync` methods if the `IAdapterCallContext.Items` dictionary for the caller has an entry with a key of `"adapter:validate-request-objects"` and a value of `false`.

This entry can be easily set using the new `UseRequestValidation` extension method for `IAdapterCallContext`.

`HttpAdapterCallContext` has been modified to disable request validation at the adapter level by default, since the incoming request object will already have been validated by the MVC pipeline. `GrpcAdapterCallContext` (which inherits from `HttpAdapterCallContext`) ensures that request validation is still required at the adapter level (since gRPC requests do not apply any validation rules).