### PR TITLE
Update package references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,55 +10,55 @@
   project. 
   -->
   <PropertyGroup>
-    <PkgVersion_OpenTelemetry>1.4.0</PkgVersion_OpenTelemetry>
-    <PkgVersion_OpenTelemetry_Api>1.4.0</PkgVersion_OpenTelemetry_Api>
-    <PkgVersion_OpenTelemetry_Exporter_Console>1.4.0</PkgVersion_OpenTelemetry_Exporter_Console>
-    <PkgVersion_OpenTelemetry_Exporter_Jaeger>1.4.0</PkgVersion_OpenTelemetry_Exporter_Jaeger>
-    <PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>1.4.0-rc.4</PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>
-    <PkgVersion_OpenTelemetry_Extensions_Hosting>1.4.0</PkgVersion_OpenTelemetry_Extensions_Hosting>
-    <PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>1.0.0-rc9.14</PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>
-    <PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>1.0.0-rc9.14</PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>
-    <PkgVersion_OpenTelemetry_Instrumentation_Http>1.0.0-rc9.14</PkgVersion_OpenTelemetry_Instrumentation_Http>
-    <PkgVersion_OpenTelemetry_Instrumentation_Runtime>1.1.0-rc.2</PkgVersion_OpenTelemetry_Instrumentation_Runtime>
-    <PkgVersion_OpenTelemetry_Instrumentation_SqlClient>1.0.0-rc9.14</PkgVersion_OpenTelemetry_Instrumentation_SqlClient>
+    <PkgVersion_OpenTelemetry>1.5.0</PkgVersion_OpenTelemetry>
+    <PkgVersion_OpenTelemetry_Api>1.5.0</PkgVersion_OpenTelemetry_Api>
+    <PkgVersion_OpenTelemetry_Exporter_Console>1.5.0</PkgVersion_OpenTelemetry_Exporter_Console>
+    <PkgVersion_OpenTelemetry_Exporter_Jaeger>1.5.0</PkgVersion_OpenTelemetry_Exporter_Jaeger>
+    <PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>1.5.0-rc.1</PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>
+    <PkgVersion_OpenTelemetry_Extensions_Hosting>1.5.0</PkgVersion_OpenTelemetry_Extensions_Hosting>
+    <PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>1.5.0-beta.1</PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>
+    <PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>1.5.0-beta.1</PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>
+    <PkgVersion_OpenTelemetry_Instrumentation_Http>1.5.0-beta.1</PkgVersion_OpenTelemetry_Instrumentation_Http>
+    <PkgVersion_OpenTelemetry_Instrumentation_Runtime>1.5.0</PkgVersion_OpenTelemetry_Instrumentation_Runtime>
+    <PkgVersion_OpenTelemetry_Instrumentation_SqlClient>1.5.0-beta.1</PkgVersion_OpenTelemetry_Instrumentation_SqlClient>
     <PkgVersion_Microsoft_Web_LibraryManager_Build>2.1.175</PkgVersion_Microsoft_Web_LibraryManager_Build>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Asp.Versioning.Http" Version="7.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="CsvHelper" Version="30.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.22.1" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.52.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.52.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.53.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.23.2" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.53.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.53.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.54.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="8.2.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="8.2.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="8.2.0" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="2.2.0" />
-    <PackageVersion Include="JsonSchema.Net.Generation" Version="3.1.0" />
+    <PackageVersion Include="JsonSchema.Net.Generation" Version="3.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.5" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.4" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.FASTER.Core" Version="2.5.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.FASTER.Core" Version="2.5.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="$(PkgVersion_Microsoft_Web_LibraryManager_Build)" />
     <PackageVersion Include="MiniValidation" Version="0.7.4" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.0.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-    <PackageVersion Include="NSwag.AspNetCore" Version="13.18.2" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />
     <PackageVersion Include="OpenTelemetry" Version="$(PkgVersion_OpenTelemetry)" />
     <PackageVersion Include="OpenTelemetry.Api" Version="$(PkgVersion_OpenTelemetry_Api)" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="$(PkgVersion_OpenTelemetry_Exporter_Console)" />
@@ -71,7 +71,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(PkgVersion_OpenTelemetry_Instrumentation_Runtime)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="$(PkgVersion_OpenTelemetry_Instrumentation_SqlClient)" />
     <PackageVersion Include="Semver" Version="2.3.0" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.4" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.5" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />


### PR DESCRIPTION
Update package references, most notably OpenTelemetry libraries to 1.5.0 or equivalent pre-release versions