### PR TITLE
Use Bootstrap 5.3 in adapter host template

### DIFF
--- a/docs/tutorials/mqtt-adapter/README.md
+++ b/docs/tutorials/mqtt-adapter/README.md
@@ -399,8 +399,8 @@ Replace the contents of `Pages/Settings.cshtml` with the following code to allow
 }
 
 <form id="settings-form" asp-page="Settings" method="post" class="g-3">
-  <div class="card">
-    <div class="card-header">
+  <div class="card border-success">
+    <div class="card-header border-success text-body-emphasis">
       <i class="fa-solid fa-puzzle-piece fa-fw"></i>
       Adapter Settings
     </div>
@@ -409,7 +409,7 @@ Replace the contents of `Pages/Settings.cshtml` with the following code to allow
 
     @if (!string.IsNullOrWhiteSpace(Model.Adapter.TypeDescriptor.HelpUrl)) {
       <div class="card-body pb-0">
-        <p class="small text-muted">
+        <p class="small text-body-secondary">
           Click
           <a href="@Model.Adapter.TypeDescriptor.HelpUrl" target="_blank" title="View help documentation for this adapter type">here</a>
           to view help documentation for this adapter type.
@@ -422,7 +422,7 @@ Replace the contents of `Pages/Settings.cshtml` with the following code to allow
         <label asp-for="Options!.Name" class="form-label"></label>
         <input asp-for="Options!.Name" asp-placeholder-for="Options!.Name" class="form-control" />
         <span asp-validation-for="Options!.Name" class="small text-danger"></span>
-        <p asp-description-for="Options!.Name" class="small text-muted"></p>
+        <p asp-description-for="Options!.Name" class="small text-body-secondary"></p>
       </div>
     </div>
 
@@ -431,7 +431,7 @@ Replace the contents of `Pages/Settings.cshtml` with the following code to allow
         <label asp-for="Options!.Description" class="form-label"></label>
         <textarea asp-for="Options!.Description" asp-placeholder-for="Options!.Description" class="form-control"></textarea>
         <span asp-validation-for="Options!.Description" class="small text-danger"></span>
-        <p asp-description-for="Options!.Description" class="small text-muted"></p>
+        <p asp-description-for="Options!.Description" class="small text-body-secondary"></p>
       </div>
     </div>
 
@@ -441,7 +441,7 @@ Replace the contents of `Pages/Settings.cshtml` with the following code to allow
           <input asp-for="Options!.IsEnabled" class="form-check-input" />
           <label asp-for="Options!.IsEnabled" class="form-check-label"></label>
         </div>
-        <p asp-description-for="Options!.IsEnabled" class="small text-muted"></p>
+        <p asp-description-for="Options!.IsEnabled" class="small text-body-secondary"></p>
       </div>
     </div>
 
@@ -450,7 +450,7 @@ Replace the contents of `Pages/Settings.cshtml` with the following code to allow
         <label asp-for="Options!.Hostname" class="form-label"></label>
         <input asp-for="Options!.Hostname" asp-placeholder-for="Options!.Hostname" class="form-control" />
         <span asp-validation-for="Options!.Hostname" class="small text-danger"></span>
-        <p asp-description-for="Options!.Hostname" class="small text-muted"></p>
+        <p asp-description-for="Options!.Hostname" class="small text-body-secondary"></p>
       </div>
     </div>
 
@@ -459,7 +459,7 @@ Replace the contents of `Pages/Settings.cshtml` with the following code to allow
         <label asp-for="Options!.Port" class="form-label"></label>
         <input asp-for="Options!.Port" asp-placeholder-for="Options!.Port" class="form-control" />
         <span asp-validation-for="Options!.Port" class="small text-danger"></span>
-        <p asp-description-for="Options!.Port" class="small text-muted"></p>
+        <p asp-description-for="Options!.Port" class="small text-body-secondary"></p>
       </div>
     </div>
 
@@ -468,13 +468,13 @@ Replace the contents of `Pages/Settings.cshtml` with the following code to allow
         <label asp-for="Options!.Topics" class="form-label"></label>
         <input asp-for="Options!.Topics" asp-placeholder-for="Options!.Topics" class="form-control" />
         <span asp-validation-for="Options!.Topics" class="small text-danger"></span>
-        <p asp-description-for="Options!.Topics" class="small text-muted"></p>
+        <p asp-description-for="Options!.Topics" class="small text-body-secondary"></p>
       </div>
     </div>
 
     <!-- Add additional controls for other adapter options fields as required. -->
 
-    <div class="card-footer">
+    <div class="card-footer border-success">
       <button type="submit" class="btn btn-sm btn-outline-success" title="Save adapter settings">
         <i class="fa-solid fa-check fa-fw"></i>
         Save Changes

--- a/examples/ExampleHostedAdapter/Pages/Settings.cshtml
+++ b/examples/ExampleHostedAdapter/Pages/Settings.cshtml
@@ -6,8 +6,8 @@
 }
 
 <form id="settings-form" asp-page="Settings" method="post" class="g-3">
