### PR TITLE
Update package references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,17 +10,17 @@
   project. 
   -->
   <PropertyGroup>
-    <PkgVersion_OpenTelemetry>1.4.0-rc.4</PkgVersion_OpenTelemetry>
-    <PkgVersion_OpenTelemetry_Api>1.4.0-rc.4</PkgVersion_OpenTelemetry_Api>
-    <PkgVersion_OpenTelemetry_Exporter_Console>1.4.0-rc.4</PkgVersion_OpenTelemetry_Exporter_Console>
-    <PkgVersion_OpenTelemetry_Exporter_Jaeger>1.4.0-rc.4</PkgVersion_OpenTelemetry_Exporter_Jaeger>
+    <PkgVersion_OpenTelemetry>1.4.0</PkgVersion_OpenTelemetry>
+    <PkgVersion_OpenTelemetry_Api>1.4.0</PkgVersion_OpenTelemetry_Api>
+    <PkgVersion_OpenTelemetry_Exporter_Console>1.4.0</PkgVersion_OpenTelemetry_Exporter_Console>
+    <PkgVersion_OpenTelemetry_Exporter_Jaeger>1.4.0</PkgVersion_OpenTelemetry_Exporter_Jaeger>
     <PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>1.4.0-rc.4</PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>
-    <PkgVersion_OpenTelemetry_Extensions_Hosting>1.4.0-rc.4</PkgVersion_OpenTelemetry_Extensions_Hosting>
-    <PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>1.0.0-rc9.13</PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>
-    <PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>1.0.0-rc9.13</PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>
-    <PkgVersion_OpenTelemetry_Instrumentation_Http>1.0.0-rc9.13</PkgVersion_OpenTelemetry_Instrumentation_Http>
-    <PkgVersion_OpenTelemetry_Instrumentation_Runtime>1.1.0-rc.1</PkgVersion_OpenTelemetry_Instrumentation_Runtime>
-    <PkgVersion_OpenTelemetry_Instrumentation_SqlClient>1.0.0-rc9.13</PkgVersion_OpenTelemetry_Instrumentation_SqlClient>
+    <PkgVersion_OpenTelemetry_Extensions_Hosting>1.4.0</PkgVersion_OpenTelemetry_Extensions_Hosting>
+    <PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>1.0.0-rc9.14</PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>
+    <PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>1.0.0-rc9.14</PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>
+    <PkgVersion_OpenTelemetry_Instrumentation_Http>1.0.0-rc9.14</PkgVersion_OpenTelemetry_Instrumentation_Http>
+    <PkgVersion_OpenTelemetry_Instrumentation_Runtime>1.1.0-rc.2</PkgVersion_OpenTelemetry_Instrumentation_Runtime>
+    <PkgVersion_OpenTelemetry_Instrumentation_SqlClient>1.0.0-rc9.14</PkgVersion_OpenTelemetry_Instrumentation_SqlClient>
     <PkgVersion_Microsoft_Web_LibraryManager_Build>2.1.175</PkgVersion_Microsoft_Web_LibraryManager_Build>
   </PropertyGroup>
   <ItemGroup>
@@ -31,7 +31,7 @@
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.51.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.3" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.51.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.51.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.52.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="8.2.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="8.2.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="8.2.0" />
@@ -47,7 +47,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.FASTER.Core" Version="2.3.5" />
+    <PackageVersion Include="Microsoft.FASTER.Core" Version="2.3.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />


### PR DESCRIPTION
Updates OpenTelemetry core packages to 1.4.0 release version and other OpenTelemetry packages to their latest version.

Updates to gRPC and Microsoft FASTER references as well.