### PR TITLE
Improve copying of template content files

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -61,7 +61,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=1.6.1
+#load nuget:?package=Jaahas.Cake.Extensions&version=1.6.2
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);

--- a/src/DataCore.Adapter.Templates/DataCore.Adapter.Templates.csproj
+++ b/src/DataCore.Adapter.Templates/DataCore.Adapter.Templates.csproj
@@ -22,22 +22,23 @@
     <None Include="src\**\*" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Include files from the ExampleHostedAdapter project. -->
-    <HostedAdapterTemplateFiles Include="..\..\examples\ExampleHostedAdapter\**\*" Exclude="..\..\examples\ExampleHostedAdapter\.*;..\..\examples\ExampleHostedAdapter\ExampleHostedAdapter.csproj;..\..\examples\ExampleHostedAdapter\Program.cs;..\..\examples\ExampleHostedAdapter\Directory.Build.props;..\..\examples\ExampleHostedAdapter\README.md;..\..\examples\ExampleHostedAdapter\wwwroot\lib\**;..\..\examples\ExampleHostedAdapter\**\bin\**;..\..\examples\ExampleHostedAdapter\**\obj\**" />
-  </ItemGroup>
-
   <Target Name="CopyAscHostedAdapterTemplateFiles" BeforeTargets="Build">
-    <!-- Remove the Properties and wwwroot folders from the template's content folder. -->
-    <RemoveDir Directories="templates\aschostedadapter\Properties;templates\aschostedadapter\wwwroot" />
-    <!-- Remove other files from the template's content folder. -->
-    <Delete Files="templates\aschostedadapter\*" />
-    <!-- Copy all HostedAdapterTemplateFiles items to the template's content folder. -->
-    <Copy SkipUnchangedFiles="false" SourceFiles="@(HostedAdapterTemplateFiles)" DestinationFiles="@(HostedAdapterTemplateFiles->'templates\aschostedadapter\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <!-- Copy the files from the src folder in this project. -->
-    <Copy SkipUnchangedFiles="false" SourceFiles="src\aschostedadapter\ExampleHostedAdapter.csproj" DestinationFiles="templates\aschostedadapter\ExampleHostedAdapter.csproj" />
-    <Copy SkipUnchangedFiles="false" SourceFiles="src\aschostedadapter\Program.cs" DestinationFiles="templates\aschostedadapter\Program.cs" />
-    <Copy SkipUnchangedFiles="false" SourceFiles="src\aschostedadapter\README.md" DestinationFiles="templates\aschostedadapter\README.md" />
+    <ItemGroup>
+      <!-- Delete all files from the template's content folder except for the template 
+           configuration. -->
+      <_FilesToDelete Include="templates\aschostedadapter\**" Exclude="templates\aschostedadapter\.template.config\**" />
+      <!-- Copy files from the ExampleHostedAdapter project. -->
+      <_FilesToCopy Include="..\..\examples\ExampleHostedAdapter\**\*" Exclude="..\..\examples\ExampleHostedAdapter\.gitignore;..\..\examples\ExampleHostedAdapter\README.md;..\..\examples\ExampleHostedAdapter\wwwroot\lib\**;..\..\examples\ExampleHostedAdapter\**\bin\**;..\..\examples\ExampleHostedAdapter\**\obj\**" />
+      <!-- Copy files from the src folder in this project. Note that some of these files 
+           overwrite equivalent files included from the ExampleHostedAdapter project. -->
+      <_FilesToCopy Include=".\src\aschostedadapter\**" />
+    </ItemGroup>
+    
+    <!-- Delete existing files from the template's content folder. -->
+    <Delete Files="@(_FilesToDelete)" />
+    
+    <!-- Copy files to the template's content folder. -->
+    <Copy SkipUnchangedFiles="false" SourceFiles="@(_FilesToCopy)" DestinationFiles="@(_FilesToCopy->'templates\aschostedadapter\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
   
   <Target Name="ReplacePackageVersions" BeforeTargets="Build" AfterTargets="CopyAscHostedAdapterTemplateFiles">

--- a/src/DataCore.Adapter.Templates/src/aschostedadapter/appsettings.json
+++ b/src/DataCore.Adapter.Templates/src/aschostedadapter/appsettings.json
@@ -1,0 +1,31 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      //#if (IsNet7OrLater)
+      "Protocols": "Http1AndHttp2AndHttp3"
+      //#else
+      "Protocols": "Http1AndHttp2"
+      //#endif
+    },
+    "Endpoints": {
+      "Https": {
+        "Url": "https://localhost:44300"
+      }
+    }
+  },
+  "AppStoreConnect": {
+    "Adapter": {
+      "Host": {
+        "InstanceId": "e445a468-19ee-456c-9aac-e26288475a45"
+      }
+    }
+  }
+}

--- a/src/DataCore.Adapter.Templates/templates/aschostedadapter/.template.config/template.json
+++ b/src/DataCore.Adapter.Templates/templates/aschostedadapter/.template.config/template.json
@@ -36,9 +36,13 @@
       "defaultValue": "net6.0",
       "replaces": "net6.0"
     },
-    "UseMinimalApi": {
+    "IsNet7OrLater": {
       "type": "computed",
       "value": "(Framework != \"net6.0\")"
+    },
+    "UseMinimalApi": {
+      "type": "computed",
+      "value": "(IsNet7OrLater)"
     },
     "AdapterOptionsName": {
       "type": "derived",


### PR DESCRIPTION
This PR improves the way that the content files for the adapter host template are copied into the template package.

It also enables HTTP/3 when creating an adapter host project if .NET 7 or higher is being targeted.