### PR TITLE
Runtime adapter descriptors

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterExtensions.cs
@@ -602,7 +602,24 @@ namespace DataCore.Adapter {
         /// <exception cref="AdapterDescriptorExtended">
         ///  <paramref name="adapter"/> is <see langword="null"/>.
         /// </exception>
-        public static AdapterDescriptorExtended CreateExtendedAdapterDescriptor(this IAdapter adapter) {
+        public static AdapterDescriptorExtended CreateExtendedAdapterDescriptor(this IAdapter adapter) => adapter.CreateExtendedAdapterDescriptorBuilder().Build();
+
+
+        /// <summary>
+        /// Creates an <see cref="AdapterDescriptorBuilder"/> that is pre-populated using the 
+        /// <see cref="IAdapter"/>.
+        /// </summary>
+        /// <param name="adapter">
+        ///   The adapter.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="AdapterDescriptorBuilder"/> that can be used to build an extended 
+        ///   descriptor for the <paramref name="adapter"/>.
+        /// </returns>
+        /// <exception cref="AdapterDescriptorExtended">
+        ///  <paramref name="adapter"/> is <see langword="null"/>.
+        /// </exception>
+        public static AdapterDescriptorBuilder CreateExtendedAdapterDescriptorBuilder(this IAdapter adapter) {
             if (adapter == null) {
                 throw new ArgumentNullException(nameof(adapter));
             }
@@ -612,7 +629,7 @@ namespace DataCore.Adapter {
                 .WithFeatures(adapter.Features.Keys)
                 .WithProperties(adapter.Properties);
 
-            return builder.Build();
+            return builder;
         }
 
 

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -45,3 +45,4 @@ DataCore.Adapter.Common.HostInfoBuilder.WithProperties(System.Collections.Generi
 DataCore.Adapter.Common.HostInfoBuilder.WithProperty(string! name, DataCore.Adapter.Common.Variant value) -> DataCore.Adapter.Common.HostInfoBuilder!
 DataCore.Adapter.Common.HostInfoBuilder.WithVendor(DataCore.Adapter.Common.VendorInfo? vendor) -> DataCore.Adapter.Common.HostInfoBuilder!
 DataCore.Adapter.Common.HostInfoBuilder.WithVersion(string? version) -> DataCore.Adapter.Common.HostInfoBuilder!
+static DataCore.Adapter.AdapterExtensions.CreateExtendedAdapterDescriptorBuilder(this DataCore.Adapter.IAdapter! adapter) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
@@ -979,7 +979,7 @@ namespace DataCore.Adapter {
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            return Common.AdapterDescriptor.Create(descriptor.Id, descriptor.Name, descriptor.Description);
+            return new Common.AdapterDescriptor(descriptor.Id, descriptor.Name, descriptor.Description);
         }
 
 

--- a/src/DataCore.Adapter.AspNetCore.Grpc/Services/AdaptersServiceImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/Services/AdaptersServiceImpl.cs
@@ -57,10 +57,10 @@ namespace DataCore.Adapter.Grpc.Server.Services {
         /// <inheritdoc/>
         public override async Task<GetAdapterResponse> GetAdapter(GetAdapterRequest request, ServerCallContext context) {
             var adapterCallContext = new GrpcAdapterCallContext(context);
-            var adapter = await _adapterAccessor.GetAdapter(adapterCallContext, request.AdapterId, context.CancellationToken).ConfigureAwait(false);
+            var descriptor = await _adapterAccessor.GetAdapterDescriptorAsync(adapterCallContext, request.AdapterId, context.CancellationToken).ConfigureAwait(false);
 
             return new GetAdapterResponse() {
-                Adapter = adapter?.CreateExtendedAdapterDescriptor().ToGrpcExtendedAdapterDescriptor()
+                Adapter = descriptor?.ToGrpcExtendedAdapterDescriptor()
             };
         }
 
@@ -70,7 +70,7 @@ namespace DataCore.Adapter.Grpc.Server.Services {
             var adapterCallContext = new GrpcAdapterCallContext(context);
             var adapterId = request.AdapterId;
             var cancellationToken = context.CancellationToken;
-            var adapter = await Util.ResolveAdapterAndFeature<Diagnostics.IHealthCheck>(adapterCallContext, _adapterAccessor, adapterId, cancellationToken).ConfigureAwait(false);
+            var adapter = await Util.ResolveAdapterAndFeature<IHealthCheck>(adapterCallContext, _adapterAccessor, adapterId, cancellationToken).ConfigureAwait(false);
 
             var result = await adapter.Feature.CheckHealthAsync(adapterCallContext, cancellationToken).ConfigureAwait(false);
 

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Internal/Utils.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Internal/Utils.cs
@@ -65,6 +65,9 @@ namespace DataCore.Adapter.AspNetCore.Internal {
         }
 
 
+        internal static IResult CreateAdapterNotFoundResult(IAdapterCallContext callContext, string adapterId) => Results.Problem(statusCode: StatusCodes.Status404NotFound, detail: string.Format(callContext.CultureInfo, Resources.Error_CannotResolveAdapterId, adapterId));
+
+
         internal static async ValueTask<ResolvedAdapter<TFeature>> ResolveAdapterAsync<TFeature>(
             HttpContext context,
             IAdapterAccessor accessor,
@@ -75,7 +78,7 @@ namespace DataCore.Adapter.AspNetCore.Internal {
 
             var resolvedFeature = await accessor.GetAdapterAndFeature<TFeature>(callContext, adapterId, cancellationToken).ConfigureAwait(false);
             if (!resolvedFeature.IsAdapterResolved) {
-                return CreateErrorResult<TFeature>(Results.Problem(statusCode: StatusCodes.Status404NotFound, detail: string.Format(callContext.CultureInfo, Resources.Error_CannotResolveAdapterId, adapterId)));
+                return CreateErrorResult<TFeature>(CreateAdapterNotFoundResult(callContext, adapterId));
             }
             if (!resolvedFeature.Adapter.IsEnabled || !resolvedFeature.Adapter.IsRunning) {
                 return CreateErrorResult<TFeature>(Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: string.Format(callContext.CultureInfo, Resources.Error_AdapterIsNotRunning, adapterId)));

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/AdapterRoutes.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/AdapterRoutes.cs
@@ -83,12 +83,13 @@ namespace DataCore.Adapter.AspNetCore.Routing.V2 {
             string adapterId,
             CancellationToken cancellationToken = default
         ) {
-            var resolverResult = await Utils.ResolveAdapterAsync<IHealthCheck>(context, adapterAccessor, adapterId, cancellationToken).ConfigureAwait(false);
-            if (resolverResult.Error != null) {
-                return resolverResult.Error;
+            var callContext = new HttpAdapterCallContext(context);
+            var descriptor = await adapterAccessor.GetAdapterDescriptorAsync(callContext, adapterId, cancellationToken).ConfigureAwait(false);
+            if (descriptor == null) {
+                return Utils.CreateAdapterNotFoundResult(callContext, adapterId);
             }
 
-            return Results.Ok(resolverResult.Adapter.CreateExtendedAdapterDescriptor());
+            return Results.Ok(descriptor);
         }
 
 

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
@@ -130,12 +130,12 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         [ProducesResponseType(typeof(AdapterDescriptorExtended), 200)]
         public async Task<IActionResult> GetAdapterById(string adapterId, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
-            var adapter = await _adapterAccessor.GetAdapter(callContext, adapterId, cancellationToken).ConfigureAwait(false);
-            if (adapter == null) {
+            var descriptor = await _adapterAccessor.GetAdapterDescriptorAsync(callContext, adapterId, cancellationToken).ConfigureAwait(false);
+            if (descriptor == null) {
                 return BadRequest(string.Format(callContext.CultureInfo, Resources.Error_CannotResolveAdapterId, adapterId)); // 400
             }
 
-            return Ok(adapter.CreateExtendedAdapterDescriptor()); // 200
+            return Ok(descriptor); // 200
         }
 
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
@@ -123,8 +123,8 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         /// </returns>
         public async Task<AdapterDescriptorExtended> GetAdapter(string adapterId) {
             var adapterCallContext = new SignalRAdapterCallContext(Context);
-            var adapter = await AdapterAccessor.GetAdapter(adapterCallContext, adapterId, Context.ConnectionAborted).ConfigureAwait(false);
-            return adapter == null ? null! : adapter.CreateExtendedAdapterDescriptor();
+            var descriptor = await AdapterAccessor.GetAdapterDescriptorAsync(adapterCallContext, adapterId, Context.ConnectionAborted).ConfigureAwait(false);
+            return descriptor!;
         }
 
 

--- a/src/DataCore.Adapter.Core/Common/AdapterDescriptor.cs
+++ b/src/DataCore.Adapter.Core/Common/AdapterDescriptor.cs
@@ -77,6 +77,7 @@ namespace DataCore.Adapter.Common {
         /// <exception cref="ArgumentException">
         ///   <paramref name="name"/> is <see langword="null"/> or white space.
         /// </exception>
+        [Obsolete("Use constructor instead.", true)]
         public static AdapterDescriptor Create(string id, string name, string? description) {
             return new AdapterDescriptor(id, name, description);
         }
@@ -97,6 +98,7 @@ namespace DataCore.Adapter.Common {
         /// <exception cref="ArgumentException">
         ///   <paramref name="name"/> is <see langword="null"/> or white space.
         /// </exception>
+        [Obsolete("Use constructor instead.", true)]
         public static AdapterDescriptor Create(string id, string name) {
             return Create(id, name, null);
         }
@@ -112,6 +114,7 @@ namespace DataCore.Adapter.Common {
         /// <exception cref="ArgumentException">
         ///   <paramref name="id"/> is <see langword="null"/> or white space.
         /// </exception>
+        [Obsolete("Use constructor instead.", true)]
         public static AdapterDescriptor Create(string id) {
             return Create(id, id, null);
         }
@@ -134,7 +137,7 @@ namespace DataCore.Adapter.Common {
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            return Create(descriptor.Id, descriptor.Name, descriptor.Description);
+            return new AdapterDescriptor(descriptor.Id, descriptor.Name, descriptor.Description);
         }
 
     }

--- a/src/DataCore.Adapter/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 ﻿#nullable enable
 DataCore.Adapter.RealTimeData.TagValueBuilder.WithSteppedTransition(bool stepped) -> DataCore.Adapter.RealTimeData.TagValueBuilder!
+static DataCore.Adapter.AdapterAccessorExtensions.GetAdapterDescriptorAsync(this DataCore.Adapter.IAdapterAccessor! adapterAccessor, DataCore.Adapter.IAdapterCallContext! context, string! adapterId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<DataCore.Adapter.Common.AdapterDescriptorExtended?>!
 static DataCore.Adapter.Security.CertificateUtilities.TryLoadCertificateFromStore(string! path, bool requirePrivateKey, bool allowInvalid, out System.Security.Cryptography.X509Certificates.X509Certificate2? certificate) -> bool

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -5,7 +5,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.AssetModel;
@@ -16,32 +15,10 @@ using DataCore.Adapter.RealTimeData;
 using DataCore.Adapter.Services;
 using DataCore.Adapter.Tags;
 
-using IntelligentPlant.BackgroundTasks;
-
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DataCore.Adapter.Tests {
     public class ExampleAdapter : AdapterCore, ITagInfo, IReadSnapshotTagValues {
-
-        //private CancellationTokenSource _stopTokenSource;
-
-        //public IBackgroundTaskService BackgroundTaskService { get; }
-
-        //public AdapterDescriptor Descriptor { get; }
-
-        //public AdapterTypeDescriptor TypeDescriptor { get; }
-
-        //public IAdapterFeaturesCollection Features { get; }
-
-        //public IEnumerable<AdapterProperty> Properties { get; } = Array.Empty<AdapterProperty>();
-
-        //public bool IsEnabled { get; set; } = true;
-
-        //public bool IsRunning { get; } = true;
-
-        //public event Func<IAdapter, Task> Started;
-
-        //public event Func<IAdapter, Task> Stopped;
 
         private readonly SnapshotSubscriptionManager _snapshotSubscriptionManager;
 
@@ -54,14 +31,7 @@ namespace DataCore.Adapter.Tests {
         private readonly CustomFunctions _customFunctions;
 
 
-        public ExampleAdapter() : base(AdapterDescriptor.Create("unit-tests", "Unit Tests Adapter", "Adapter for use in unit tests")) {
-            //BackgroundTaskService = new BackgroundTaskServiceWrapper(
-            //    IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default,
-            //    () => _stopTokenSource?.Token ?? default
-            //);
-            //Descriptor = AdapterDescriptor.Create("unit-tests", "Unit Tests Adapter", "Adapter for use in unit tests");
-            //TypeDescriptor = this.CreateTypeDescriptor();
-            //var features = new AdapterFeaturesCollection();
+        public ExampleAdapter() : base(new AdapterDescriptor("unit-tests", "Unit Tests Adapter", "Adapter for use in unit tests")) {
             _snapshotSubscriptionManager = new SnapshotSubscriptionManager(this);
             _eventSubscriptionManager = new EventSubscriptionManager();
             _eventTopicSubscriptionManager = new EventTopicSubscriptionManager();
@@ -75,13 +45,10 @@ namespace DataCore.Adapter.Tests {
             AddFeatures(_assetModelManager);
             AddFeatures(_customFunctions);
             AddFeatures(new PingPongExtension(BackgroundTaskService, AssemblyInitializer.ApplicationServices.GetServices<IObjectEncoder>()));
-            //Features = features;
         }
 
 
         protected override async Task StartAsyncCore(CancellationToken cancellationToken = default) {
-            //_stopTokenSource = new CancellationTokenSource();
-
             using var sha = System.Security.Cryptography.SHA256.Create();
 
             var nodes = new[] { "Alpha", "Beta", "Gamma", "Delta" }.ToDictionary(x => x, x => GetNodeId(x));
@@ -99,10 +66,6 @@ namespace DataCore.Adapter.Tests {
                     UtcServerTime = DateTime.UtcNow
                 });
             }, cancellationToken: cancellationToken);
-
-            //if (Started != null) {
-            //    await Started.Invoke(this).ConfigureAwait(false);
-            //}
         }
 
 
@@ -113,12 +76,6 @@ namespace DataCore.Adapter.Tests {
 
 
         protected override Task StopAsyncCore(CancellationToken cancellationToken = default) {
-            //_stopTokenSource?.Cancel();
-            //_stopTokenSource?.Dispose();
-
-            //if (Stopped != null) {
-            //    await Stopped.Invoke(this).ConfigureAwait(false);
-            //}
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
This PR introduces the concept of runtime adapter descriptors i.e. API calls to get extended adapter descriptors will return descriptors that only contain features that the caller is authorized to access.