### PR TITLE
Fix warnings when packing templates project in CI build

### DIFF
--- a/DataCore.Adapter.sln
+++ b/DataCore.Adapter.sln
@@ -128,7 +128,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "features", "features", "{4A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.AspNetCore.MinimalApi", "src\DataCore.Adapter.AspNetCore.MinimalApi\DataCore.Adapter.AspNetCore.MinimalApi.csproj", "{7DAD7F07-BE1A-4A33-A9BF-90FFE15D3478}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataCore.Adapter.Compatibility", "src\DataCore.Adapter.Compatibility\DataCore.Adapter.Compatibility.csproj", "{9B6385F3-BDAE-4E8D-8096-7007C67CCE84}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.Compatibility", "src\DataCore.Adapter.Compatibility\DataCore.Adapter.Compatibility.csproj", "{9B6385F3-BDAE-4E8D-8096-7007C67CCE84}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/DataCore.Adapter.Templates/DataCore.Adapter.Templates.csproj
+++ b/src/DataCore.Adapter.Templates/DataCore.Adapter.Templates.csproj
@@ -13,6 +13,7 @@
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,7 +24,7 @@
 
   <ItemGroup>
     <!-- Include files from the ExampleHostedAdapter project. -->
-    <HostedAdapterTemplateFiles Include="..\..\examples\ExampleHostedAdapter\**\*" Exclude="..\..\examples\ExampleHostedAdapter\ExampleHostedAdapter.csproj;..\..\examples\ExampleHostedAdapter\Program.cs;..\..\examples\ExampleHostedAdapter\Directory.Build.props;..\..\examples\ExampleHostedAdapter\README.md;..\..\examples\ExampleHostedAdapter\wwwroot\lib\**;..\..\examples\ExampleHostedAdapter\**\bin\**;..\..\examples\ExampleHostedAdapter\**\obj\**" />
+    <HostedAdapterTemplateFiles Include="..\..\examples\ExampleHostedAdapter\**\*" Exclude="..\..\examples\ExampleHostedAdapter\.*;..\..\examples\ExampleHostedAdapter\ExampleHostedAdapter.csproj;..\..\examples\ExampleHostedAdapter\Program.cs;..\..\examples\ExampleHostedAdapter\Directory.Build.props;..\..\examples\ExampleHostedAdapter\README.md;..\..\examples\ExampleHostedAdapter\wwwroot\lib\**;..\..\examples\ExampleHostedAdapter\**\bin\**;..\..\examples\ExampleHostedAdapter\**\obj\**" />
   </ItemGroup>
 
   <Target Name="CopyAscHostedAdapterTemplateFiles" BeforeTargets="Build">


### PR DESCRIPTION
When packing the DataCore.Adapter.Templates project, two NuGet-related build warnings are raised:

- NU5119: raised because the project that template files are copied from includes a .gitignore file
- NU5128: raised because the templates project file targets .NET Standard 2.0, but uses the `IncludeBuildOutput` property to prevent the project output from included in the package (since the templates package only contains a `content` folder).

CI build is now configured to treat all build warnings as errors which results in the pack task failing because of the above warnings.

The fix adds a new exclusion for template source files that start with `.` and sets the `SuppressDependenciesWhenPacking` build property to `true`.