### PR TITLE
Allow TagValueBuilder to set visualization hints

### DIFF
--- a/src/DataCore.Adapter.Core/Common/VariantExtensions.cs
+++ b/src/DataCore.Adapter.Core/Common/VariantExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace DataCore.Adapter.Common {
 
@@ -98,9 +97,7 @@ namespace DataCore.Adapter.Common {
         /// All other types are considered to be non-numeric.
         /// 
         /// </remarks>
-        public static bool IsNumericType(this Variant variant) {
-            return variant.Type.IsNumericType();
-        }
+        public static bool IsNumericType(this Variant variant) => variant.Type.IsNumericType();
 
 
         /// <summary>
@@ -169,6 +166,68 @@ namespace DataCore.Adapter.Common {
                 case VariantType.UInt16:
                 case VariantType.UInt32:
                 case VariantType.UInt64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+
+        /// <summary>
+        /// Tests if the type of the variant is a floating-point numeric type.
+        /// </summary>
+        /// <param name="variant">
+        ///   The variant.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the variant's <see cref="Variant.Type"/> indicates that 
+        ///   its value is a floating-point value, or <see langword="false"/> otherwise.
+        /// </returns>
+        /// <remarks>
+        /// 
+        /// The following types are treated as floating-point:
+        /// 
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="VariantType.Double"/></description>
+        ///   </item>
+        ///   <item>
+        ///     <description><see cref="VariantType.Float"/></description>
+        ///   </item>
+        /// </list>
+        /// 
+        /// </remarks>
+        public static bool IsFloatingPointNumericType(this Variant variant) => variant.Type.IsFloatingPointNumericType();
+
+
+        /// <summary>
+        /// Tests if the variant type is a floating-point numeric type.
+        /// </summary>
+        /// <param name="variantType">
+        ///   The variant type.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the variant's <see cref="Variant.Type"/> indicates that 
+        ///   its value is a floating-point value, or <see langword="false"/> otherwise.
+        /// </returns>
+        /// <remarks>
+        /// 
+        /// The following types are treated as floating-point:
+        /// 
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="VariantType.Double"/></description>
+        ///   </item>
+        ///   <item>
+        ///     <description><see cref="VariantType.Float"/></description>
+        ///   </item>
+        /// </list>
+        /// 
+        /// </remarks>
+        public static bool IsFloatingPointNumericType(this VariantType variantType) {
+            switch (variantType) {
+                case VariantType.Double:
+                case VariantType.Float:
                     return true;
                 default:
                     return false;

--- a/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
 const DataCore.Adapter.WellKnownProperties.TagValue.Stepped = "Stepped" -> string!
 static DataCore.Adapter.Common.VariantExtensions.IsFloatingPointNumericType(this DataCore.Adapter.Common.Variant variant) -> bool
+static DataCore.Adapter.Common.VariantExtensions.IsFloatingPointNumericType(this DataCore.Adapter.Common.VariantType variantType) -> bool
 static DataCore.Adapter.RealTimeData.TagValueExtensions.IsFloatingPointNumericType(this DataCore.Adapter.RealTimeData.TagValue! value) -> bool

--- a/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 ﻿#nullable enable
+const DataCore.Adapter.WellKnownProperties.TagValue.Stepped = "Stepped" -> string!
+static DataCore.Adapter.Common.VariantExtensions.IsFloatingPointNumericType(this DataCore.Adapter.Common.Variant variant) -> bool
+static DataCore.Adapter.RealTimeData.TagValueExtensions.IsFloatingPointNumericType(this DataCore.Adapter.RealTimeData.TagValue! value) -> bool

--- a/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@ const DataCore.Adapter.WellKnownProperties.TagValue.Stepped = "Stepped" -> strin
 static DataCore.Adapter.Common.VariantExtensions.IsFloatingPointNumericType(this DataCore.Adapter.Common.Variant variant) -> bool
 static DataCore.Adapter.Common.VariantExtensions.IsFloatingPointNumericType(this DataCore.Adapter.Common.VariantType variantType) -> bool
 static DataCore.Adapter.RealTimeData.TagValueExtensions.IsFloatingPointNumericType(this DataCore.Adapter.RealTimeData.TagValue! value) -> bool
+static DataCore.Adapter.RealTimeData.TagValueExtensions.TryGetSteppedFlag(this DataCore.Adapter.RealTimeData.TagValueExtended! value, out bool stepped) -> bool

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValueExtensions.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValueExtensions.cs
@@ -74,6 +74,40 @@ namespace DataCore.Adapter.RealTimeData {
 
 
         /// <summary>
+        /// Tests if the <see cref="TagValue.Value"/> of a <see cref="TagValue"/> has a floating-point 
+        /// numeric type.
+        /// </summary>
+        /// <param name="value">
+        ///   The <see cref="TagValue"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the <see cref="TagValue.Value"/> has a floating-point numeric 
+        ///   type, or <see langword="false"/> otherwise.
+        /// </returns>
+        /// <remarks>
+        /// 
+        /// The following types are treated as floating-point:
+        /// 
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="VariantType.Double"/></description>
+        ///   </item>
+        ///   <item>
+        ///     <description><see cref="VariantType.Float"/></description>
+        ///   </item>
+        /// </list>
+        /// 
+        /// </remarks>
+        public static bool IsFloatingPointNumericType(this TagValue value) {
+            if (value == null) {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return value.Value.IsFloatingPointNumericType();
+        }
+
+
+        /// <summary>
         /// Gets the first value in the <see cref="TagValue"/> that can be cast to the specified 
         /// type, or returns a default value.
         /// </summary>

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValueExtensions.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValueExtensions.cs
@@ -183,5 +183,37 @@ namespace DataCore.Adapter.RealTimeData {
             return displayValue != null;
         }
 
+
+        /// <summary>
+        /// Tests if the <see cref="TagValueExtended"/> specifies a value for the <see cref="WellKnownProperties.TagValue.Stepped"/> 
+        /// property and returns the value of the property if it is defined.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="stepped"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <remarks>
+        ///   Note that this method only detects if a <see cref="TagValueExtended"/> explicitly 
+        ///   provides a display hint that it represents a stepped transition. Consuming applications 
+        ///   should assume that default visualization behaviour applies unless a hint is specified 
+        ///   on the sample. For example, samples from analogue tags should generally be visualized 
+        ///   using linear interpolation if the samples do not explicitly specify if they use stepped
+        ///   transitions or not.
+        /// </remarks>
+        public static bool TryGetSteppedFlag(this TagValueExtended value, out bool stepped) {
+            if (value == null) {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var prop = value.Properties.FirstOrDefault(x => x.Name.Equals(WellKnownProperties.TagValue.Stepped, StringComparison.OrdinalIgnoreCase));
+            if (prop == null) {
+                stepped = false;
+                return false;
+            }
+
+            stepped = prop.Value.GetValueOrDefault<bool>();
+            return true;
+        }
+
     }
 }

--- a/src/DataCore.Adapter.Core/WellKnownProperties.cs
+++ b/src/DataCore.Adapter.Core/WellKnownProperties.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace DataCore.Adapter {
 
@@ -25,6 +23,16 @@ namespace DataCore.Adapter {
             ///   the digital state.
             /// </remarks>
             public const string DisplayValue = "Display-Value";
+
+            /// <summary>
+            /// Specifies if a tag value represents a stepped value transition (such as a discrete 
+            /// value change on a digital tag or an analogue process limit). 
+            /// </summary>
+            /// <remarks>
+            ///   This property can be used to provide a hint to an application about how a tag 
+            ///   value should be visualized.
+            /// </remarks>
+            public const string Stepped = "Stepped";
 
         }
 

--- a/src/DataCore.Adapter/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 ﻿#nullable enable
+DataCore.Adapter.RealTimeData.TagValueBuilder.WithSteppedTransition(bool stepped) -> DataCore.Adapter.RealTimeData.TagValueBuilder!
 static DataCore.Adapter.Security.CertificateUtilities.TryLoadCertificateFromStore(string! path, bool requirePrivateKey, bool allowInvalid, out System.Security.Cryptography.X509Certificates.X509Certificate2? certificate) -> bool

--- a/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
@@ -172,7 +172,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// </returns>
         public TagValueBuilder WithValue(Variant value, string? displayValue = null) {
             _value = value;
-            var existingDisplayValue = _properties.RemoveAll(x => x.Name.Equals(WellKnownProperties.TagValue.DisplayValue, StringComparison.OrdinalIgnoreCase));
+            var _ = _properties.RemoveAll(x => x.Name.Equals(WellKnownProperties.TagValue.DisplayValue, StringComparison.OrdinalIgnoreCase));
             if (displayValue != null) {
                 return WithProperty(WellKnownProperties.TagValue.DisplayValue, displayValue);
             }
@@ -265,6 +265,36 @@ namespace DataCore.Adapter.RealTimeData {
                 _status = TagValueStatus.Bad;
             }
             return this;
+        }
+
+
+        /// <summary>
+        /// Specifies if a tag value represents a stepped value transition (such as a discrete 
+        /// value change on a digital tag or an analogue process limit). 
+        /// </summary>
+        /// <param name="stepped">
+        ///   <see langword="true"/> if the tag value represents a stepped value transition, or 
+        ///   <see langword="false"/> otherwise.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TagValueBuilder"/>.
+        /// </returns>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   Calling <see cref="WithSteppedTransition"/> sets the <see cref="WellKnownProperties.TagValue.Stepped"/> 
+        ///   property on the tag value.
+        /// </para>
+        /// 
+        /// <para>
+        ///   Consuming applications can use this property as a hint regarding how the time series 
+        ///   data should be visualized.
+        /// </para>
+        /// 
+        /// </remarks>
+        public TagValueBuilder WithSteppedTransition(bool stepped) {
+            var _ = _properties.RemoveAll(x => x.Name.Equals(WellKnownProperties.TagValue.Stepped, StringComparison.OrdinalIgnoreCase));
+            return WithProperty(WellKnownProperties.TagValue.Stepped, stepped);
         }
 
 


### PR DESCRIPTION
Fixes #315.

Adds a `WithSteppedTransition(bool)` method to `TagValueBuilder` to allow an individual sample to specify if it represents a stepped transition instead of a linear transition.

A new well-known `Stepped` property has been added to store this flag on the sample as a custom property.