### PR TITLE
Allow individual features to be removed from AdapterDescriptorBuilder

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
@@ -607,19 +607,10 @@ namespace DataCore.Adapter {
                 throw new ArgumentNullException(nameof(adapter));
             }
 
-            var standardFeatures = adapter
-                .Features
-                .Keys
-                .Where(x => x.IsStandardFeatureUri())
-                .ToArray();
-
-#pragma warning disable CS0618 // Type or member is obsolete
             var builder = new AdapterDescriptorBuilder(adapter.Descriptor)
                 .WithTypeDescriptor(adapter.TypeDescriptor)
-                .WithFeatures(standardFeatures)
-                .WithExtensionFeatures(adapter.Features.Keys.Except(standardFeatures))
+                .WithFeatures(adapter.Features.Keys)
                 .WithProperties(adapter.Properties);
-#pragma warning restore CS0618 // Type or member is obsolete
 
             return builder.Build();
         }

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -2,17 +2,15 @@
 DataCore.Adapter.Common.AdapterDescriptorBuilder
 DataCore.Adapter.Common.AdapterDescriptorBuilder.AdapterDescriptorBuilder(DataCore.Adapter.Common.AdapterDescriptor! descriptor) -> void
 DataCore.Adapter.Common.AdapterDescriptorBuilder.AdapterDescriptorBuilder(DataCore.Adapter.Common.AdapterDescriptorExtended! descriptor) -> void
+DataCore.Adapter.Common.AdapterDescriptorBuilder.AdapterDescriptorBuilder(string! id) -> void
 DataCore.Adapter.Common.AdapterDescriptorBuilder.AdapterDescriptorBuilder(string! id, string! name) -> void
 DataCore.Adapter.Common.AdapterDescriptorBuilder.Build() -> DataCore.Adapter.Common.AdapterDescriptorExtended!
-DataCore.Adapter.Common.AdapterDescriptorBuilder.ClearExtensionFeatures() -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
+DataCore.Adapter.Common.AdapterDescriptorBuilder.ClearFeature(string! feature) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
+DataCore.Adapter.Common.AdapterDescriptorBuilder.ClearFeature(System.Uri! feature) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
+DataCore.Adapter.Common.AdapterDescriptorBuilder.ClearFeature<TFeature>() -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
 DataCore.Adapter.Common.AdapterDescriptorBuilder.ClearFeatures() -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
 DataCore.Adapter.Common.AdapterDescriptorBuilder.ClearProperties() -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
 DataCore.Adapter.Common.AdapterDescriptorBuilder.WithDescription(string? description) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
-DataCore.Adapter.Common.AdapterDescriptorBuilder.WithExtensionFeature<TFeature>() -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
-DataCore.Adapter.Common.AdapterDescriptorBuilder.WithExtensionFeatures(params string![]! features) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
-DataCore.Adapter.Common.AdapterDescriptorBuilder.WithExtensionFeatures(params System.Uri![]! features) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
-DataCore.Adapter.Common.AdapterDescriptorBuilder.WithExtensionFeatures(System.Collections.Generic.IEnumerable<string!>! features) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
-DataCore.Adapter.Common.AdapterDescriptorBuilder.WithExtensionFeatures(System.Collections.Generic.IEnumerable<System.Uri!>! features) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
 DataCore.Adapter.Common.AdapterDescriptorBuilder.WithFeature<TFeature>() -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
 DataCore.Adapter.Common.AdapterDescriptorBuilder.WithFeatures(params string![]! features) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
 DataCore.Adapter.Common.AdapterDescriptorBuilder.WithFeatures(params System.Uri![]! features) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!

--- a/test/DataCore.Adapter.Tests/AdapterDescriptorBuilderTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterDescriptorBuilderTests.cs
@@ -1,0 +1,54 @@
+﻿using DataCore.Adapter.Common;
+using DataCore.Adapter.Tags;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DataCore.Adapter.Tests {
+
+    [TestClass]
+    public class AdapterDescriptorBuilderTests : TestsBase {
+
+        [TestMethod]
+        public void ShouldSetStandardFeature() {
+            var descriptor = new AdapterDescriptorBuilder(TestContext.TestName)
+                .WithFeature<ITagInfo>()
+                .Build();
+
+            Assert.IsTrue(descriptor.HasFeature<ITagInfo>());
+        }
+
+
+        [TestMethod]
+        public void ShouldClearStandardFeature() {
+            var descriptor = new AdapterDescriptorBuilder(TestContext.TestName)
+                .WithFeature<ITagInfo>()
+                .ClearFeature<ITagInfo>()
+                .Build();
+
+            Assert.IsFalse(descriptor.HasFeature<ITagInfo>());
+        }
+
+
+        [TestMethod]
+        public void ShouldSetExtensionFeature() {
+            var descriptor = new AdapterDescriptorBuilder(TestContext.TestName)
+                .WithFeature<PingPongExtension>()
+                .Build();
+
+            Assert.IsTrue(descriptor.HasFeature<PingPongExtension>());
+        }
+
+
+        [TestMethod]
+        public void ShouldClearExtensionFeature() {
+            var descriptor = new AdapterDescriptorBuilder(TestContext.TestName)
+                .WithFeature<PingPongExtension>()
+                .ClearFeature<PingPongExtension>()
+                .Build();
+
+            Assert.IsFalse(descriptor.HasFeature<PingPongExtension>());
+        }
+
+    }
+
+}


### PR DESCRIPTION
Adds methods to `AdapterDescriptorBuilder` to allow individual features to be removed from the builder.

Also removes the separate methods for adding/clearing extension features - this is now done via the same `WithFeature` and `ClearFeatures` methods as for standard features.