### PR TITLE
Expose HttpContext in IAdapterCallContext

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
     building via build.ps1 or build.sh. It is defined here to allow Visual Studio to build with 
     the solution with the correct version number.
     -->
-    <Version>3.0.0</Version>
+    <Version>3.1.0-pre.0</Version>
   </PropertyGroup>
 
   <Choose>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 3,
-  "Minor": 0,
+  "Minor": 1,
   "Patch": 0,
-  "PreRelease": ""
+  "PreRelease": "pre"
 }

--- a/src/DataCore.Adapter.Abstractions/IAdapterCallContextT.cs
+++ b/src/DataCore.Adapter.Abstractions/IAdapterCallContextT.cs
@@ -1,0 +1,20 @@
+﻿namespace DataCore.Adapter {
+
+    /// <summary>
+    /// Extends <see cref="IAdapterCallContext"/> to define a <see cref="Provider"/> that is used 
+    /// to implement the other <see cref="IAdapterCallContext"/> members.
+    /// </summary>
+    /// <typeparam name="T">
+    ///   The type of the provider.
+    /// </typeparam>
+    public interface IAdapterCallContext<T> : IAdapterCallContext {
+
+        /// <summary>
+        /// The provider that is used to implement the other <see cref="IAdapterCallContext"/> 
+        /// members.
+        /// </summary>
+        T Provider { get; }
+
+    }
+
+}

--- a/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
@@ -2,45 +2,46 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Security.Claims;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 
 namespace DataCore.Adapter.AspNetCore {
 
     /// <summary>
-    /// <see cref="IAdapterCallContext"/> implementation that uses an <see cref="HttpContext"/> to 
+    /// <see cref="IAdapterCallContext"/> implementation that uses an <see cref="Microsoft.AspNetCore.Http.HttpContext"/> to 
     /// provide context settings.
     /// </summary>
     public class HttpAdapterCallContext : IAdapterCallContext {
 
         /// <summary>
-        /// The <see cref="HttpContext"/> associated with the <see cref="HttpAdapterCallContext"/>.
+        /// The <see cref="Microsoft.AspNetCore.Http.HttpContext"/> associated with the <see cref="HttpAdapterCallContext"/>.
         /// </summary>
-        private readonly HttpContext _httpContext;
+        public HttpContext HttpContext { get; }
 
         /// <inheritdoc/>
         public ClaimsPrincipal? User {
-            get { return _httpContext.User; }
+            get { return HttpContext.User; }
         }
 
         /// <inheritdoc/>
         public string ConnectionId {
-            get { return _httpContext.Connection.Id; }
+            get { return HttpContext.Connection.Id; }
         }
 
         /// <inheritdoc/>
         public string CorrelationId {
-            get { return _httpContext.TraceIdentifier; }
+            get { return HttpContext.TraceIdentifier; }
         }
 
         /// <inheritdoc/>
         public CultureInfo CultureInfo {
-            get { return _httpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture?.Culture ?? CultureInfo.CurrentCulture; }
+            get { return HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture?.Culture ?? CultureInfo.CurrentCulture; }
         }
 
         /// <inheritdoc/>
         public IDictionary<object, object?> Items {
-            get { return _httpContext.Items; }
+            get { return HttpContext.Items; }
         }
 
 
@@ -48,13 +49,13 @@ namespace DataCore.Adapter.AspNetCore {
         /// Creates a new <see cref="HttpAdapterCallContext"/> object.
         /// </summary>
         /// <param name="httpContext">
-        ///   The <see cref="HttpContext"/> to use.
+        ///   The <see cref="Microsoft.AspNetCore.Http.HttpContext"/> to use.
         /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="httpContext"/> is <see langword="null"/>
         /// </exception>
         public HttpAdapterCallContext(HttpContext httpContext) {
-            _httpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
+            HttpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
         }
 
     }

--- a/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
@@ -9,39 +9,37 @@ using Microsoft.AspNetCore.Localization;
 namespace DataCore.Adapter.AspNetCore {
 
     /// <summary>
-    /// <see cref="IAdapterCallContext"/> implementation that uses an <see cref="Microsoft.AspNetCore.Http.HttpContext"/> to 
+    /// <see cref="IAdapterCallContext"/> implementation that uses an <see cref="HttpContext"/> to 
     /// provide context settings.
     /// </summary>
-    public class HttpAdapterCallContext : IAdapterCallContext {
+    public class HttpAdapterCallContext : IAdapterCallContext<HttpContext> {
 
-        /// <summary>
-        /// The <see cref="Microsoft.AspNetCore.Http.HttpContext"/> associated with the <see cref="HttpAdapterCallContext"/>.
-        /// </summary>
-        public HttpContext HttpContext { get; }
+        /// <inheritdoc/>
+        public HttpContext Provider { get; }
 
         /// <inheritdoc/>
         public ClaimsPrincipal? User {
-            get { return HttpContext.User; }
+            get { return Provider.User; }
         }
 
         /// <inheritdoc/>
         public string ConnectionId {
-            get { return HttpContext.Connection.Id; }
+            get { return Provider.Connection.Id; }
         }
 
         /// <inheritdoc/>
         public string CorrelationId {
-            get { return HttpContext.TraceIdentifier; }
+            get { return Provider.TraceIdentifier; }
         }
 
         /// <inheritdoc/>
         public CultureInfo CultureInfo {
-            get { return HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture?.Culture ?? CultureInfo.CurrentCulture; }
+            get { return Provider.Features.Get<IRequestCultureFeature>()?.RequestCulture?.Culture ?? CultureInfo.CurrentCulture; }
         }
 
         /// <inheritdoc/>
         public IDictionary<object, object?> Items {
-            get { return HttpContext.Items; }
+            get { return Provider.Items; }
         }
 
 
@@ -55,7 +53,7 @@ namespace DataCore.Adapter.AspNetCore {
         ///   <paramref name="httpContext"/> is <see langword="null"/>
         /// </exception>
         public HttpAdapterCallContext(HttpContext httpContext) {
-            HttpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
+            Provider = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
         }
 
     }


### PR DESCRIPTION
This PR adds a new `IAdapterCallContext<T>` interface that extends `IAdapterCallContext` by adding a `T Provider { get; }` property. `HttpAdapterCallContext` has been updated to implement `IAdapterCallContext<HttpContext>`.

The purpose of this new interface is to provide a generic way for `IAdapterCallContext` implementations such as `HttpAdapterCallContext` that piggyback onto an underlying provider to expose the provider.

This allows ASP.NET Core-hosted adapters to access the `HttpContext` for the current request inside an adapter call, which might in turn be useful if the adapter uses some form of pass-through authentication when calling a back-end or remote service (e.g. the adapter host authenticates using bearer tokens with an audience that matches the remote service and then re-uses the same bearer token when calling the remote service).