### PR TITLE
Handle undefined values in NullableJsonElementConverter

### DIFF
--- a/src/DataCore.Adapter.Json.Newtonsoft/JsonElementConverter.cs
+++ b/src/DataCore.Adapter.Json.Newtonsoft/JsonElementConverter.cs
@@ -54,31 +54,4 @@ namespace DataCore.Adapter.NewtonsoftJson {
 
     }
 
-
-    /// <summary>
-    /// <see cref="JsonConverter{T}"/> for a nullable <see cref="System.Text.Json.JsonElement"/>.
-    /// </summary>
-    public class NullableJsonElementConverter : JsonConverter<System.Text.Json.JsonElement?> {
-
-        /// <inheritdoc/>
-        public override void WriteJson(JsonWriter writer, System.Text.Json.JsonElement? value, JsonSerializer serializer) {
-            if (value == null) {
-                writer.WriteNull();
-                return;
-            }
-
-            writer.WriteRawValue(value.Value.ToString());
-        }
-
-
-        /// <inheritdoc/>
-        public override System.Text.Json.JsonElement? ReadJson(JsonReader reader, Type objectType, System.Text.Json.JsonElement? existingValue, bool hasExistingValue, JsonSerializer serializer) {
-            var token = serializer.Deserialize<JToken>(reader);
-            return token == null
-                ? default
-                : System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(token.ToString());
-        }
-
-    }
-
 }

--- a/src/DataCore.Adapter.Json.Newtonsoft/JsonSerializerSettingsExtensions.cs
+++ b/src/DataCore.Adapter.Json.Newtonsoft/JsonSerializerSettingsExtensions.cs
@@ -21,7 +21,7 @@ namespace DataCore.Adapter.NewtonsoftJson {
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            settings.Converters.AddDataCoreAdapterConverters();
+            settings.AddDataCoreAdapterConverters(null);
 
         }
 
@@ -37,10 +37,48 @@ namespace DataCore.Adapter.NewtonsoftJson {
                 throw new ArgumentNullException(nameof(converters));
             }
 
-            converters.Add(new JsonElementConverter());
-            converters.Add(new NullableJsonElementConverter());
-            converters.Add(new VariantConverter());
+            converters.AddDataCoreAdapterConverters(null);
+        }
 
+
+        /// <summary>
+        /// Registers adapter-related converters.
+        /// </summary>
+        /// <param name="settings">
+        ///   The JSON serialization settings.
+        /// </param>
+        /// <param name="jsonElementConverterOptions">
+        ///   The <see cref="System.Text.Json.JsonSerializerOptions"/> to use with the <see cref="JsonElementConverter"/> 
+        ///   registered by this method.
+        /// </param>
+        public static void AddDataCoreAdapterConverters(this JsonSerializerSettings settings, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) {
+            if (settings == null) {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.Converters.AddDataCoreAdapterConverters(jsonElementConverterOptions);
+
+        }
+
+
+        /// <summary>
+        /// Registers adapter-related converters.
+        /// </summary>
+        /// <param name="converters">
+        ///   The JSON converter collection to add new converters to.
+        /// </param>
+        /// <param name="jsonElementConverterOptions">
+        ///   The <see cref="System.Text.Json.JsonSerializerOptions"/> to use with the <see cref="JsonElementConverter"/> 
+        ///   registered by this method.
+        /// </param>
+        public static void AddDataCoreAdapterConverters(this ICollection<JsonConverter> converters, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) {
+            if (converters == null) {
+                throw new ArgumentNullException(nameof(converters));
+            }
+
+            converters.Add(new JsonElementConverter(jsonElementConverterOptions));
+            converters.Add(new NullableJsonElementConverter(jsonElementConverterOptions));
+            converters.Add(new VariantConverter());
         }
 
     }

--- a/src/DataCore.Adapter.Json.Newtonsoft/NullableJsonElementConverter.cs
+++ b/src/DataCore.Adapter.Json.Newtonsoft/NullableJsonElementConverter.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+
+namespace DataCore.Adapter.NewtonsoftJson {
+
+    /// <summary>
+    /// <see cref="JsonConverter{T}"/> for a nullable <see cref="System.Text.Json.JsonElement"/>.
+    /// </summary>
+    public class NullableJsonElementConverter : JsonConverter<System.Text.Json.JsonElement?> {
+
+        /// <summary>
+        /// System.Text.Json serializer options.
+        /// </summary>
+        private System.Text.Json.JsonSerializerOptions? _stjOptions;
+
+
+        /// <summary>
+        /// Creates a new <see cref="JsonElementConverter"/> instance.
+        /// </summary>
+        public NullableJsonElementConverter() : this(null) { }
+
+
+        /// <summary>
+        /// Creates a new <see cref="NullableJsonElementConverter"/> instance using the specified 
+        /// <see cref="System.Text.Json.JsonSerializerOptions"/>.
+        /// </summary>
+        /// <param name="options">
+        ///   The <see cref="System.Text.Json.JsonSerializerOptions"/> to use.
+        /// </param>
+        public NullableJsonElementConverter(System.Text.Json.JsonSerializerOptions? options) {
+            _stjOptions = options;
+        }
+
+
+        /// <inheritdoc/>
+        public override void WriteJson(JsonWriter writer, System.Text.Json.JsonElement? value, JsonSerializer serializer) {
+            if (value == null || value.Value.ValueKind == System.Text.Json.JsonValueKind.Undefined) {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.WriteRawValue(System.Text.Json.JsonSerializer.Serialize(value.Value, _stjOptions));
+        }
+
+
+        /// <inheritdoc/>
+        public override System.Text.Json.JsonElement? ReadJson(JsonReader reader, Type objectType, System.Text.Json.JsonElement? existingValue, bool hasExistingValue, JsonSerializer serializer) {
+            var token = serializer.Deserialize<JToken>(reader);
+            return token == null
+                ? default
+                : System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(token.ToString(), _stjOptions);
+        }
+
+    }
+
+}

--- a/src/DataCore.Adapter.Json.Newtonsoft/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Json.Newtonsoft/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 ﻿#nullable enable
 DataCore.Adapter.NewtonsoftJson.JsonElementConverter.JsonElementConverter(System.Text.Json.JsonSerializerOptions? options) -> void
+DataCore.Adapter.NewtonsoftJson.NullableJsonElementConverter.NullableJsonElementConverter(System.Text.Json.JsonSerializerOptions? options) -> void
+static DataCore.Adapter.NewtonsoftJson.JsonSerializerSettingsExtensions.AddDataCoreAdapterConverters(this Newtonsoft.Json.JsonSerializerSettings! settings, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) -> void
+static DataCore.Adapter.NewtonsoftJson.JsonSerializerSettingsExtensions.AddDataCoreAdapterConverters(this System.Collections.Generic.ICollection<Newtonsoft.Json.JsonConverter!>! converters, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) -> void


### PR DESCRIPTION
Fixes #313.

Updates `NullableJsonElementConverter` to serialize instances with a `ValueKind` property of `System.Text.Json.JsonValueKind.Undefined` as `null`. Notes around this decision can be viewed in #310 and #311.