### PR TITLE
Handle undefined values in JsonElementConverter

### DIFF
--- a/src/DataCore.Adapter.Json.Newtonsoft/JsonElementConverter.cs
+++ b/src/DataCore.Adapter.Json.Newtonsoft/JsonElementConverter.cs
@@ -10,9 +10,37 @@ namespace DataCore.Adapter.NewtonsoftJson {
     /// </summary>
     public class JsonElementConverter : JsonConverter<System.Text.Json.JsonElement> {
 
+        /// <summary>
+        /// System.Text.Json serializer options.
+        /// </summary>
+        private System.Text.Json.JsonSerializerOptions? _stjOptions;
+
+
+        /// <summary>
+        /// Creates a new <see cref="JsonElementConverter"/> instance.
+        /// </summary>
+        public JsonElementConverter(): this(null) { }
+
+
+        /// <summary>
+        /// Creates a new <see cref="JsonElementConverter"/> instance using the specified 
+        /// <see cref="System.Text.Json.JsonSerializerOptions"/>.
+        /// </summary>
+        /// <param name="options">
+        ///   The <see cref="System.Text.Json.JsonSerializerOptions"/> to use.
+        /// </param>
+        public JsonElementConverter(System.Text.Json.JsonSerializerOptions? options) {
+            _stjOptions = options;
+        }
+
+
         /// <inheritdoc/>
         public override void WriteJson(JsonWriter writer, System.Text.Json.JsonElement value, JsonSerializer serializer) {
-            writer.WriteRawValue(value.ToString());
+            if (value.ValueKind == System.Text.Json.JsonValueKind.Undefined) {
+                writer.WriteNull();
+                return;
+            }
+            writer.WriteRawValue(System.Text.Json.JsonSerializer.Serialize(value, _stjOptions));
         }
 
 
@@ -21,7 +49,7 @@ namespace DataCore.Adapter.NewtonsoftJson {
             var token = serializer.Deserialize<JToken>(reader);
             return token == null 
                 ? default 
-                : System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(token.ToString());
+                : System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(token.ToString(), _stjOptions);
         }
 
     }

--- a/src/DataCore.Adapter.Json.Newtonsoft/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Json.Newtonsoft/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+DataCore.Adapter.NewtonsoftJson.JsonElementConverter.JsonElementConverter(System.Text.Json.JsonSerializerOptions? options) -> void


### PR DESCRIPTION
Fixes #310.

Updates `JsonElementConverter` to serialize instances with a `ValueKind` property of `System.Text.Json.JsonValueKind.Undefined` as `null`.

This is not an ideal approach, but undefined values currently get serialized as an empty token (which produces invalid JSON) and using `JsonWriter.WriteUndefined` writes a token of `undefined`, which is also invalid JSON.

Writing a `null` value means that the `JsonElement` and its serialized version are no longer equivalent, but it means that we produce valid JSON which is a more important factor.