### PR TITLE
Handle SignalR availability checks more gracefully

### DIFF
--- a/src/DataCore.Adapter.Http.Proxy/Resources.Designer.cs
+++ b/src/DataCore.Adapter.Http.Proxy/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace DataCore.Adapter.Http.Proxy {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -84,6 +84,15 @@ namespace DataCore.Adapter.Http.Proxy {
         public static string Error_AdapterIdIsRequired {
             get {
                 return ResourceManager.GetString("Error_AdapterIdIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to check if SignalR support is available on the remote host. Assuming that the remote host is available, this can occur if the HTTP proxy has been set to v3.0 or higher but the remote host is running an earlier version of the HTTP API..
+        /// </summary>
+        public static string Error_SignalRSupportCheckFailed {
+            get {
+                return ResourceManager.GetString("Error_SignalRSupportCheckFailed", resourceCulture);
             }
         }
         

--- a/src/DataCore.Adapter.Http.Proxy/Resources.resx
+++ b/src/DataCore.Adapter.Http.Proxy/Resources.resx
@@ -126,6 +126,9 @@
   <data name="Error_AdapterIdIsRequired" xml:space="preserve">
     <value>Adapter ID is required.</value>
   </data>
+  <data name="Error_SignalRSupportCheckFailed" xml:space="preserve">
+    <value>Failed to check if SignalR support is available on the remote host. Assuming that the remote host is available, this can occur if the HTTP proxy has been set to v3.0 or higher but the remote host is running an earlier version of the HTTP API.</value>
+  </data>
   <data name="HealthChecks_RemoteHeathDescription" xml:space="preserve">
     <value>See inner results for remote adapter health.</value>
   </data>


### PR DESCRIPTION
This PR fixes #283 by catching exceptions in the SignalR availability check (other than cancellations) and wrapping them in an `InvalidOperationException` with a more helpful error message describing the likely problem.