### PR TITLE
Fixes minimal API validation issues with URI properties

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="$(PkgVersion_Microsoft_Web_LibraryManager_Build)" />
-    <PackageVersion Include="MiniValidation" Version="0.7.2" />
+    <PackageVersion Include="MiniValidation" Version="0.7.4" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />


### PR DESCRIPTION
The MiniValidation NuGet package is used for validating requests in minimal API routes but had issues in versions 0.7.2 and 0.7.3 that meant that requests containing `Uri` request properties would cause exceptions when validated.

The workaround was to have a temporary request types for models that replaced `Uri` properties with `string`s instead, that were then mapped to the original model types.

This issue has been fixed in MiniValidation 0.7.4.