### PR TITLE
Health check subscription updates

### DIFF
--- a/src/DataCore.Adapter/AdapterBaseT.cs
+++ b/src/DataCore.Adapter/AdapterBaseT.cs
@@ -420,7 +420,7 @@ namespace DataCore.Adapter {
 
         /// <inheritdoc/>
         protected sealed override async Task StartAsyncCore(CancellationToken cancellationToken) {
-            await _healthCheckManager.Init(cancellationToken).ConfigureAwait(false);
+            await _healthCheckManager.InitAsync(cancellationToken).ConfigureAwait(false);
             await StartAsync(cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/DataCore.Adapter/Diagnostics/HealthCheckManager.cs
+++ b/src/DataCore.Adapter/Diagnostics/HealthCheckManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -30,7 +31,7 @@ namespace DataCore.Adapter.Diagnostics {
         /// <summary>
         /// The most recent health check that was performed.
         /// </summary>
-        private HealthCheckResult? _latestHealthCheck;
+        private HealthCheckResultWithSequenceId? _latestHealthCheck;
 
         /// <summary>
         /// The last subscription ID that was issued.
@@ -40,12 +41,12 @@ namespace DataCore.Adapter.Diagnostics {
         /// <summary>
         /// The active subscriptions.
         /// </summary>
-        private readonly ConcurrentDictionary<int, SubscriptionChannel<string, HealthCheckResult>> _subscriptions = new ConcurrentDictionary<int, SubscriptionChannel<string, HealthCheckResult>>();
+        private readonly ConcurrentDictionary<int, SubscriberRegistration> _subscriptions = new ConcurrentDictionary<int, SubscriberRegistration>();
 
         /// <summary>
         /// Lock to ensure that only a single call to <see cref="CheckHealthAsync"/> is ongoing.
         /// </summary>
-        private readonly SemaphoreSlim _updateLock = new SemaphoreSlim(1, 1);
+        private readonly Nito.AsyncEx.AsyncLock _updateLock = new Nito.AsyncEx.AsyncLock();
 
         /// <summary>
         /// A channel that is used to inform the <see cref="HealthCheckManager{TAdapterOptions}"/> that it should 
@@ -83,13 +84,13 @@ namespace DataCore.Adapter.Diagnostics {
         ///   A <see cref="Task"/> that will initialise the <see cref="HealthCheckManager{TAdapterOptions}"/> and 
         ///   get the initial health status.
         /// </returns>
-        internal async Task Init(CancellationToken cancellationToken) {
+        internal async Task InitAsync(CancellationToken cancellationToken) {
             if (_isDisposed) {
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
             await CheckHealthAsync(new DefaultAdapterCallContext(), cancellationToken).ConfigureAwait(false);
-            _adapter.BackgroundTaskService.QueueBackgroundWorkItem(PublishToHealthCheckSubscribers);
+            _adapter.BackgroundTaskService.QueueBackgroundWorkItem(ProcessRecomputeHealthChannelAsync);
         }
 
 
@@ -105,55 +106,85 @@ namespace DataCore.Adapter.Diagnostics {
         /// <summary>
         /// Long-running task that monitors the <see cref="_recomputeHealthChannel"/>, 
         /// recalculates the adapter health when messages are published to the channel, and then 
-        /// publishes he health status to subscribers.
+        /// publishes the updated health status to subscribers.
         /// </summary>
         /// <param name="cancellationToken">
         ///   A cancellation token that can be used to stop processing of the queue.
         /// </param>
         /// <returns>
-        ///   A task that will complete when the cancellation token fires
+        ///   A task that will complete when the cancellation token fires.
         /// </returns>
-        private async Task PublishToHealthCheckSubscribers(CancellationToken cancellationToken) {
+        private async Task ProcessRecomputeHealthChannelAsync(CancellationToken cancellationToken) {
             while (await _recomputeHealthChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false)) {
                 if (!_recomputeHealthChannel.Reader.TryRead(out var val) || !val) {
                     continue;
                 }
 
-                var subscribers = _subscriptions.Values.ToArray();
-
-                var update = await CheckHealthAsync(
+                var update = await CheckHealthAsyncCore(
                     new DefaultAdapterCallContext(),
                     cancellationToken
                 ).ConfigureAwait(false);
 
-                _latestHealthCheck = update;
+                await PublishToHealthCheckSubscribers(update, cancellationToken).ConfigureAwait(false);
+            }
+        }
 
-                if (subscribers.Length == 0) {
-                    continue;
+
+        /// <summary>
+        /// Publishes the specified health check update to all subscribers.
+        /// </summary>
+        /// <param name="update">
+        ///   The health check update.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will publish the update to the subscribers.
+        /// </returns>
+        private async ValueTask PublishToHealthCheckSubscribers(HealthCheckResultWithSequenceId update, CancellationToken cancellationToken) {
+            var subscribers = _subscriptions.Values;
+
+            if (subscribers.Count == 0) {
+                return;
+            }
+
+            foreach (var registration in subscribers) {
+                if (cancellationToken.IsCancellationRequested) {
+                    break;
                 }
 
-                foreach (var subscriber in subscribers) {
-                    if (cancellationToken.IsCancellationRequested) {
-                        break;
+                try {
+                    var success = await registration.PublishAsync(update, false).ConfigureAwait(false);
+                    if (!success) {
+                        _adapter.Logger.LogTrace(Resources.Log_PublishToSubscriberWasUnsuccessful, registration.Subscriber.Context?.ConnectionId);
                     }
-
-                    try {
-                        var success = subscriber.Publish(update);
-                        if (!success) {
-                            _adapter.Logger.LogTrace(Resources.Log_PublishToSubscriberWasUnsuccessful, subscriber.Context?.ConnectionId);
-                        }
-                    }
-                    catch (OperationCanceledException) { }
-                    catch (Exception e) {
-                        _adapter.Logger.LogError(e, Resources.Log_PublishToSubscriberThrewException, subscriber.Context?.ConnectionId);
-                    }
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception e) {
+                    _adapter.Logger.LogError(e, Resources.Log_PublishToSubscriberThrewException, registration.Subscriber.Context?.ConnectionId);
                 }
             }
         }
 
 
-        /// <inheritdoc/>
-        public async Task<HealthCheckResult> CheckHealthAsync(IAdapterCallContext context, CancellationToken cancellationToken) {
+        /// <summary>
+        /// Checks the health of the adapter and updates the <see cref="_latestHealthCheck"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/> for the operation.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns></returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   The <see cref="HealthCheckManager{TAdapterOptions}"/> has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="context"/> is <see langword="null"/>.
+        /// </exception>
+        private async Task<HealthCheckResultWithSequenceId> CheckHealthAsyncCore(IAdapterCallContext context, CancellationToken cancellationToken) {
             if (_isDisposed) {
                 throw new ObjectDisposedException(GetType().FullName);
             }
@@ -162,50 +193,55 @@ namespace DataCore.Adapter.Diagnostics {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            await _updateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try {
-                var results = await _adapter.CheckHealthAsync(context, cancellationToken).ConfigureAwait(false);
-                if (results == null || !results.Any()) {
-                    _latestHealthCheck = HealthCheckResult.Healthy(Resources.HealthChecks_DisplayName_OverallAdapterHealth, Resources.HealthChecks_CompositeResultDescription_Healthy);
+            using (await _updateLock.LockAsync(cancellationToken).ConfigureAwait(false)) {
+                try {
+                    var results = await _adapter.CheckHealthAsync(context, cancellationToken).ConfigureAwait(false);
+                    if (results == null || !results.Any()) {
+                        _latestHealthCheck = new HealthCheckResultWithSequenceId(HealthCheckResult.Healthy(Resources.HealthChecks_DisplayName_OverallAdapterHealth, Resources.HealthChecks_CompositeResultDescription_Healthy));
+                        return _latestHealthCheck.Value;
+                    }
+
+                    var resultsArray = results.ToArray();
+
+                    var compositeStatus = HealthCheckResult.GetAggregateHealthStatus(resultsArray.Select(x => x.Status));
+                    string description;
+
+                    switch (compositeStatus) {
+                        case HealthStatus.Unhealthy:
+                            description = Resources.HealthChecks_CompositeResultDescription_Unhealthy;
+                            break;
+                        case HealthStatus.Degraded:
+                            description = Resources.HealthChecks_CompositeResultDescription_Degraded;
+                            break;
+                        default:
+                            description = Resources.HealthChecks_CompositeResultDescription_Healthy;
+                            break;
+                    }
+
+                    _latestHealthCheck = new HealthCheckResultWithSequenceId(new HealthCheckResult(Resources.HealthChecks_DisplayName_OverallAdapterHealth, compositeStatus, description, null, null, resultsArray));
                     return _latestHealthCheck.Value;
                 }
-
-                var resultsArray = results.ToArray();
-
-                var compositeStatus = HealthCheckResult.GetAggregateHealthStatus(resultsArray.Select(x => x.Status));
-                string description;
-
-                switch (compositeStatus) {
-                    case HealthStatus.Unhealthy:
-                        description = Resources.HealthChecks_CompositeResultDescription_Unhealthy;
-                        break;
-                    case HealthStatus.Degraded:
-                        description = Resources.HealthChecks_CompositeResultDescription_Degraded;
-                        break;
-                    default:
-                        description = Resources.HealthChecks_CompositeResultDescription_Healthy;
-                        break;
+                catch (OperationCanceledException) {
+                    throw;
                 }
-
-                _latestHealthCheck = new HealthCheckResult(Resources.HealthChecks_DisplayName_OverallAdapterHealth, compositeStatus, description, null, null, resultsArray);
-
-                return _latestHealthCheck.Value;
-            }
-            catch (OperationCanceledException) {
-                throw;
-            }
-            catch (Exception e) {
-                return HealthCheckResult.Unhealthy(Resources.HealthChecks_DisplayName_OverallAdapterHealth, Resources.HealthChecks_CompositeResultDescription_Error, e.Message);
-            }
-            finally {
-                _updateLock.Release();
+                catch (Exception e) {
+                    return new HealthCheckResultWithSequenceId(HealthCheckResult.Unhealthy(Resources.HealthChecks_DisplayName_OverallAdapterHealth, Resources.HealthChecks_CompositeResultDescription_Error, e.Message));
+                }
             }
         }
 
 
         /// <inheritdoc/>
-        public IAsyncEnumerable<HealthCheckResult> Subscribe(
-            IAdapterCallContext context, 
+        public async Task<HealthCheckResult> CheckHealthAsync(IAdapterCallContext context, CancellationToken cancellationToken) {
+            var result = _latestHealthCheck ?? await CheckHealthAsyncCore(context, cancellationToken).ConfigureAwait(false);
+            return result.Result;
+        }
+
+
+        /// <inheritdoc/>
+        public async IAsyncEnumerable<HealthCheckResult> Subscribe(
+            IAdapterCallContext context,
+            [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
             if (_isDisposed) {
@@ -230,14 +266,17 @@ namespace DataCore.Adapter.Diagnostics {
                 10
             );
 
+            var registration = new SubscriberRegistration(subscription);
+            _subscriptions[subscriptionId] = registration;
+
             var latestResult = _latestHealthCheck;
             if (latestResult != null) {
-                subscription.Publish(latestResult.Value, true);
+                await registration.PublishAsync(latestResult.Value, true).ConfigureAwait(false);
             }
 
-            _subscriptions[subscriptionId] = subscription;
-
-            return subscription.ReadAllAsync(cancellationToken);
+            await foreach (var item in subscription.ReadAllAsync(cancellationToken).ConfigureAwait(false)) {
+                yield return item;
+            }
         }
 
 
@@ -256,7 +295,7 @@ namespace DataCore.Adapter.Diagnostics {
                 return;
             }
 
-            subscription.Dispose();
+            subscription.Subscriber.Dispose();
         }
 
 
@@ -266,12 +305,113 @@ namespace DataCore.Adapter.Diagnostics {
                 return;
             }
 
-            _updateLock.Dispose();
             foreach (var subscription in _subscriptions.Values.ToArray()) {
-                subscription.Dispose();
+                subscription.Subscriber.Dispose();
             }
             _subscriptions.Clear();
             _isDisposed = true;
+        }
+
+
+        /// <summary>
+        /// Wraps a <see cref="HealthCheckResult"/> to include a sequence ID as well, so that a 
+        /// subscription can choose to ignore the result if it is older than the most-recent 
+        /// result received by the subscriber.
+        /// </summary>
+        private readonly struct HealthCheckResultWithSequenceId {
+
+            /// <summary>
+            /// The sequence ID of the most-recent <see cref="HealthCheckResultWithSequenceId"/>.
+            /// </summary>
+            private static long s_lastSequenceId;
+        
+            /// <summary>
+            /// The <see cref="HealthCheckResult"/>.
+            /// </summary>
+            public HealthCheckResult Result { get; }
+
+            /// <summary>
+            /// The sequence ID for the result.
+            /// </summary>
+            public long SequenceId { get; }
+
+
+            /// <summary>
+            /// Creates a new <see cref="HealthCheckResultWithSequenceId"/> instance.
+            /// </summary>
+            /// <param name="result">
+            ///   The <see cref="HealthCheckResult"/>.
+            /// </param>
+            public HealthCheckResultWithSequenceId(HealthCheckResult result) {
+                Result = result;
+                SequenceId = Interlocked.Increment(ref s_lastSequenceId);
+            }
+
+        }
+
+
+        /// <summary>
+        /// Wrapper for a health check subscription channel that will only accept updates that are 
+        /// newer than the last update published to the channel.
+        /// </summary>
+        private class SubscriberRegistration {
+
+            /// <summary>
+            /// Ensures that only one publish can occur at a time.
+            /// </summary>
+            private readonly Nito.AsyncEx.AsyncLock _publishLock = new Nito.AsyncEx.AsyncLock();
+
+            /// <summary>
+            /// The subscription channel.
+            /// </summary>
+            public SubscriptionChannel<string, HealthCheckResult> Subscriber { get; }
+
+            /// <summary>
+            /// The sequence ID of the last update that was published to the <see cref="Subscriber"/>.
+            /// </summary>
+            public long? LastSequenceId { get; private set; }
+
+
+            /// <summary>
+            /// Creates a new <see cref="SubscriberRegistration"/> instance.
+            /// </summary>
+            /// <param name="subscriber">
+            ///   The subscription channel.
+            /// </param>
+            public SubscriberRegistration(SubscriptionChannel<string, HealthCheckResult> subscriber) {
+                Subscriber = subscriber;
+            }
+
+
+            /// <summary>
+            /// Publishes a health check result to the subscriber.
+            /// </summary>
+            /// <param name="message">
+            ///   The health check result.
+            /// </param>
+            /// <param name="immediate">
+            ///   Specifies if the message should be published immediately to the subscriber, even 
+            ///   if it normally emits new updates on a periodic basis.
+            /// </param>
+            /// <returns>
+            ///   <see langword="true"/> if the <paramref name="message"/> was successfully 
+            ///   published, or <see langword="false"/> otherwise.
+            /// </returns>
+            public async ValueTask<bool> PublishAsync(HealthCheckResultWithSequenceId message, bool immediate) {
+                using (await _publishLock.LockAsync().ConfigureAwait(false)) {
+                    // LastSequenceId.Value > 0 && message.SequenceId < 0 clause here handles
+                    // scenarios where the sequence ID has wrapped around from long.MaxValue to
+                    // long.MinValue.
+                    var canPublish = !LastSequenceId.HasValue || message.SequenceId > LastSequenceId.Value || LastSequenceId.Value > 0 && message.SequenceId < 0;
+                    if (!canPublish) {
+                        return false;
+                    }
+
+                    LastSequenceId = message.SequenceId;
+                    return Subscriber.Publish(message.Result, immediate);
+                }
+            }
+
         }
 
     }


### PR DESCRIPTION
Fixes #307.

Changes how `HealthCheckManager<TAdapterOptions>` registers new subscriptions and publishes updates to subscribers:

- New subscribers are registered before the latest health check result is published to them. This ensures that, if the adapter health is being recalculated while the subscription is registered, the new subscriber will always receive the most-recent update.
- Each health status update is assigned a sequence ID. A registered subscription will only allow an update to be published to its subscription channel if the update has a more-recent sequence ID than the last message that was published to the channel.
- Sequence IDs are incremented using `Interlocked.Increment`, meaning that the ID will wrap around from `long.MaxValue` to `long.MinValue` if required.