-  <div class="card">
-    <div class="card-header">
+  <div class="card border-success">
+    <div class="card-header border-success text-body-emphasis">
       <i class="fa-solid fa-puzzle-piece fa-fw"></i>
       Adapter Settings
     </div>
@@ -16,7 +16,7 @@
 
     @if (!string.IsNullOrWhiteSpace(Model.Adapter.TypeDescriptor.HelpUrl)) {
       <div class="card-body pb-0">
-        <p class="small text-muted">
+        <p class="small text-body-secondary">
           Click
           <a href="@Model.Adapter.TypeDescriptor.HelpUrl" target="_blank" title="View help documentation for this adapter type">here</a>
           to view help documentation for this adapter type.
@@ -29,7 +29,7 @@
         <label asp-for="Options!.Name" class="form-label"></label>
         <input asp-for="Options!.Name" asp-placeholder-for="Options!.Name" class="form-control" />
         <span asp-validation-for="Options!.Name" class="small text-danger"></span>
-        <p asp-description-for="Options!.Name" class="small text-muted"></p>
+        <p asp-description-for="Options!.Name" class="small text-body-secondary"></p>
       </div>
     </div>
 
@@ -38,7 +38,7 @@
         <label asp-for="Options!.Description" class="form-label"></label>
         <textarea asp-for="Options!.Description" asp-placeholder-for="Options!.Description" class="form-control"></textarea>
         <span asp-validation-for="Options!.Description" class="small text-danger"></span>
-        <p asp-description-for="Options!.Description" class="small text-muted"></p>
+        <p asp-description-for="Options!.Description" class="small text-body-secondary"></p>
       </div>
     </div>
 
@@ -48,7 +48,7 @@
           <input asp-for="Options!.IsEnabled" class="form-check-input" />
           <label asp-for="Options!.IsEnabled" class="form-check-label"></label>
         </div>
-        <p asp-description-for="Options!.IsEnabled" class="small text-muted"></p>
+        <p asp-description-for="Options!.IsEnabled" class="small text-body-secondary"></p>
       </div>
     </div>
 
@@ -57,13 +57,13 @@
         <label asp-for="Options!.Seed" class="form-label"></label>
         <input asp-for="Options!.Seed" asp-placeholder-for="Options!.Seed" class="form-control" />
         <span asp-validation-for="Options!.Seed" class="small text-danger"></span>
-        <p asp-description-for="Options!.Seed" class="small text-muted"></p>
+        <p asp-description-for="Options!.Seed" class="small text-body-secondary"></p>
       </div>
     </div>
 
     <!-- Add additional controls for other adapter options fields as required. -->
 
-    <div class="card-footer">
+    <div class="card-footer border-success">
       <button type="submit" class="btn btn-sm btn-outline-success" title="Save adapter settings">
         <i class="fa-solid fa-check fa-fw"></i>
         Save Changes

--- a/examples/ExampleHostedAdapter/Pages/Settings.cshtml.css
+++ b/examples/ExampleHostedAdapter/Pages/Settings.cshtml.css
@@ -1,0 +1,3 @@
+﻿::deep .form-label, .form-check {
+    color: var(--bs-emphasis-color);
+}

--- a/examples/ExampleHostedAdapter/Pages/Shared/_Layout.cshtml
+++ b/examples/ExampleHostedAdapter/Pages/Shared/_Layout.cshtml
@@ -7,29 +7,59 @@
     <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/ExampleHostedAdapter.styles.css" asp-append-version="true" />
-    <script defer src="~/lib/font-awesome/js/all.min.js"></script>
+    <script defer src="~/lib/font-awesome/js/all.min.js" data-auto-replace-svg="nest"></script>
 </head>
 <body>
     <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
             <div class="container-fluid">
                 <a class="navbar-brand" asp-area="" asp-page="/Index">ASC Adapter Host</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
-                    <ul class="navbar-nav flex-grow-1">
+                    <ul class="navbar-nav d-flex">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Index" title="Home">
+                            <a class="nav-link" asp-area="" asp-page="/Index" title="Home">
                               <i class="fa-solid fa-house fa-fw"></i>
                               Home
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Settings" title="Modify adapter settings">
+                            <a class="nav-link" asp-area="" asp-page="/Settings" title="Modify adapter settings">
                               <i class="fa-solid fa-gears fa-fw"></i>
                               Settings
                             </a>
+                        </li>
+                    </ul>
+                    <ul class="navbar-nav d-flex">
+                        <li class="nav-item dropdown">
+                            <button class="btn btn-dark dropdown-toggle" id="theme-toggle" type="button" aria-expanded="false" data-bs-toggle="dropdown" title="Select theme">
+                                <i class="fa-solid fa-circle-half-stroke fa-fw"></i>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="theme-toggle">
+                                <li>
+                                  <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" title="Light mode">
+                                    <i class="fa-solid fa-sun fa-fw me-2"></i>
+                                    Light
+                                    <i class="fa-solid fa-check fa-fw ms-auto d-none" data-active-indicator></i>
+                                  </button>
+                                </li>
+                                <li>
+                                  <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark" title="Dark mode">
+                                    <i class="fa-solid fa-moon fa-fw me-2"></i>
+                                    Dark
+                                    <i class="fa-solid fa-check fa-fw ms-auto d-none" data-active-indicator></i>
+                                  </button>
+                                </li>
+                                <li>
+                                  <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="auto" title="Use system theme">
+                                    <i class="fa-solid fa-circle-half-stroke fa-fw me-2"></i>
+                                    Auto
+                                    <i class="fa-solid fa-check fa-fw ms-auto d-none" data-active-indicator></i>
+                                  </button>
+                                </li>
+                            </ul>
                         </li>
                     </ul>
                 </div>

--- a/examples/ExampleHostedAdapter/Pages/_AdapterStatusPartial.cshtml
+++ b/examples/ExampleHostedAdapter/Pages/_AdapterStatusPartial.cshtml
@@ -3,38 +3,32 @@
 
 @{
   string cardColourModifier;
-  string cardTextModifier;
   string statusIcon;
   string statusText;
 
   switch (Model.State) {
     case ExampleHostedAdapter.Pages.IndexModel.AdapterState.Disabled:
       cardColourModifier = "danger";
-      cardTextModifier = "text-white";
       statusIcon = "fa-circle-stop";
       statusText = "Disabled";
       break;
     case ExampleHostedAdapter.Pages.IndexModel.AdapterState.Enabled:
       cardColourModifier = "warning";
-      cardTextModifier = "";
       statusIcon = "fa-circle-half-stroke";
       statusText = "Enabled";
       break;
     case ExampleHostedAdapter.Pages.IndexModel.AdapterState.Running:
       cardColourModifier = "success";
-      cardTextModifier = "text-white";
       statusIcon = "fa-circle-play";
       statusText = "Running";
       break;
     case ExampleHostedAdapter.Pages.IndexModel.AdapterState.RunningWithWarning:
       cardColourModifier = "warning";
-      cardTextModifier = "";
       statusIcon = "fa-circle-exclamation";
       statusText = "Running (Unhealthy)";
       break;
     default:
       cardColourModifier = "light";
-      cardTextModifier = "";
       statusIcon = "fa-circle-question";
       statusText = "Unknown Status";
       break;
@@ -69,16 +63,16 @@
 
 <div class="w-100">
   <div class="card border-@cardColourModifier">
-    <div class="card-header @cardTextModifier bg-@cardColourModifier">
+    <div class="card-header text-bg-@cardColourModifier">
       <i class="fa-solid fa-puzzle-piece fa-fw"></i>
-      Adapter Status
+      Adapter Status: @statusText
     </div>
     <div class="card-body">
 
       <div class="row">
         <div class="col-12 col-lg-2">
           <div class="pb-1">
-            <span data-bs-toggle="popover" data-bs-trigger="hover focus" title="Host Instance ID" data-bs-content="The instance ID of the adapter host. This is used to uniquely identify this adapter host in distributed tracing systems.">
+            <span class="adapter-status-heading" data-bs-toggle="popover" data-bs-trigger="hover focus" title="Host Instance ID" data-bs-content="The instance ID of the adapter host. This is used to uniquely identify this adapter host in distributed tracing systems.">
               <i class="fa-solid fa-network-wired fa-fw"></i>
               Host Instance ID
             </span>
@@ -94,7 +88,7 @@
       <div class="row">
         <div class="col-12 col-lg-2">
           <div class="pb-1">
-            <span data-bs-toggle="popover" data-bs-trigger="hover focus" title="Adapter ID" data-bs-content="The identifier for the adapter. Use this value when configuring the App Store Connect connection to your adapter.">
+            <span class="adapter-status-heading" data-bs-toggle="popover" data-bs-trigger="hover focus" title="Adapter ID" data-bs-content="The identifier for the adapter. Use this value when configuring the App Store Connect connection to your adapter.">
               <i class="fa-solid fa-fingerprint fa-fw"></i>
               Adapter ID
             </span>
@@ -113,7 +107,7 @@
       <div class="row">
         <div class="col-12 col-lg-2">
           <div class="pb-1">
-            <span data-bs-toggle="popover" data-bs-trigger="hover focus" title="Name" data-bs-content="The display name for the adapter.">
+            <span class="adapter-status-heading" data-bs-toggle="popover" data-bs-trigger="hover focus" title="Name" data-bs-content="The display name for the adapter.">
               <i class="fa-solid fa-id-badge fa-fw"></i>
               Name
             </span>
@@ -127,7 +121,7 @@
       <div class="row">
         <div class="col-12 col-lg-2">
           <div class="pb-1">
-            <span data-bs-toggle="popover" data-bs-trigger="hover focus" title="Description" data-bs-content="The adapter description.">
+            <span class="adapter-status-heading" data-bs-toggle="popover" data-bs-trigger="hover focus" title="Description" data-bs-content="The adapter description.">
               <i class="fa-solid fa-circle-info fa-fw"></i>
               Description
             </span>
@@ -141,7 +135,7 @@
       <div class="row">
         <div class="col-12 col-lg-2">
           <div class="pb-1">
-            <span data-bs-toggle="popover" data-bs-trigger="hover focus" title="Driver" data-bs-content="Information about the adapter driver and vendor.">
+            <span class="adapter-status-heading" data-bs-toggle="popover" data-bs-trigger="hover focus" title="Driver" data-bs-content="Information about the adapter driver and vendor.">
               <i class="fa-solid fa-code fa-fw"></i>
               Driver
             </span>
@@ -167,7 +161,7 @@
           <div class="row">
             <div class="col-12 col-lg-2 d-none d-lg-block">
               <div class="pb-1">
-                <span data-bs-toggle="popover" data-bs-trigger="hover focus" title="Features" data-bs-content="The features that the adapter supports.">
+                <span class="adapter-status-heading" data-bs-toggle="popover" data-bs-trigger="hover focus" title="Features" data-bs-content="The features that the adapter supports.">
                   <i class="fa-solid fa-microchip fa-fw"></i>
                   Features
                 </span>
@@ -176,7 +170,7 @@
             <div class="col">
               <div class="pb-1">
                 @foreach (var featureGroup in Model.Adapter.Features.Keys.Select(x => WellKnownFeatures.TryGetFeatureDescriptor(x, out var descriptor) ? descriptor : Model.Adapter.Features[x]!.GetType().CreateFeatureDescriptor()).OrderBy(x => GetFeatureCategory(x!), ExampleHostedAdapter.FeatureCategoryComparer.Instance).ThenBy(x => x!.DisplayName, StringComparer.OrdinalIgnoreCase).ToLookup(x => GetFeatureCategory(x!), StringComparer.OrdinalIgnoreCase)) {
-                  <div class="pb-2">
+                  <div class="pb-2 adapter-status-heading">
                     <i class="fa-solid @GetFeatureIcon(featureGroup.First()!) fa-fw" title="Adapter features: @featureGroup.Key"></i>
                     <span class="d-lg-none">Features: </span>
                     @featureGroup.Key
@@ -186,14 +180,14 @@
                       <div class="col pb-2">
                         <div class="card w-100 h-100 small">
                           <div class="card-body p-2">
-                            <p class="card-title">
+                            <p class="card-title adapter-status-heading">
                               @feature!.DisplayName
                             </p>
                             <p class="card-subtitle">
                               <code>@feature!.Uri</code>
                             </p>
                             @if (!string.IsNullOrWhiteSpace(feature?.Description)) {
-                              <p class="card-text text-muted">
+                              <p class="card-text text-secondary-emphasis">
                                 @feature.Description
                               </p>
                             }
@@ -211,7 +205,7 @@
         <div class="row">
           <div class="col-12 col-lg-2">
             <div class="pb-1">
-              <span data-bs-toggle="popover" data-bs-trigger="hover focus" title="Enabled APIs" data-bs-content="The APIs that can be used to query the adapter.">
+              <span class="adapter-status-heading" data-bs-toggle="popover" data-bs-trigger="hover focus" title="Enabled APIs" data-bs-content="The APIs that can be used to query the adapter.">
                 <i class="fa-solid fa-circle-nodes fa-fw"></i>
                 Enabled APIs
               </span>
@@ -225,7 +219,7 @@
                     <div>@api.Name</div>
                   }
                   else {
-                    <div>@api.Name <span class="small text-muted">(provider: @(string.IsNullOrWhiteSpace(api.Version) ? api.Provider : $"{api.Provider} v{api.Version}"))</span></div>
+                    <div>@api.Name <span class="small text-secondary-emphasis">(provider: @(string.IsNullOrWhiteSpace(api.Version) ? api.Provider : $"{api.Provider} v{api.Version}"))</span></div>
                   }
                 }
               }
@@ -243,7 +237,7 @@
     </div>
 
     <div class="card-footer">
-      <div class="small text-muted">
+      <div class="small text-secondary-emphasis">
         <div class="d-flex justify-content-between">
           <div>
             <i class="fa-solid @statusIcon fa-fw"></i>

--- a/examples/ExampleHostedAdapter/Pages/_AdapterStatusPartial.cshtml.css
+++ b/examples/ExampleHostedAdapter/Pages/_AdapterStatusPartial.cshtml.css
@@ -1,0 +1,3 @@
+﻿.adapter-status-heading, .copy-adapter-id {
+    color: var(--bs-emphasis-color);
+}

--- a/examples/ExampleHostedAdapter/libman.json
+++ b/examples/ExampleHostedAdapter/libman.json
@@ -5,7 +5,7 @@
 
     {
       "provider": "cdnjs",
-      "library": "bootstrap@5.2.0",
+      "library": "bootstrap@5.3.0-alpha1",
       "destination": "wwwroot/lib/bootstrap/",
       "files": [
         "js/*",

--- a/examples/ExampleHostedAdapter/wwwroot/js/site.js
+++ b/examples/ExampleHostedAdapter/wwwroot/js/site.js
@@ -1,4 +1,94 @@
 ﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
-// Write your JavaScript code.
+/*!
+ * Color mode toggler for Bootstrap's docs (https://getbootstrap.com/)
+ * Copyright 2011-2022 The Bootstrap Authors
+ * Licensed under the Creative Commons Attribution 3.0 Unported License.
+ * Modified by Intelligent Plant for use in App Store Connect adapter host app template.
+ */
+
+(() => {
+    'use strict';
+
+    const storedTheme = localStorage.getItem('theme');
+
+    const getPreferredTheme = () => {
+        if (storedTheme) {
+            return storedTheme;
+        }
+
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    const setTheme = function (theme) {
+        if (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            document.documentElement.setAttribute('data-bs-theme', 'dark');
+        } else {
+            document.documentElement.setAttribute('data-bs-theme', theme);
+        }
+
+        const themeToggleButton = document.getElementById('theme-toggle');
+        let themeIcon = themeToggleButton.querySelector('i[data-fa-i2svg] svg');
+        if (!themeIcon) {
+            themeIcon = themeToggleButton.querySelector('i.fa-fw');
+        }
+
+        themeIcon.classList.remove('fa-sun', 'fa-moon', 'fa-circle-half-stroke');
+        switch (theme) {
+            case 'dark':
+                themeIcon.classList.add('fa-moon');
+                break;
+            case 'auto':
+                themeIcon.classList.add('fa-circle-half-stroke');
+                break;
+            case 'light':
+            default:
+                themeIcon.classList.add('fa-sun');
+                break;
+        }
+
+        if (document.documentElement.getAttribute('data-bs-theme') === 'dark') {
+            themeToggleButton.classList.remove('btn-light');
+            themeToggleButton.classList.add('btn-dark');
+        }
+        else {
+            themeToggleButton.classList.remove('btn-dark');
+            themeToggleButton.classList.add('btn-light');
+        }
+    }
+
+    setTheme(getPreferredTheme())
+
+    const showActiveTheme = theme => {
+        const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`);
+
+        document.querySelectorAll('[data-bs-theme-value]').forEach(element => {
+            element.classList.remove('active');
+            element.querySelector('i[data-active-indicator]').classList.add('d-none');
+        });
+
+        btnToActive.classList.add('active');
+        btnToActive.querySelector('i[data-active-indicator]').classList.remove('d-none')
+    }
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+        if (storedTheme !== 'light' || storedTheme !== 'dark') {
+            setTheme(getPreferredTheme());
+        }
+    })
+
+    window.addEventListener('DOMContentLoaded', () => {
+        showActiveTheme(getPreferredTheme());
+
+        document.querySelectorAll('[data-bs-theme-value]')
+            .forEach(toggle => {
+                toggle.addEventListener('click', () => {
+                    const theme = toggle.getAttribute('data-bs-theme-value')
+                    localStorage.setItem('theme', theme)
+                    setTheme(theme)
+                    showActiveTheme(theme)
+                });
+            });
+    });
+})();


### PR DESCRIPTION
This PR updates the example adapter host (and therefore the adapter host template) to use Bootstrap 5.3-alpha1.

Among other things, Bootstrap 5.3 adds support for light/dark mode theming. A light/dark/system-default theme switcher has been added to the template UI.