### PR TITLE
CertificateUtilities improvements

### DIFF
--- a/src/DataCore.Adapter/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+static DataCore.Adapter.Security.CertificateUtilities.TryLoadCertificateFromStore(string! path, bool requirePrivateKey, bool allowInvalid, out System.Security.Cryptography.X509Certificates.X509Certificate2? certificate) -> bool


### PR DESCRIPTION
Miscellaneous improvements to the `CertificateUtilities` class:

- Marks `SelectCertificate` as obsolete (no compiler error).
- Marks the existing `TryLoadCertificateFromStore` method as obsolete (no compiler error).
- Adds a new `TryLoadCertificateFromStore` overload that also accepts parameters that control if invalid/expired certificates or certificates without private keys can be returned.
- Modifies `TryLoadCertificateFromStore` selection criteria so that the best match is returned depending on whether the caller has identified a certificate using a thumbprint, a full subject distinguished name, or a simple name.