### PR TITLE
Request validation improvements

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/AdapterRoutes.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/AdapterRoutes.cs
@@ -22,11 +22,11 @@ namespace DataCore.Adapter.AspNetCore.Routing.V2 {
                 .Produces<IAsyncEnumerable<AdapterDescriptor>>()
                 .ProducesValidationProblem();
 
-            builder.MapGet("/{adapterId}", GetAdapterAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}", GetAdapterAsync)
                 .Produces<AdapterDescriptorExtended>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/health-status", CheckAdapterHealthAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/health-status", CheckAdapterHealthAsync)
                 .Produces<HealthCheckResult>()
                 .ProducesDefaultErrors();
         }

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/AssetModelRoutes.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/AssetModelRoutes.cs
@@ -1,5 +1,6 @@
 ﻿using DataCore.Adapter.AspNetCore.Internal;
 using DataCore.Adapter.AssetModel;
+using DataCore.Adapter.Common;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -9,23 +10,23 @@ namespace DataCore.Adapter.AspNetCore.Routing.V2 {
     internal class AssetModelRoutes : IRouteProvider {
 
         public static void Register(IEndpointRouteBuilder builder) {
-            builder.MapGet("/{adapterId}/browse", BrowseNodesGetAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/browse", BrowseNodesGetAsync)
                 .Produces<IAsyncEnumerable<AssetModelNode>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/browse", BrowseNodesPostAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/browse", BrowseNodesPostAsync)
                 .Produces<IAsyncEnumerable<AssetModelNode>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/get-by-id", GetNodesGetAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/get-by-id", GetNodesGetAsync)
                 .Produces<IAsyncEnumerable<AssetModelNode>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/get-by-id", GetNodesPostAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/get-by-id", GetNodesPostAsync)
                 .Produces<IAsyncEnumerable<AssetModelNode>>()
                 .ProducesDefaultErrors();
             
-            builder.MapPost("/{adapterId}/find", FindNodesAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/find", FindNodesAsync)
                 .Produces<IAsyncEnumerable<AssetModelNode>>()
                 .ProducesDefaultErrors();
         }

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/CustomFunctionRoutes.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/CustomFunctionRoutes.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 
 using DataCore.Adapter.AspNetCore.Internal;
+using DataCore.Adapter.Common;
 using DataCore.Adapter.Extensions;
 
 using Microsoft.AspNetCore.Builder;
@@ -12,23 +13,23 @@ using Microsoft.Extensions.Options;
 namespace DataCore.Adapter.AspNetCore.Routing.V2 {
     internal class CustomFunctionRoutes : IRouteProvider {
         public static void Register(IEndpointRouteBuilder builder) {
-            builder.MapGet("/{adapterId}", GetCustomFunctionsGetAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}", GetCustomFunctionsGetAsync)
                 .Produces<IEnumerable<CustomFunctionDescriptor>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}", GetCustomFunctionsPostAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}", GetCustomFunctionsPostAsync)
                 .Produces<IEnumerable<CustomFunctionDescriptor>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/details", GetCustomFunctionGetAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/details", GetCustomFunctionGetAsync)
                 .Produces<CustomFunctionDescriptorExtended>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/details", GetCustomFunctionPostAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/details", GetCustomFunctionPostAsync)
                 .Produces<CustomFunctionDescriptorExtended>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/invoke", InvokeCustomFunctionAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/invoke", InvokeCustomFunctionAsync)
                 .Produces<CustomFunctionInvocationResponse>()
                 .ProducesDefaultErrors();
         }

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/EventRoutes.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/EventRoutes.cs
@@ -1,4 +1,5 @@
 ﻿using DataCore.Adapter.AspNetCore.Internal;
+using DataCore.Adapter.Common;
 using DataCore.Adapter.Events;
 
 using Microsoft.AspNetCore.Builder;
@@ -9,15 +10,15 @@ namespace DataCore.Adapter.AspNetCore.Routing.V2 {
     internal class EventRoutes : IRouteProvider {
 
         public static void Register(IEndpointRouteBuilder builder) {
-            builder.MapPost("/{adapterId}/by-time-range", ReadEventMessagesForTimeRangeAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/by-time-range", ReadEventMessagesForTimeRangeAsync)
                 .Produces<IAsyncEnumerable<EventMessage>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/by-cursor", ReadEventMessagesUsingCursorAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/by-cursor", ReadEventMessagesUsingCursorAsync)
                 .Produces<IAsyncEnumerable<EventMessageWithCursorPosition>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/write", WriteEventMessagesAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/write", WriteEventMessagesAsync)
                 .Produces<IAsyncEnumerable<WriteEventMessageResult>>()
                 .ProducesDefaultErrors();
         }

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/ExtensionRoutes.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/ExtensionRoutes.cs
@@ -1,4 +1,5 @@
 ﻿using DataCore.Adapter.AspNetCore.Internal;
+using DataCore.Adapter.Common;
 using DataCore.Adapter.Extensions;
 
 using Microsoft.AspNetCore.Builder;
@@ -11,19 +12,19 @@ namespace DataCore.Adapter.AspNetCore.Routing.V2 {
     internal class ExtensionRoutes : IRouteProvider {
 
         public static void Register(IEndpointRouteBuilder builder) {
-            builder.MapGet("/{adapterId}", GetAvailableExtensionsAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}", GetAvailableExtensionsAsync)
                 .Produces<IEnumerable<string>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/descriptor", GetDescriptorAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/descriptor", GetDescriptorAsync)
                 .Produces<Common.FeatureDescriptor>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/operations", GetAvailableOperationsAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/operations", GetAvailableOperationsAsync)
                 .Produces<IEnumerable<ExtensionFeatureOperationDescriptor>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/operations/invoke", InvokeOperationAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/operations/invoke", InvokeOperationAsync)
                 .Produces<InvocationResponse>()
                 .ProducesDefaultErrors();
         }

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/TagAnnotationRoutes.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/TagAnnotationRoutes.cs
@@ -1,4 +1,5 @@
 ﻿using DataCore.Adapter.AspNetCore.Internal;
+using DataCore.Adapter.Common;
 using DataCore.Adapter.RealTimeData;
 
 using Microsoft.AspNetCore.Builder;
@@ -9,23 +10,23 @@ namespace DataCore.Adapter.AspNetCore.Routing.V2 {
     internal class TagAnnotationRoutes : IRouteProvider {
 
         public static void Register(IEndpointRouteBuilder builder) {
-            builder.MapPost("/{adapterId}", ReadAnnotationsAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}", ReadAnnotationsAsync)
                 .Produces<IAsyncEnumerable<TagValueAnnotationQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/{tagId}/{annotationId}", ReadAnnotationAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/{{tagId}}/{{annotationId}}", ReadAnnotationAsync)
                 .Produces<TagValueAnnotationExtended>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/{tagId}/create", CreateAnnotationAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/{{tagId}}/create", CreateAnnotationAsync)
                 .Produces<WriteTagValueAnnotationResult>()
                 .ProducesDefaultErrors();
 
-            builder.MapPut("/{adapterId}/{tagId}/{annotationId}", UpdateAnnotationAsync)
+            builder.MapPut($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/{{tagId}}/{{annotationId}}", UpdateAnnotationAsync)
                 .Produces<WriteTagValueAnnotationResult>()
                 .ProducesDefaultErrors();
 
-            builder.MapDelete("/{adapterId}/{tagId}/{annotationId}", DeleteAnnotationAsync)
+            builder.MapDelete($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/{{tagId}}/{{annotationId}}", DeleteAnnotationAsync)
                 .Produces<WriteTagValueAnnotationResult>()
                 .ProducesDefaultErrors();
         }

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/TagRoutes.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/TagRoutes.cs
@@ -1,4 +1,5 @@
 ﻿using DataCore.Adapter.AspNetCore.Internal;
+using DataCore.Adapter.Common;
 using DataCore.Adapter.Tags;
 
 using Microsoft.AspNetCore.Builder;
@@ -10,51 +11,51 @@ using Microsoft.Extensions.Options;
 namespace DataCore.Adapter.AspNetCore.Routing.V2 {
     internal class TagRoutes : IRouteProvider {
         public static void Register(IEndpointRouteBuilder builder) {
-            builder.MapGet("/{adapterId}", FindTagsGetAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}", FindTagsGetAsync)
                 .Produces<IAsyncEnumerable<TagDefinition>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}", FindTagsPostAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}", FindTagsPostAsync)
                 .Produces<IAsyncEnumerable<TagDefinition>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/find", FindTagsGetAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/find", FindTagsGetAsync)
                 .Produces<IAsyncEnumerable<TagDefinition>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/find", FindTagsPostAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/find", FindTagsPostAsync)
                 .Produces<IAsyncEnumerable<TagDefinition>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/properties", GetTagPropertiesGetAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/properties", GetTagPropertiesGetAsync)
                 .Produces<IAsyncEnumerable<Common.AdapterProperty>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/properties", GetTagPropertiesPostAsync)
-                .Produces<IAsyncEnumerable<Common.AdapterProperty>>()
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/properties", GetTagPropertiesPostAsync)
+                .Produces<IAsyncEnumerable<AdapterProperty>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/get-by-id", GetTagsGetAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/get-by-id", GetTagsGetAsync)
                 .Produces<IAsyncEnumerable<TagDefinition>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/get-by-id", GetTagsPostAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/get-by-id", GetTagsPostAsync)
                 .Produces<IAsyncEnumerable<TagDefinition>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("/{adapterId}/schema", GetTagSchemaAsync)
+            builder.MapGet($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/schema", GetTagSchemaAsync)
                 .Produces<System.Text.Json.JsonElement>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/create", CreateTagAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/create", CreateTagAsync)
                 .Produces<TagDefinition>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/update", UpdateTagAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/update", UpdateTagAsync)
                 .Produces<TagDefinition>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("/{adapterId}/delete", DeleteTagAsync)
+            builder.MapPost($"/{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/delete", DeleteTagAsync)
                 .Produces<bool>()
                 .ProducesDefaultErrors();
         }

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/TagValueRoutes.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/Routing/V2/TagValueRoutes.cs
@@ -1,4 +1,5 @@
 ﻿using DataCore.Adapter.AspNetCore.Internal;
+using DataCore.Adapter.Common;
 using DataCore.Adapter.RealTimeData;
 
 using Microsoft.AspNetCore.Builder;
@@ -22,59 +23,59 @@ namespace DataCore.Adapter.AspNetCore.Routing.V2 {
 
 
         public static void Register(IEndpointRouteBuilder builder) {
-            builder.MapGet("{adapterId}/snapshot", ReadSnapshotTagValuesGetAsync)
+            builder.MapGet($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/snapshot", ReadSnapshotTagValuesGetAsync)
                 .Produces<IAsyncEnumerable<TagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("{adapterId}/snapshot", ReadSnapshotTagValuesPostAsync)
+            builder.MapPost($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/snapshot", ReadSnapshotTagValuesPostAsync)
                 .Produces<IAsyncEnumerable<TagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("{adapterId}/raw", ReadRawTagValuesGetAsync)
+            builder.MapGet($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/raw", ReadRawTagValuesGetAsync)
                 .Produces<IAsyncEnumerable<TagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("{adapterId}/raw", ReadRawTagValuesPostAsync)
+            builder.MapPost($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/raw", ReadRawTagValuesPostAsync)
                 .Produces<IAsyncEnumerable<TagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("{adapterId}/plot", ReadPlotTagValuesGetAsync)
+            builder.MapGet($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/plot", ReadPlotTagValuesGetAsync)
                 .Produces<IAsyncEnumerable<TagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("{adapterId}/plot", ReadPlotTagValuesPostAsync)
+            builder.MapPost($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/plot", ReadPlotTagValuesPostAsync)
                 .Produces<IAsyncEnumerable<TagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("{adapterId}/values-at-times", ReadTagValuesAtTimesGetAsync)
+            builder.MapGet($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/values-at-times", ReadTagValuesAtTimesGetAsync)
                 .Produces<IAsyncEnumerable<TagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("{adapterId}/values-at-times", ReadTagValuesAtTimesPostAsync)
+            builder.MapPost($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/values-at-times", ReadTagValuesAtTimesPostAsync)
                 .Produces<IAsyncEnumerable<TagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("{adapterId}/supported-aggregations", GetSupportedAggregationsGetAsync)
+            builder.MapGet($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/supported-aggregations", GetSupportedAggregationsGetAsync)
                 .Produces<IAsyncEnumerable<DataFunctionDescriptor>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("{adapterId}/supported-aggregations", GetSupportedAggregationsPostAsync)
+            builder.MapPost($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/supported-aggregations", GetSupportedAggregationsPostAsync)
                 .Produces<IAsyncEnumerable<DataFunctionDescriptor>>()
                 .ProducesDefaultErrors();
 
-            builder.MapGet("{adapterId}/processed", ReadProcessedTagValuesGetAsync)
+            builder.MapGet($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/processed", ReadProcessedTagValuesGetAsync)
                 .Produces<IAsyncEnumerable<ProcessedTagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("{adapterId}/processed", ReadProcessedTagValuesPostAsync)
+            builder.MapPost($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/processed", ReadProcessedTagValuesPostAsync)
                 .Produces<IAsyncEnumerable<ProcessedTagValueQueryResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("{adapterId}/write/snapshot", WriteSnapshotTagValuesAsync)
+            builder.MapPost($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/write/snapshot", WriteSnapshotTagValuesAsync)
                 .Produces<IAsyncEnumerable<WriteTagValueResult>>()
                 .ProducesDefaultErrors();
 
-            builder.MapPost("{adapterId}/write/history", WriteHistoricalTagValuesAsync)
+            builder.MapPost($"{{adapterId:maxlength({AdapterDescriptor.IdMaxLength})}}/write/history", WriteHistoricalTagValuesAsync)
                 .Produces<IAsyncEnumerable<WriteTagValueResult>>()
                 .ProducesDefaultErrors();
         }

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AdaptersController.cs
@@ -126,7 +126,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   requested adapter.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}")]
+        [Route("{adapterId:maxlength(200)}")]
         [ProducesResponseType(typeof(AdapterDescriptorExtended), 200)]
         public async Task<IActionResult> GetAdapterById(string adapterId, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -153,7 +153,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   adapter.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/health-status")]
+        [Route("{adapterId:maxlength(200)}/health-status")]
         [ProducesResponseType(typeof(HealthCheckResult), 200)]
         public async Task<IActionResult> CheckAdapterHealth(string adapterId, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AssetModelBrowserController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/AssetModelBrowserController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -60,15 +61,16 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the matching <see cref="AssetModelNode"/> objects.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/browse")]
+        [Route("{adapterId:maxlength(200)}/browse")]
         [ProducesResponseType(typeof(IAsyncEnumerable<AssetModelNode>), 200)]
-        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> BrowseNodes(string adapterId, string? start = null, int page = 1, int pageSize = 10, CancellationToken cancellationToken = default) {
-            return BrowseNodesPost(adapterId, new BrowseAssetModelNodesRequest() { 
+            var request = new BrowseAssetModelNodesRequest() {
                 ParentId = start,
                 PageSize = pageSize,
                 Page = page
-            }, cancellationToken);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+            return BrowseNodesPost(adapterId, request, cancellationToken);
         }
 
 
@@ -88,7 +90,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the matching <see cref="AssetModelNode"/> objects.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/browse")]
+        [Route("{adapterId:maxlength(200)}/browse")]
         [ProducesResponseType(typeof(IAsyncEnumerable<AssetModelNode>), 200)]
         public async Task<IActionResult> BrowseNodesPost(string adapterId, BrowseAssetModelNodesRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -126,7 +128,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the matching <see cref="AssetModelNode"/> objects.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/get-by-id")]
+        [Route("{adapterId:maxlength(200)}/get-by-id")]
         [ProducesResponseType(typeof(IAsyncEnumerable<AssetModelNode>), 200)]
         public async Task<IActionResult> GetNodes(string adapterId, GetAssetModelNodesRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -166,7 +168,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the matching <see cref="AssetModelNode"/> objects.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/find")]
+        [Route("{adapterId:maxlength(200)}/find")]
         [ProducesResponseType(typeof(IAsyncEnumerable<AssetModelNode>), 200)]
         public async Task<IActionResult> FindNodes(string adapterId, FindAssetModelNodesRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/CustomFunctionsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/CustomFunctionsController.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CS0618 // Type or member is obsolete
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,7 +54,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the descriptors for the available custom functions.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}")]
+        [Route("{adapterId:maxlength(200)}")]
         [ProducesResponseType(typeof(IEnumerable<CustomFunctionDescriptor>), 200)]
         public async Task<IActionResult> GetFunctionsAsync(string adapterId, GetCustomFunctionsRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -105,17 +106,18 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the descriptors for the available custom functions.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}")]
+        [Route("{adapterId:maxlength(200)}")]
         [ProducesResponseType(typeof(IEnumerable<CustomFunctionDescriptor>), 200)]
-        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> GetFunctionsAsync(string adapterId, string? id = null, string? name = null, string? description = null, int pageSize = 10, int page = 1, CancellationToken cancellationToken = default) {
-            return await GetFunctionsAsync(adapterId, new GetCustomFunctionsRequest() { 
+            var request = new GetCustomFunctionsRequest() {
                 Id = id,
                 Name = name,
                 Description = description,
                 PageSize = pageSize,
                 Page = page
-            }, cancellationToken).ConfigureAwait(false);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+            return await GetFunctionsAsync(adapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -135,7 +137,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the extended descriptor for the requested custom function.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/details")]
+        [Route("{adapterId:maxlength(200)}/details")]
         [ProducesResponseType(typeof(CustomFunctionDescriptorExtended), 200)]
         public async Task<IActionResult> GetFunctionAsync(string adapterId, GetCustomFunctionRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -175,13 +177,15 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the extended descriptor for the requested custom function.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/details")]
+        [Route("{adapterId:maxlength(200)}/details")]
         [ProducesResponseType(typeof(CustomFunctionDescriptorExtended), 200)]
-        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> GetFunctionAsync(string adapterId, [FromQuery] Uri id, CancellationToken cancellationToken) {
-            return await GetFunctionAsync(adapterId, new GetCustomFunctionRequest() { 
+            var request = new GetCustomFunctionRequest() {
                 Id = id
-            }, cancellationToken).ConfigureAwait(false);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+
+            return await GetFunctionAsync(adapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -204,7 +208,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the result of the custom function invocation.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/invoke")]
+        [Route("{adapterId:maxlength(200)}/invoke")]
         [ProducesResponseType(typeof(CustomFunctionInvocationResponse), 200)]
         public async Task<IActionResult> InvokeFunctionAsync(
             string adapterId,

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/EventsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/EventsController.cs
@@ -72,7 +72,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain a collection of <see cref="EventMessage"/> objects.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/by-time-range")]
+        [Route("{adapterId:maxlength(200)}/by-time-range")]
         [ProducesResponseType(typeof(IAsyncEnumerable<EventMessage>), 200)]
         public async Task<IActionResult> ReadEventMessagesForTimeRange(string adapterId, ReadEventMessagesForTimeRangeRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -112,7 +112,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   objects.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/by-cursor")]
+        [Route("{adapterId:maxlength(200)}/by-cursor")]
         [ProducesResponseType(typeof(IAsyncEnumerable<EventMessageWithCursorPosition>), 200)]
         public async Task<IActionResult> ReadEventMessagesByCursor(string adapterId, ReadEventMessagesUsingCursorRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -155,7 +155,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   objects (one per sample written).
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/write")]
+        [Route("{adapterId:maxlength(200)}/write")]
         [ProducesResponseType(typeof(IAsyncEnumerable<WriteEventMessageResult>), 200)]
         public async Task<IActionResult> WriteEventMessages(string adapterId, WriteEventMessagesRequestExtended request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/ExtensionFeaturesController.cs
@@ -54,7 +54,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain a collection of adapter extension feature URIs.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}")]
+        [Route("{adapterId:maxlength(200)}")]
         [ProducesResponseType(typeof(IEnumerable<string>), 200)]
         public async Task<IActionResult> GetAvailableExtensions(string adapterId, CancellationToken cancellationToken = default) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -84,7 +84,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain a <see cref="FeatureDescriptor"/> object.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/descriptor")]
+        [Route("{adapterId:maxlength(200)}/descriptor")]
         [ProducesResponseType(typeof(FeatureDescriptor), 200)]
         public async Task<IActionResult> GetDescriptor(
             string adapterId, 
@@ -142,7 +142,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   objects.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/operations")]
+        [Route("{adapterId:maxlength(200)}/operations")]
         [ProducesResponseType(typeof(IEnumerable<ExtensionFeatureOperationDescriptor>), 200)]
         public async Task<IActionResult> GetAvailableOperations(
             string adapterId, 
@@ -201,7 +201,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   operation result.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/operations/invoke")]
+        [Route("{adapterId:maxlength(200)}/operations/invoke")]
         [ProducesResponseType(typeof(InvocationResponse), 200)]
         public async Task<IActionResult> InvokeExtension(
             string adapterId, 

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagAnnotationsController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagAnnotationsController.cs
@@ -54,7 +54,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain a collection of <see cref="TagValueAnnotationQueryResult"/> objects.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}")]
+        [Route("{adapterId:maxlength(200)}")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueAnnotationQueryResult>), 200)]
         public async Task<IActionResult> ReadAnnotations(string adapterId, ReadAnnotationsRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -99,7 +99,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the matching <see cref="TagValueAnnotationExtended"/> object.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/{tagId}/{annotationId}")]
+        [Route("{adapterId:maxlength(200)}/{tagId}/{annotationId}")]
         [ProducesResponseType(typeof(TagValueAnnotationExtended), 200)]
         [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> ReadAnnotation(string adapterId, string tagId, string annotationId, CancellationToken cancellationToken) {
@@ -153,7 +153,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   describing the operation.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/{tagId}/create")]
+        [Route("{adapterId:maxlength(200)}/{tagId}/create")]
         [ProducesResponseType(typeof(WriteTagValueAnnotationResult), 200)]
         [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> CreateAnnotation(string adapterId, string tagId, TagValueAnnotation annotation, CancellationToken cancellationToken) {
@@ -212,7 +212,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   describing the operation.
         /// </returns>
         [HttpPut]
-        [Route("{adapterId}/{tagId}/{annotationId}")]
+        [Route("{adapterId:maxlength(200)}/{tagId}/{annotationId}")]
         [ProducesResponseType(typeof(WriteTagValueAnnotationResult), 200)]
         [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> UpdateAnnotation(string adapterId, string tagId, string annotationId, TagValueAnnotation annotation, CancellationToken cancellationToken) {
@@ -269,7 +269,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   describing the operation.
         /// </returns>
         [HttpDelete]
-        [Route("{adapterId}/{tagId}/{annotationId}")]
+        [Route("{adapterId:maxlength(200)}/{tagId}/{annotationId}")]
         [ProducesResponseType(typeof(WriteTagValueAnnotationResult), 200)]
         [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> DeleteAnnotation(string adapterId, string tagId, string annotationId, CancellationToken cancellationToken) {

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagSearchController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -54,7 +55,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain a collection of <see cref="AdapterProperty"/> objects.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/properties")]
+        [Route("{adapterId:maxlength(200)}/properties")]
         [ProducesResponseType(typeof(IAsyncEnumerable<AdapterProperty>), 200)]
         public async Task<IActionResult> GetTagProperties(string adapterId, GetTagPropertiesRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -99,14 +100,15 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain a collection of <see cref="TagDefinition"/> objects.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/properties")]
+        [Route("{adapterId:maxlength(200)}/properties")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagDefinition>), 200)]
-        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> GetTagProperties(string adapterId, int pageSize = 10, int page = 1, CancellationToken cancellationToken = default) {
-            return await GetTagProperties(adapterId, new GetTagPropertiesRequest() {
+            var request = new GetTagPropertiesRequest() {
                 PageSize = pageSize,
                 Page = page
-            }, cancellationToken).ConfigureAwait(false);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+            return await GetTagProperties(adapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -126,8 +128,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain a collection of <see cref="TagDefinition"/> objects.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/find")]
-        [Route("{adapterId}")]
+        [Route("{adapterId:maxlength(200)}/find")]
+        [Route("{adapterId:maxlength(200)}")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagDefinition>), 200)]
         public async Task<IActionResult> FindTags(string adapterId, FindTagsRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -181,18 +183,19 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain a collection of <see cref="TagDefinition"/> objects.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/find")]
-        [Route("{adapterId}")]
+        [Route("{adapterId:maxlength(200)}/find")]
+        [Route("{adapterId:maxlength(200)}")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagDefinition>), 200)]
-        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> FindTags(string adapterId, string? name = null, string? description = null, string? units = null, int pageSize = 10, int page = 1, CancellationToken cancellationToken = default) {
-            return await FindTags(adapterId, new FindTagsRequest() {
+            var request = new FindTagsRequest() {
                 Name = name,
                 Description = description,
                 Units = units,
                 PageSize = pageSize,
                 Page = page
-            }, cancellationToken).ConfigureAwait(false);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+            return await FindTags(adapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -213,7 +216,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   objects.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/get-by-id")]
+        [Route("{adapterId:maxlength(200)}/get-by-id")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagDefinition>), 200)]
         public async Task<IActionResult> GetTags(string adapterId, GetTagsRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -255,13 +258,14 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   objects.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/get-by-id")]
+        [Route("{adapterId:maxlength(200)}/get-by-id")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagDefinition>), 200)]
-        [UseAdapterRequestValidation(true)]
         public async Task<IActionResult> GetTags(string adapterId, [FromQuery] string[] tag, CancellationToken cancellationToken) {
-            return await GetTags(adapterId, new GetTagsRequest() {
+            var request = new GetTagsRequest() {
                 Tags = tag
-            }, cancellationToken).ConfigureAwait(false);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+            return await GetTags(adapterId, request, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -279,7 +283,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   model.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/schema")]
+        [Route("{adapterId:maxlength(200)}/schema")]
         [ProducesResponseType(typeof(System.Text.Json.JsonElement), 200)]
         public async Task<IActionResult> GetTagSchema(string adapterId, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -322,7 +326,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the created <see cref="TagDefinition"/> object.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/create")]
+        [Route("{adapterId:maxlength(200)}/create")]
         [ProducesResponseType(typeof(TagDefinition), 200)]
         public async Task<IActionResult> CreateTag(string adapterId, CreateTagRequest request, [FromServices] Microsoft.Extensions.Options.IOptions<JsonOptions> jsonOptions, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -372,7 +376,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the updated <see cref="TagDefinition"/> object.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/update")]
+        [Route("{adapterId:maxlength(200)}/update")]
         [ProducesResponseType(typeof(TagDefinition), 200)]
         public async Task<IActionResult> UpdateTag(string adapterId, UpdateTagRequest request, [FromServices] Microsoft.Extensions.Options.IOptions<JsonOptions> jsonOptions, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -419,7 +423,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain a Boolean value indicating if the tag was deleted.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/delete")]
+        [Route("{adapterId:maxlength(200)}/delete")]
         [ProducesResponseType(typeof(bool), 200)]
         public async Task<IActionResult> DeleteTag(string adapterId, DeleteTagRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);

--- a/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagValuesController.cs
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/Controllers/TagValuesController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
@@ -84,13 +85,14 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the snapshot values for the requested tags.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/snapshot")]
+        [Route("{adapterId:maxlength(200)}/snapshot")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
-        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadSnapshotValues(string adapterId, [FromQuery] string[] tag = null!, CancellationToken cancellationToken = default) {
-            return ReadSnapshotValues(adapterId, new ReadSnapshotTagValuesRequest() { 
+            var request = new ReadSnapshotTagValuesRequest() {
                 Tags = tag ?? Array.Empty<string>()
-            }, cancellationToken);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+            return ReadSnapshotValues(adapterId, request, cancellationToken);
         }
 
 
@@ -110,7 +112,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the snapshot values for the requested tags.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/snapshot")]
+        [Route("{adapterId:maxlength(200)}/snapshot")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
         public async Task<IActionResult> ReadSnapshotValues(string adapterId, ReadSnapshotTagValuesRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -164,9 +166,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the raw values for the requested tags.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/raw")]
+        [Route("{adapterId:maxlength(200)}/raw")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
-        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadRawValues(
             string adapterId, 
             [FromQuery] string[] tag = null!, 
@@ -188,13 +189,15 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
                 end = start.Value.Add(DefaultHistoricalQueryDuration);
             }
 
-            return ReadRawValues(adapterId, new ReadRawTagValuesRequest() {
+            var request = new ReadRawTagValuesRequest() {
                 Tags = tag ?? Array.Empty<string>(),
                 UtcStartTime = Util.ConvertToUniversalTime(start.Value),
                 UtcEndTime = Util.ConvertToUniversalTime(end.Value),
                 SampleCount = count,
                 BoundaryType = boundary
-            }, cancellationToken);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+            return ReadRawValues(adapterId, request, cancellationToken);
         }
 
 
@@ -214,7 +217,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the raw values for the requested tags.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/raw")]
+        [Route("{adapterId:maxlength(200)}/raw")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
         public async Task<IActionResult> ReadRawValues(string adapterId, ReadRawTagValuesRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -270,9 +273,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   charts.
         /// </remarks>
         [HttpGet]
-        [Route("{adapterId}/plot")]
+        [Route("{adapterId:maxlength(200)}/plot")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
-        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadPlotValues(
             string adapterId, 
             [FromQuery] string[] tag = null!, 
@@ -293,12 +295,14 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
                 end = start.Value.Add(DefaultHistoricalQueryDuration);
             }
 
-            return ReadPlotValues(adapterId, new ReadPlotTagValuesRequest() {
+            var request = new ReadPlotTagValuesRequest() {
                 Tags = tag ?? Array.Empty<string>(),
                 UtcStartTime = Util.ConvertToUniversalTime(start.Value),
                 UtcEndTime = Util.ConvertToUniversalTime(end.Value),
                 Intervals = count
-            }, cancellationToken);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+            return ReadPlotValues(adapterId, request, cancellationToken);
         }
 
 
@@ -322,7 +326,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   charts.
         /// </remarks>
         [HttpPost]
-        [Route("{adapterId}/plot")]
+        [Route("{adapterId:maxlength(200)}/plot")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
         public async Task<IActionResult> ReadPlotValues(string adapterId, ReadPlotTagValuesRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -367,19 +371,20 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the values for the requested tags at the requested times.
         /// </returns>
         [HttpGet]
-        [Route("{adapterId}/values-at-times")]
+        [Route("{adapterId:maxlength(200)}/values-at-times")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
-        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadValuesAtTimes(
             string adapterId, 
             [FromQuery] string[] tag = null!,
             [FromQuery] DateTime[] time = null!,
             CancellationToken cancellationToken = default
         ) {
-            return ReadValuesAtTimes(adapterId, new ReadTagValuesAtTimesRequest() { 
+            var request = new ReadTagValuesAtTimesRequest() {
                 Tags = tag ?? Array.Empty<string>(),
                 UtcSampleTimes = time?.Select(Util.ConvertToUniversalTime)?.ToArray() ?? Array.Empty<DateTime>()
-            }, cancellationToken);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+            return ReadValuesAtTimes(adapterId, request, cancellationToken);
         }
 
 
@@ -399,7 +404,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   Successful responses contain the values for the requested tags at the requested times.
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/values-at-times")]
+        [Route("{adapterId:maxlength(200)}/values-at-times")]
         [ProducesResponseType(typeof(IAsyncEnumerable<TagValueQueryResult>), 200)]
         public async Task<IActionResult> ReadValuesAtTimes(string adapterId, ReadTagValuesAtTimesRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -461,9 +466,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         /// </remarks>
         /// <seealso cref="DefaultDataFunctions"/>
         [HttpGet]
-        [Route("{adapterId}/processed")]
+        [Route("{adapterId:maxlength(200)}/processed")]
         [ProducesResponseType(typeof(IAsyncEnumerable<ProcessedTagValueQueryResult>), 200)]
-        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> ReadProcessedValues(
             string adapterId,
             [FromQuery] string[] tag = null!,
@@ -491,13 +495,16 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
 
             var interval = TimeSpan.FromSeconds((end.Value - start.Value).TotalSeconds / count);
 
-            return ReadProcessedValues(adapterId, new ReadProcessedTagValuesRequest() {
+            var request = new ReadProcessedTagValuesRequest() {
                 Tags = tag ?? Array.Empty<string>(),
                 UtcStartTime = Util.ConvertToUniversalTime(start.Value),
                 UtcEndTime = Util.ConvertToUniversalTime(end.Value),
                 SampleInterval = interval,
                 DataFunctions = function ?? Array.Empty<string>()
-            }, cancellationToken);
+            };
+            Validator.ValidateObject(request, new ValidationContext(request), true);
+
+            return ReadProcessedValues(adapterId, request, cancellationToken);
         }
 
 
@@ -524,7 +531,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         /// </remarks>
         /// <seealso cref="DefaultDataFunctions"/>
         [HttpPost]
-        [Route("{adapterId}/processed")]
+        [Route("{adapterId:maxlength(200)}/processed")]
         [ProducesResponseType(typeof(IAsyncEnumerable<ProcessedTagValueQueryResult>), 200)]
         public async Task<IActionResult> ReadProcessedValues(string adapterId, ReadProcessedTagValuesRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -570,9 +577,8 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         /// </remarks>
         /// <seealso cref="DefaultDataFunctions"/>
         [HttpGet]
-        [Route("{adapterId}/supported-aggregations")]
+        [Route("{adapterId:maxlength(200)}/supported-aggregations")]
         [ProducesResponseType(typeof(IAsyncEnumerable<DataFunctionDescriptor>), 200)]
-        [UseAdapterRequestValidation(true)]
         public Task<IActionResult> GetSupportedDataFunctions(string adapterId, CancellationToken cancellationToken) {
             return GetSupportedDataFunctions(adapterId, new GetSupportedDataFunctionsRequest(), cancellationToken);
         }
@@ -601,7 +607,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         /// </remarks>
         /// <seealso cref="DefaultDataFunctions"/>
         [HttpPost]
-        [Route("{adapterId}/supported-aggregations")]
+        [Route("{adapterId:maxlength(200)}/supported-aggregations")]
         [ProducesResponseType(typeof(IAsyncEnumerable<DataFunctionDescriptor>), 200)]
         public async Task<IActionResult> GetSupportedDataFunctions(string adapterId, GetSupportedDataFunctionsRequest request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -644,7 +650,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   objects (one per sample written).
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/write/snapshot")]
+        [Route("{adapterId:maxlength(200)}/write/snapshot")]
         [ProducesResponseType(typeof(IAsyncEnumerable<WriteTagValueResult>), 200)]
         public async Task<IActionResult> WriteSnapshotValues(string adapterId, WriteTagValuesRequestExtended request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);
@@ -689,7 +695,7 @@ namespace DataCore.Adapter.AspNetCore.Controllers {
         ///   objects (one per sample written).
         /// </returns>
         [HttpPost]
-        [Route("{adapterId}/write/history")]
+        [Route("{adapterId:maxlength(200)}/write/history")]
         [ProducesResponseType(typeof(IAsyncEnumerable<WriteTagValueResult>), 200)]
         public async Task<IActionResult> WriteHistoricalValues(string adapterId, WriteTagValuesRequestExtended request, CancellationToken cancellationToken) {
             var callContext = new HttpAdapterCallContext(HttpContext);

--- a/src/DataCore.Adapter.Core/AssetModel/BrowseAssetModelNodesRequest.cs
+++ b/src/DataCore.Adapter.Core/AssetModel/BrowseAssetModelNodesRequest.cs
@@ -1,25 +1,31 @@
-﻿using DataCore.Adapter.Common;
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
+
+using DataCore.Adapter.Common;
 
 namespace DataCore.Adapter.AssetModel {
 
     /// <summary>
     /// Describes a request to browse nodes in an adapter's asset model.
     /// </summary>
-    public class BrowseAssetModelNodesRequest : PageableAdapterRequest {
+    public class BrowseAssetModelNodesRequest : AdapterRequest, IPageableAdapterRequest {
 
         /// <summary>
         /// The ID of the parent node to start at. Specify <see langword="null"/> to request top-level 
         /// nodes.
         /// </summary>
+        [MaxLength(200)]
         public string? ParentId { get; set; }
 
+        /// <inheritdoc/>
+        [Range(1, 500)]
+        [DefaultValue(100)]
+        public int PageSize { get; set; } = 100;
 
-        /// <summary>
-        /// Creates a new <see cref="BrowseAssetModelNodesRequest"/> object.
-        /// </summary>
-        public BrowseAssetModelNodesRequest() {
-            PageSize = 100;
-        }
+        /// <inheritdoc/>
+        [Range(1, int.MaxValue)]
+        [DefaultValue(1)]
+        public int Page { get; set; } = 1;
 
     }
 }

--- a/src/DataCore.Adapter.Core/AssetModel/FindAssetModelNodesRequest.cs
+++ b/src/DataCore.Adapter.Core/AssetModel/FindAssetModelNodesRequest.cs
@@ -7,17 +7,29 @@ namespace DataCore.Adapter.AssetModel {
     /// <summary>
     /// Describes a request to search for asset model nodes.
     /// </summary>
-    public class FindAssetModelNodesRequest : PageableAdapterRequest {
+    public class FindAssetModelNodesRequest : AdapterRequest, IPageableAdapterRequest {
 
         /// <summary>
         /// The name filter.
         /// </summary>
+        [MaxLength(200)]
         public string? Name { get; set; }
 
         /// <summary>
         /// The description filter.
         /// </summary>
+        [MaxLength(200)]
         public string? Description { get; set; }
+
+        /// <inheritdoc/>
+        [Range(1, 500)]
+        [DefaultValue(10)]
+        public int PageSize { get; set; } = 10;
+
+        /// <inheritdoc/>
+        [Range(1, int.MaxValue)]
+        [DefaultValue(1)]
+        public int Page { get; set; } = 1;
 
     }
 }

--- a/src/DataCore.Adapter.Core/AssetModel/GetAssetModelNodesRequest.cs
+++ b/src/DataCore.Adapter.Core/AssetModel/GetAssetModelNodesRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 
 using DataCore.Adapter.Common;
@@ -16,6 +17,7 @@ namespace DataCore.Adapter.AssetModel {
         /// </summary>
         [Required]
         [MinLength(1)]
+        [MaxLength(500)]
         public IEnumerable<string> Nodes { get; set; } = Array.Empty<string>();
 
 
@@ -29,8 +31,16 @@ namespace DataCore.Adapter.AssetModel {
         ///   A collection of validation errors.
         /// </returns>
         protected override IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+            foreach (var item in base.Validate(validationContext)) {
+                yield return item;
+            }
+
             if (Nodes.Any(x => x == null)) {
                 yield return new ValidationResult(SharedResources.Error_NodeIdCannotBeNull, new[] { nameof(Nodes) });
+            }
+
+            if (Nodes.Any(x => x?.Length > 200)) {
+                yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_IdIsTooLong, 200), new[] { nameof(Nodes) });
             }
         }
 

--- a/src/DataCore.Adapter.Core/Common/AdapterDescriptor.cs
+++ b/src/DataCore.Adapter.Core/Common/AdapterDescriptor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Text.Json.Serialization;
 
 namespace DataCore.Adapter.Common {
@@ -10,10 +11,16 @@ namespace DataCore.Adapter.Common {
     public class AdapterDescriptor {
 
         /// <summary>
+        /// The maximum length of an adapter <see cref="Id"/>.
+        /// </summary>
+        public const int IdMaxLength = 200;
+
+        /// <summary>
         /// The identifier for the adapter. This can be any type of value, as long as it is unique 
         /// within the hosting application, and does not change.
         /// </summary>
         [Required]
+        [MaxLength(IdMaxLength)]
         public string Id { get; }
 
         /// <summary>
@@ -40,17 +47,19 @@ namespace DataCore.Adapter.Common {
         /// <param name="description">
         ///   The adapter description.
         /// </param>
-        /// <exception cref="ArgumentException">
-        ///   <paramref name="id"/> is <see langword="null"/> or white space.
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="id"/> is <see langword="null"/>, white space or longer than <see cref="IdMaxLength"/>.
         /// </exception>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="name"/> is <see langword="null"/> or white space.
         /// </exception>
         [JsonConstructor]
         public AdapterDescriptor(string id, string name, string? description) {
             Id = string.IsNullOrWhiteSpace(id)
                 ? throw new ArgumentOutOfRangeException(nameof(id), SharedResources.Error_IdIsRequired)
-                : id;
+                : id.Length > IdMaxLength
+                    ? throw new ArgumentOutOfRangeException(nameof(id), string.Format(CultureInfo.CurrentCulture, SharedResources.Error_IdIsTooLong, IdMaxLength))
+                    : id;
             Name = string.IsNullOrWhiteSpace(name)
                 ? throw new ArgumentOutOfRangeException(nameof(name), SharedResources.Error_NameIsRequired)
                 : name;
@@ -71,10 +80,10 @@ namespace DataCore.Adapter.Common {
         /// <param name="description">
         ///   The adapter description.
         /// </param>
-        /// <exception cref="ArgumentException">
-        ///   <paramref name="id"/> is <see langword="null"/> or white space.
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="id"/> is <see langword="null"/>, white space or longer than <see cref="IdMaxLength"/>.
         /// </exception>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="name"/> is <see langword="null"/> or white space.
         /// </exception>
         [Obsolete("Use constructor instead.", true)]
@@ -92,10 +101,10 @@ namespace DataCore.Adapter.Common {
         /// <param name="name">
         ///   The adapter name.
         /// </param>
-        /// <exception cref="ArgumentException">
-        ///   <paramref name="id"/> is <see langword="null"/> or white space.
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="id"/> is <see langword="null"/>, white space or longer than <see cref="IdMaxLength"/>.
         /// </exception>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="name"/> is <see langword="null"/> or white space.
         /// </exception>
         [Obsolete("Use constructor instead.", true)]
@@ -111,8 +120,8 @@ namespace DataCore.Adapter.Common {
         /// <param name="id">
         ///   The adapter ID.
         /// </param>
-        /// <exception cref="ArgumentException">
-        ///   <paramref name="id"/> is <see langword="null"/> or white space.
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="id"/> is <see langword="null"/>, white space or longer than <see cref="IdMaxLength"/>.
         /// </exception>
         [Obsolete("Use constructor instead.", true)]
         public static AdapterDescriptor Create(string id) {

--- a/src/DataCore.Adapter.Core/Common/AdapterRequest.cs
+++ b/src/DataCore.Adapter.Core/Common/AdapterRequest.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
 
 namespace DataCore.Adapter.Common {
 
@@ -7,6 +9,21 @@ namespace DataCore.Adapter.Common {
     /// Base class that adapter request objects can inherit from.
     /// </summary>
     public abstract class AdapterRequest : IValidatableObject {
+
+        /// <summary>
+        /// The maximum length of a key in the <see cref="Properties"/> dictionary.
+        /// </summary>
+        public const int MaxPropertyKeyLength = 50;
+
+        /// <summary>
+        /// The maximum length of a value in the <see cref="Properties"/> dictionary.
+        /// </summary>
+        public const int MaxPropertyValueLength = 100;
+
+        /// <summary>
+        /// The maximum length of the <see cref="Properties"/> dictionary.
+        /// </summary>
+        public const int MaxPropertiesCount = 20;
 
         /// <summary>
         /// Additional request properties. These can be used to provide bespoke query parameters 
@@ -39,7 +56,17 @@ namespace DataCore.Adapter.Common {
         ///   A collection of validation errors.
         /// </returns>
         protected virtual IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
-            return System.Array.Empty<ValidationResult>();
+            if (Properties != null) {
+                if (Properties.Any(x => x.Key.Length > MaxPropertyKeyLength)) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_KeyIsTooLong, MaxPropertyKeyLength), new[] { nameof(Properties) });
+                }
+                if (Properties.Any(x => x.Value != null && x.Value.Length > MaxPropertyValueLength)) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_ValueIsTooLong, MaxPropertyValueLength), new[] { nameof(Properties) });
+                }
+                if (Properties.Count > MaxPropertiesCount) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_TooManyEntries, MaxPropertiesCount), new[] { nameof(Properties) });
+                }
+            }
         }
     }
 }

--- a/src/DataCore.Adapter.Core/Common/FindAdaptersRequest.cs
+++ b/src/DataCore.Adapter.Core/Common/FindAdaptersRequest.cs
@@ -1,11 +1,15 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
+using System.Linq;
+using System.Globalization;
 
 namespace DataCore.Adapter.Common {
 
     /// <summary>
     /// A request to retrieve a filtered list of adapters.
     /// </summary>
-    public class FindAdaptersRequest : PageableAdapterRequest {
+    public class FindAdaptersRequest : AdapterRequest, IPageableAdapterRequest {
 
         /// <summary>
         /// The adapter ID filter. Partial matches can be specified.
@@ -14,6 +18,7 @@ namespace DataCore.Adapter.Common {
         ///   Partial matches can be specified; <c>?</c> and <c>*</c> can be used as single- and 
         ///   multi-character wildcards respectively.
         /// </remarks>
+        [MaxLength(AdapterDescriptor.IdMaxLength)]
         public string? Id { get; set; }
 
         /// <summary>
@@ -23,6 +28,7 @@ namespace DataCore.Adapter.Common {
         ///   Partial matches can be specified; <c>?</c> and <c>*</c> can be used as single- and 
         ///   multi-character wildcards respectively.
         /// </remarks>
+        [MaxLength(200)]
         public string? Name { get; set; }
 
         /// <summary>
@@ -32,6 +38,7 @@ namespace DataCore.Adapter.Common {
         ///   Partial matches can be specified; <c>?</c> and <c>*</c> can be used as single- and 
         ///   multi-character wildcards respectively.
         /// </remarks>
+        [MaxLength(200)]
         public string? Description { get; set; }
 
         /// <summary>
@@ -42,7 +49,32 @@ namespace DataCore.Adapter.Common {
         ///   filters, the <see cref="Features"/> filters must exactly match the name of a 
         ///   standard or extension feature.
         /// </remarks>
+        [MaxLength(10)]
         public IEnumerable<string>? Features { get; set; }
+
+        /// <inheritdoc/>
+        [Range(1, 500)]
+        [DefaultValue(10)]
+        public int PageSize { get; set; } = 10;
+
+        /// <inheritdoc/>
+        [Range(1, int.MaxValue)]
+        [DefaultValue(1)]
+        public int Page { get; set; } = 1;
+
+
+        /// <inheritdoc/>
+        protected override IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+            foreach (var item in base.Validate(validationContext)) {
+                yield return item;
+            }
+
+            if (Features != null) {
+                if (Features.Any(x => x != null && x.Length > 200)) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_CollectionItemIsTooLong, 200), new[] { nameof(Features) });
+                }
+            }
+        }
 
     }
 }

--- a/src/DataCore.Adapter.Core/Common/PageableAdapterRequest.cs
+++ b/src/DataCore.Adapter.Core/Common/PageableAdapterRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace DataCore.Adapter.Common {
@@ -6,6 +7,7 @@ namespace DataCore.Adapter.Common {
     /// <summary>
     /// Base class for adapter requests that support paging.
     /// </summary>
+    [Obsolete("Implement IPageableAdapterRequest directly and supply appropriate validation ranges for PageSize and Page.", true)]
     public abstract class PageableAdapterRequest : AdapterRequest, IPageableAdapterRequest {
 
         /// <inheritdoc/>

--- a/src/DataCore.Adapter.Core/DataValidation/MaxUriLengthAttribute.cs
+++ b/src/DataCore.Adapter.Core/DataValidation/MaxUriLengthAttribute.cs
@@ -27,7 +27,7 @@ namespace DataCore.Adapter.DataValidation {
 
 
         /// <inheritdoc/>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext) {
+        protected override ValidationResult IsValid(object? value, ValidationContext validationContext) {
             if (Length > 0 && value is Uri uri && uri.ToString().Length > Length) {
                 return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
             }

--- a/src/DataCore.Adapter.Core/DataValidation/MaxUriLengthAttribute.cs
+++ b/src/DataCore.Adapter.Core/DataValidation/MaxUriLengthAttribute.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace DataCore.Adapter.DataValidation {
+
+    /// <summary>
+    /// Specifies the maximum length allowed on a <see cref="Uri"/> property.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class MaxUriLengthAttribute : ValidationAttribute {
+
+        /// <summary>
+        /// The maximum length of the <see cref="Uri"/>.
+        /// </summary>
+        public int Length { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="MaxUriLengthAttribute"/> instance.
+        /// </summary>
+        /// <param name="length">
+        ///   The maximum length of the URI.
+        /// </param>
+        public MaxUriLengthAttribute(int length) { 
+            Length = length; 
+        }
+
+
+        /// <inheritdoc/>
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext) {
+            if (Length > 0 && value is Uri uri && uri.ToString().Length > Length) {
+                return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
+            }
+
+            return null!;
+        }
+
+
+        /// <inheritdoc/>
+        public override string FormatErrorMessage(string name) => new MaxLengthAttribute(Length).FormatErrorMessage(name);
+
+    }
+}

--- a/src/DataCore.Adapter.Core/Diagnostics/ConfigurationChangesSubscriptionRequest.cs
+++ b/src/DataCore.Adapter.Core/Diagnostics/ConfigurationChangesSubscriptionRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 
 using DataCore.Adapter.Common;
@@ -27,6 +28,10 @@ namespace DataCore.Adapter.Diagnostics {
 
             if (ItemTypes != null && ItemTypes.Any(x => string.IsNullOrWhiteSpace(x))) {
                 yield return new ValidationResult(SharedResources.Error_ItemTypeCannotBeNull, new[] { nameof(ItemTypes) });
+            }
+
+            if (ItemTypes != null && ItemTypes.Any(x => x?.Length > 50)) {
+                yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_CollectionItemIsTooLong, 50), new[] { nameof(ItemTypes) });
             }
         }
 

--- a/src/DataCore.Adapter.Core/Events/CreateEventMessageTopicSubscriptionRequest.cs
+++ b/src/DataCore.Adapter.Core/Events/CreateEventMessageTopicSubscriptionRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 
 namespace DataCore.Adapter.Events {
@@ -26,6 +27,9 @@ namespace DataCore.Adapter.Events {
             if (Topics != null) {
                 if (Topics.Any(string.IsNullOrWhiteSpace)) {
                     yield return new ValidationResult(SharedResources.Error_SubscriptionTopicsCannotBeNullOrWhiteSpace, new[] { nameof(Topics) });
+                }
+                if (Topics.Any(x => x?.Length > 500)) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_CollectionItemIsTooLong, 500), new[] { nameof(Topics) });
                 }
                 if (Topics.GroupBy(x => x).Any(x => x.Count() > 1)) {
                     yield return new ValidationResult(SharedResources.Error_DuplicateSubscriptionTopicsAreNotAllowed, new[] { nameof(Topics) });

--- a/src/DataCore.Adapter.Core/Events/ReadEventMessagesForTimeRangeRequest.cs
+++ b/src/DataCore.Adapter.Core/Events/ReadEventMessagesForTimeRangeRequest.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+
 using DataCore.Adapter.Common;
 
 namespace DataCore.Adapter.Events {
@@ -33,7 +36,7 @@ namespace DataCore.Adapter.Events {
         /// <summary>
         /// The page size for the query.
         /// </summary>
-        [Range(1, int.MaxValue)]
+        [Range(1, 500)]
         [DefaultValue(10)]
         public int PageSize { get; set; } = 10;
 
@@ -57,6 +60,10 @@ namespace DataCore.Adapter.Events {
         protected override IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
             foreach (var item in base.Validate(validationContext)) {
                 yield return item;
+            }
+
+            if (Topics != null && Topics.Any(x => x?.Length > 500)) {
+                yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_CollectionItemIsTooLong, 500), new[] { nameof(Topics) });
             }
 
             if (UtcStartTime >= UtcEndTime) {

--- a/src/DataCore.Adapter.Core/Events/ReadEventMessagesUsingCursorRequest.cs
+++ b/src/DataCore.Adapter.Core/Events/ReadEventMessagesUsingCursorRequest.cs
@@ -12,17 +12,19 @@ namespace DataCore.Adapter.Events {
         /// The topic to read messages for. This property will be ignored if the adapter does not 
         /// support a topic-based event model.
         /// </summary>
+        [MaxLength(500)]
         public string? Topic { get; set; }
 
         /// <summary>
         /// The cursor position to start the query at.
         /// </summary>
+        [MaxLength(500)]
         public string? CursorPosition { get; set; }
 
         /// <summary>
         /// The page size for the query.
         /// </summary>
-        [Range(1, int.MaxValue)]
+        [Range(1, 500)]
         [DefaultValue(10)]
         public int PageSize { get; set; } = 10;
 

--- a/src/DataCore.Adapter.Core/Events/WriteEventMessagesRequestExtended.cs
+++ b/src/DataCore.Adapter.Core/Events/WriteEventMessagesRequestExtended.cs
@@ -13,6 +13,7 @@ namespace DataCore.Adapter.Events {
         /// </summary>
         [Required]
         [MinLength(1)]
+        [MaxLength(10000)]
         public WriteEventMessageItem[] Events { get; set; } = Array.Empty<WriteEventMessageItem>();
 
     }

--- a/src/DataCore.Adapter.Core/Extensions/CustomFunctionInvocationRequest.cs
+++ b/src/DataCore.Adapter.Core/Extensions/CustomFunctionInvocationRequest.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 
 using DataCore.Adapter.Common;
+using DataCore.Adapter.DataValidation;
 
 namespace DataCore.Adapter.Extensions {
 
@@ -26,6 +27,7 @@ namespace DataCore.Adapter.Extensions {
         ///   to an adapter-defined base URI.
         /// </remarks>
         [Required]
+        [MaxUriLength(500)]
         public Uri Id { get; set; } = default!;
 
         /// <summary>

--- a/src/DataCore.Adapter.Core/Extensions/GetCustomFunctionRequest.cs
+++ b/src/DataCore.Adapter.Core/Extensions/GetCustomFunctionRequest.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 
 using DataCore.Adapter.Common;
+using DataCore.Adapter.DataValidation;
 
 namespace DataCore.Adapter.Extensions {
 
@@ -18,6 +19,7 @@ namespace DataCore.Adapter.Extensions {
         ///   to an adapter-defined base URI.
         /// </remarks>
         [Required]
+        [MaxUriLength(500)]
         public Uri Id { get; set; } = default!;
 
     }

--- a/src/DataCore.Adapter.Core/Extensions/GetCustomFunctionsRequest.cs
+++ b/src/DataCore.Adapter.Core/Extensions/GetCustomFunctionsRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 using DataCore.Adapter.Common;
 
@@ -7,7 +8,7 @@ namespace DataCore.Adapter.Extensions {
     /// <summary>
     /// A request to retrieve the available custom functions on an adapter.
     /// </summary>
-    public class GetCustomFunctionsRequest : PageableAdapterRequest {
+    public class GetCustomFunctionsRequest : AdapterRequest, IPageableAdapterRequest {
 
         /// <summary>
         /// The ID filter to apply to the functions.
@@ -26,6 +27,16 @@ namespace DataCore.Adapter.Extensions {
         /// </summary>
         [MaxLength(100)]
         public string? Description { get; set; }
+
+        /// <inheritdoc/>
+        [Range(1, 100)]
+        [DefaultValue(10)]
+        public int PageSize { get; set; } = 10;
+
+        /// <inheritdoc/>
+        [Range(1, int.MaxValue)]
+        [DefaultValue(1)]
+        public int Page { get; set; } = 1;
 
     }
 

--- a/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
@@ -1,6 +1,47 @@
 ﻿#nullable enable
+const DataCore.Adapter.Common.AdapterDescriptor.IdMaxLength = 200 -> int
+const DataCore.Adapter.Common.AdapterRequest.MaxPropertiesCount = 20 -> int
+const DataCore.Adapter.Common.AdapterRequest.MaxPropertyKeyLength = 50 -> int
+const DataCore.Adapter.Common.AdapterRequest.MaxPropertyValueLength = 100 -> int
 const DataCore.Adapter.WellKnownProperties.TagValue.Stepped = "Stepped" -> string!
+DataCore.Adapter.AssetModel.BrowseAssetModelNodesRequest.Page.get -> int
+DataCore.Adapter.AssetModel.BrowseAssetModelNodesRequest.Page.set -> void
+DataCore.Adapter.AssetModel.BrowseAssetModelNodesRequest.PageSize.get -> int
+DataCore.Adapter.AssetModel.BrowseAssetModelNodesRequest.PageSize.set -> void
+DataCore.Adapter.AssetModel.FindAssetModelNodesRequest.Page.get -> int
+DataCore.Adapter.AssetModel.FindAssetModelNodesRequest.Page.set -> void
+DataCore.Adapter.AssetModel.FindAssetModelNodesRequest.PageSize.get -> int
+DataCore.Adapter.AssetModel.FindAssetModelNodesRequest.PageSize.set -> void
+DataCore.Adapter.Common.FindAdaptersRequest.Page.get -> int
+DataCore.Adapter.Common.FindAdaptersRequest.Page.set -> void
+DataCore.Adapter.Common.FindAdaptersRequest.PageSize.get -> int
+DataCore.Adapter.Common.FindAdaptersRequest.PageSize.set -> void
+DataCore.Adapter.DataValidation.MaxUriLengthAttribute
+DataCore.Adapter.DataValidation.MaxUriLengthAttribute.Length.get -> int
+DataCore.Adapter.DataValidation.MaxUriLengthAttribute.MaxUriLengthAttribute(int length) -> void
+DataCore.Adapter.Extensions.GetCustomFunctionsRequest.Page.get -> int
+DataCore.Adapter.Extensions.GetCustomFunctionsRequest.Page.set -> void
+DataCore.Adapter.Extensions.GetCustomFunctionsRequest.PageSize.get -> int
+DataCore.Adapter.Extensions.GetCustomFunctionsRequest.PageSize.set -> void
+DataCore.Adapter.Tags.FindTagsRequest.Page.get -> int
+DataCore.Adapter.Tags.FindTagsRequest.Page.set -> void
+DataCore.Adapter.Tags.FindTagsRequest.PageSize.get -> int
+DataCore.Adapter.Tags.FindTagsRequest.PageSize.set -> void
+DataCore.Adapter.Tags.GetTagPropertiesRequest.Page.get -> int
+DataCore.Adapter.Tags.GetTagPropertiesRequest.Page.set -> void
+DataCore.Adapter.Tags.GetTagPropertiesRequest.PageSize.get -> int
+DataCore.Adapter.Tags.GetTagPropertiesRequest.PageSize.set -> void
+override DataCore.Adapter.Common.FindAdaptersRequest.Validate(System.ComponentModel.DataAnnotations.ValidationContext! validationContext) -> System.Collections.Generic.IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult!>!
+override DataCore.Adapter.DataValidation.MaxUriLengthAttribute.FormatErrorMessage(string! name) -> string!
 static DataCore.Adapter.Common.VariantExtensions.IsFloatingPointNumericType(this DataCore.Adapter.Common.Variant variant) -> bool
 static DataCore.Adapter.Common.VariantExtensions.IsFloatingPointNumericType(this DataCore.Adapter.Common.VariantType variantType) -> bool
 static DataCore.Adapter.RealTimeData.TagValueExtensions.IsFloatingPointNumericType(this DataCore.Adapter.RealTimeData.TagValue! value) -> bool
 static DataCore.Adapter.RealTimeData.TagValueExtensions.TryGetSteppedFlag(this DataCore.Adapter.RealTimeData.TagValueExtended! value, out bool stepped) -> bool
+~static DataCore.Adapter.SharedResources.Error_CollectionItemIsTooLong.get -> string
+~static DataCore.Adapter.SharedResources.Error_DescriptionIsTooLong.get -> string
+~static DataCore.Adapter.SharedResources.Error_IdIsTooLong.get -> string
+~static DataCore.Adapter.SharedResources.Error_KeyIsTooLong.get -> string
+~static DataCore.Adapter.SharedResources.Error_NameIsTooLong.get -> string
+~static DataCore.Adapter.SharedResources.Error_TooManyEntries.get -> string
+~static DataCore.Adapter.SharedResources.Error_UnitIsTooLong.get -> string
+~static DataCore.Adapter.SharedResources.Error_ValueIsTooLong.get -> string

--- a/src/DataCore.Adapter.Core/RealTimeData/CreateAnnotationRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/CreateAnnotationRequest.cs
@@ -13,6 +13,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// The ID or name of the tag that the annotation is associated with.
         /// </summary>
         [Required]
+        [MaxLength(500)]
         public string Tag { get; set; } = default!;
 
         /// <summary>

--- a/src/DataCore.Adapter.Core/RealTimeData/CreateSnapshotTagValueSubscriptionRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/CreateSnapshotTagValueSubscriptionRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 
 using DataCore.Adapter.Common;
@@ -35,6 +36,9 @@ namespace DataCore.Adapter.RealTimeData {
             if (Tags != null) {
                 if (Tags.Any(string.IsNullOrWhiteSpace)) {
                     yield return new ValidationResult(SharedResources.Error_SubscriptionTopicsCannotBeNullOrWhiteSpace, new[] { nameof(Tags) });
+                }
+                if (Tags.Any(x => x?.Length > 500)) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_CollectionItemIsTooLong, 500), new[] { nameof(Tags) });
                 }
                 if (Tags.GroupBy(x => x).Any(x => x.Count() > 1)) {
                     yield return new ValidationResult(SharedResources.Error_DuplicateSubscriptionTopicsAreNotAllowed, new[] { nameof(Tags) });

--- a/src/DataCore.Adapter.Core/RealTimeData/DeleteAnnotationRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/DeleteAnnotationRequest.cs
@@ -13,12 +13,14 @@ namespace DataCore.Adapter.RealTimeData {
         /// The tag ID or name.
         /// </summary>
         [Required]
+        [MaxLength(500)]
         public string Tag { get; set; } = default!;
 
         /// <summary>
         /// The annotation ID.
         /// </summary>
         [Required]
+        [MaxLength(500)]
         public string AnnotationId { get; set; } = default!;
 
     }

--- a/src/DataCore.Adapter.Core/RealTimeData/ReadAnnotationRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/ReadAnnotationRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using DataCore.Adapter.Common;
+using DataCore.Adapter.Tags;
 
 namespace DataCore.Adapter.RealTimeData {
 
@@ -12,12 +13,14 @@ namespace DataCore.Adapter.RealTimeData {
         /// The tag ID or name for the annotation.
         /// </summary>
         [Required]
+        [MaxLength(500)]
         public string Tag { get; set; } = default!;
 
         /// <summary>
         /// The annotation ID.
         /// </summary>
         [Required]
+        [MaxLength(500)]
         public string AnnotationId { get; set; } = default!;
 
     }

--- a/src/DataCore.Adapter.Core/RealTimeData/ReadAnnotationsRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/ReadAnnotationsRequest.cs
@@ -1,18 +1,16 @@
-﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace DataCore.Adapter.RealTimeData {
 
     /// <summary>
     /// Describes a request to read annotations on tag values.
     /// </summary>
-    public sealed class ReadAnnotationsRequest: ReadHistoricalTagValuesRequest { 
-    
+    public sealed class ReadAnnotationsRequest: ReadHistoricalTagValuesRequest {
+
         /// <summary>
         /// The maximum number of annotations to retrieve per tag.
         /// </summary>
         [Required]
-        [DefaultValue(50)]
         public int AnnotationCount { get; set; }
 
     }

--- a/src/DataCore.Adapter.Core/RealTimeData/ReadProcessedTagValuesRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/ReadProcessedTagValuesRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 
 namespace DataCore.Adapter.RealTimeData {
@@ -40,6 +41,10 @@ namespace DataCore.Adapter.RealTimeData {
 
             if (DataFunctions.Any(x => x == null)) {
                 yield return new ValidationResult(SharedResources.Error_DataFunctionCannotBeNull, new[] { nameof(DataFunctions) });
+            }
+
+            if (DataFunctions.Any(x => x?.Length > 50)) {
+                yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_CollectionItemIsTooLong, 50), new[] { nameof(DataFunctions) });
             }
 
             if (SampleInterval <= TimeSpan.Zero) {

--- a/src/DataCore.Adapter.Core/RealTimeData/ReadTagDataRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/ReadTagDataRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 
 using DataCore.Adapter.Common;
@@ -31,8 +32,17 @@ namespace DataCore.Adapter.RealTimeData {
         ///   A collection of validation errors.
         /// </returns>
         protected override IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
-            if (Tags.Any(x => x == null)) {
-                yield return new ValidationResult(SharedResources.Error_NameOrIdCannotBeNull, new[] { nameof(Tags) });
+            foreach (var item in base.Validate(validationContext)) {
+                yield return item;
+            }
+
+            if (Tags != null) {
+                if (Tags.Any(x => x == null)) {
+                    yield return new ValidationResult(SharedResources.Error_NameOrIdCannotBeNull, new[] { nameof(Tags) });
+                }
+                if (Tags.Any(x => x?.Length > 500)) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_CollectionItemIsTooLong, 500), new[] { nameof(Tags) });
+                }
             }
         }
 

--- a/src/DataCore.Adapter.Core/RealTimeData/ReadTagValuesAtTimesRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/ReadTagValuesAtTimesRequest.cs
@@ -14,6 +14,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// </summary>
         [Required]
         [MinLength(1)]
+        [MaxLength(500)]
         public IEnumerable<DateTime> UtcSampleTimes { get; set; } = Array.Empty<DateTime>();
 
     }

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValue.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValue.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 using DataCore.Adapter.Common;
@@ -28,6 +29,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <summary>
         /// The value units.
         /// </summary>
+        [MaxLength(50)]
         public string? Units { get; }
 
 

--- a/src/DataCore.Adapter.Core/RealTimeData/UpdateAnnotationRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/UpdateAnnotationRequest.cs
@@ -13,12 +13,14 @@ namespace DataCore.Adapter.RealTimeData {
         /// The tag name or ID.
         /// </summary>
         [Required]
+        [MaxLength(500)]
         public string Tag { get; set; } = default!;
 
         /// <summary>
         /// The annotation ID.
         /// </summary>
         [Required]
+        [MaxLength(500)]
         public string AnnotationId { get; set; } = default!;
 
         /// <summary>

--- a/src/DataCore.Adapter.Core/RealTimeData/WriteTagValueItem.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/WriteTagValueItem.cs
@@ -10,12 +10,14 @@ namespace DataCore.Adapter.RealTimeData {
         /// <summary>
         /// An optional correlation ID to assign to the write operation.
         /// </summary>
+        [MaxLength(500)]
         public string? CorrelationId { get; set; }
 
         /// <summary>
         /// The tag ID.
         /// </summary>
         [Required]
+        [MaxLength(500)]
         public string TagId { get; set; } = default!;
 
         /// <summary>

--- a/src/DataCore.Adapter.Core/RealTimeData/WriteTagValuesRequestExtended.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/WriteTagValuesRequestExtended.cs
@@ -13,6 +13,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// </summary>
         [Required]
         [MinLength(1)]
+        [MaxLength(10000)]
         public WriteTagValueItem[] Values { get; set; } = Array.Empty<WriteTagValueItem>();
 
     }

--- a/src/DataCore.Adapter.Core/SharedResources.Designer.cs
+++ b/src/DataCore.Adapter.Core/SharedResources.Designer.cs
@@ -133,6 +133,15 @@ namespace DataCore.Adapter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Maximum length of an entry in the collection is {0}..
+        /// </summary>
+        public static string Error_CollectionItemIsTooLong {
+            get {
+                return ResourceManager.GetString("Error_CollectionItemIsTooLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must specify a content type..
         /// </summary>
         public static string Error_ContentTypeIsRequired {
@@ -147,6 +156,15 @@ namespace DataCore.Adapter {
         public static string Error_DataFunctionCannotBeNull {
             get {
                 return ResourceManager.GetString("Error_DataFunctionCannotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum description length is {0}..
+        /// </summary>
+        public static string Error_DescriptionIsTooLong {
+            get {
+                return ResourceManager.GetString("Error_DescriptionIsTooLong", resourceCulture);
             }
         }
         
@@ -192,6 +210,15 @@ namespace DataCore.Adapter {
         public static string Error_IdIsRequired {
             get {
                 return ResourceManager.GetString("Error_IdIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum ID length is {0}..
+        /// </summary>
+        public static string Error_IdIsTooLong {
+            get {
+                return ResourceManager.GetString("Error_IdIsTooLong", resourceCulture);
             }
         }
         
@@ -277,11 +304,29 @@ namespace DataCore.Adapter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Maximum key length is {0}..
+        /// </summary>
+        public static string Error_KeyIsTooLong {
+            get {
+                return ResourceManager.GetString("Error_KeyIsTooLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must specify a name..
         /// </summary>
         public static string Error_NameIsRequired {
             get {
                 return ResourceManager.GetString("Error_NameIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum name length is {0}..
+        /// </summary>
+        public static string Error_NameIsTooLong {
+            get {
+                return ResourceManager.GetString("Error_NameIsTooLong", resourceCulture);
             }
         }
         
@@ -385,6 +430,15 @@ namespace DataCore.Adapter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Maximum number of entries is {0}..
+        /// </summary>
+        public static string Error_TooManyEntries {
+            get {
+                return ResourceManager.GetString("Error_TooManyEntries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The type does not define a {0} attribute..
         /// </summary>
         public static string Error_TypeIdIsUndefined {
@@ -417,6 +471,24 @@ namespace DataCore.Adapter {
         public static string Error_UnableToResolveNameOrId {
             get {
                 return ResourceManager.GetString("Error_UnableToResolveNameOrId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum unit length is {0}..
+        /// </summary>
+        public static string Error_UnitIsTooLong {
+            get {
+                return ResourceManager.GetString("Error_UnitIsTooLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum value length is {0}..
+        /// </summary>
+        public static string Error_ValueIsTooLong {
+            get {
+                return ResourceManager.GetString("Error_ValueIsTooLong", resourceCulture);
             }
         }
         

--- a/src/DataCore.Adapter.Core/SharedResources.resx
+++ b/src/DataCore.Adapter.Core/SharedResources.resx
@@ -142,11 +142,19 @@
   <data name="Error_CannotEncodeType" xml:space="preserve">
     <value>The specified type cannot be encoded by this encoder.</value>
   </data>
+  <data name="Error_CollectionItemIsTooLong" xml:space="preserve">
+    <value>Maximum length of an entry in the collection is {0}.</value>
+    <comment>{0} - maximum length</comment>
+  </data>
   <data name="Error_ContentTypeIsRequired" xml:space="preserve">
     <value>You must specify a content type.</value>
   </data>
   <data name="Error_DataFunctionCannotBeNull" xml:space="preserve">
     <value>You cannot specify a null data function name.</value>
+  </data>
+  <data name="Error_DescriptionIsTooLong" xml:space="preserve">
+    <value>Maximum description length is {0}.</value>
+    <comment>{0} - maximum length</comment>
   </data>
   <data name="Error_DuplicateSubscriptionTopicsAreNotAllowed" xml:space="preserve">
     <value>Duplicate subscription topics are not allowed.</value>
@@ -164,6 +172,10 @@
   </data>
   <data name="Error_IdIsRequired" xml:space="preserve">
     <value>You must specify an ID.</value>
+  </data>
+  <data name="Error_IdIsTooLong" xml:space="preserve">
+    <value>Maximum ID length is {0}.</value>
+    <comment>{0} - maximum length</comment>
   </data>
   <data name="Error_IntervalCountMustBeGreaterThanZero" xml:space="preserve">
     <value>Interval count must be greater than zero.</value>
@@ -193,8 +205,16 @@
   <data name="Error_ItemTypeCannotBeNull" xml:space="preserve">
     <value>You cannot specify a null or white space item type.</value>
   </data>
+  <data name="Error_KeyIsTooLong" xml:space="preserve">
+    <value>Maximum key length is {0}.</value>
+    <comment>{0} - maximum length</comment>
+  </data>
   <data name="Error_NameIsRequired" xml:space="preserve">
     <value>You must specify a name.</value>
+  </data>
+  <data name="Error_NameIsTooLong" xml:space="preserve">
+    <value>Maximum name length is {0}.</value>
+    <comment>{0} - maximum length</comment>
   </data>
   <data name="Error_NameOrIdCannotBeNull" xml:space="preserve">
     <value>You cannot specify a null name or ID.</value>
@@ -232,6 +252,10 @@
   <data name="Error_TagSearchRequiresAtLeastOneFilter" xml:space="preserve">
     <value>At least one tag search filter field must be specified.</value>
   </data>
+  <data name="Error_TooManyEntries" xml:space="preserve">
+    <value>Maximum number of entries is {0}.</value>
+    <comment>{0} - maximum count</comment>
+  </data>
   <data name="Error_TypeIdIsUndefined" xml:space="preserve">
     <value>The type does not define a {0} attribute.</value>
     <comment>{0} - TypeIdAttribute name</comment>
@@ -245,6 +269,14 @@
   <data name="Error_UnableToResolveNameOrId" xml:space="preserve">
     <value>Unable to resolve name or ID '{0}'.</value>
     <comment>{0} - name or ID.</comment>
+  </data>
+  <data name="Error_UnitIsTooLong" xml:space="preserve">
+    <value>Maximum unit length is {0}.</value>
+    <comment>{0} - maximum length</comment>
+  </data>
+  <data name="Error_ValueIsTooLong" xml:space="preserve">
+    <value>Maximum value length is {0}.</value>
+    <comment>{0} - maximum length</comment>
   </data>
   <data name="HostInfo_Unspecified_Description" xml:space="preserve">
     <value>Host information has not been provided.</value>

--- a/src/DataCore.Adapter.Core/Tags/FindTagsRequest.cs
+++ b/src/DataCore.Adapter.Core/Tags/FindTagsRequest.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
 
 using DataCore.Adapter.Common;
 
@@ -8,26 +11,30 @@ namespace DataCore.Adapter.Tags {
     /// <summary>
     /// Describes a tag search query.
     /// </summary>
-    public sealed class FindTagsRequest : PageableAdapterRequest {
+    public sealed class FindTagsRequest : AdapterRequest, IPageableAdapterRequest {
 
         /// <summary>
         /// The tag name filter.
         /// </summary>
+        [MaxLength(500)]
         public string? Name { get; set; }
 
         /// <summary>
         /// The tag description filter.
         /// </summary>
+        [MaxLength(500)]
         public string? Description { get; set; }
 
         /// <summary>
         /// The tag units filter.
         /// </summary>
+        [MaxLength(50)]
         public string? Units { get; set; }
 
         /// <summary>
         /// The tag label filter.
         /// </summary>
+        [MaxLength(100)]
         public string? Label { get; set; }
 
         /// <summary>
@@ -40,6 +47,36 @@ namespace DataCore.Adapter.Tags {
         /// </summary>
         [DefaultValue(TagDefinitionFields.All)]
         public TagDefinitionFields ResultFields { get; set; } = TagDefinitionFields.All;
+
+        /// <inheritdoc/>
+        [Range(1, 500)]
+        [DefaultValue(10)]
+        public int PageSize { get; set; } = 10;
+
+        /// <inheritdoc/>
+        [Range(1, int.MaxValue)]
+        [DefaultValue(1)]
+        public int Page { get; set; } = 1;
+
+
+        /// <inheritdoc/>
+        protected override IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+            foreach (var item in base.Validate(validationContext)) {
+                yield return item;
+            }
+
+            if (Other != null) {
+                if (Other.Any(x => x.Key.Length > 50)) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_KeyIsTooLong, 50), new[] { nameof(Other) });
+                }
+                if (Other.Any(x => x.Value != null && x.Value.Length > 100)) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_ValueIsTooLong, 100), new[] { nameof(Other) });
+                }
+                if (Other.Count > 20) {
+                    yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_TooManyEntries, 20), new[] { nameof(Other) });
+                }
+            }
+        }
 
     }
 }

--- a/src/DataCore.Adapter.Core/Tags/GetTagPropertiesRequest.cs
+++ b/src/DataCore.Adapter.Core/Tags/GetTagPropertiesRequest.cs
@@ -1,10 +1,25 @@
-﻿using DataCore.Adapter.Common;
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
+
+using DataCore.Adapter.Common;
 
 namespace DataCore.Adapter.Tags {
 
     /// <summary>
     /// Describes a request to retrieve tag property definitions.
     /// </summary>
-    public class GetTagPropertiesRequest : PageableAdapterRequest { }
+    public class GetTagPropertiesRequest : AdapterRequest, IPageableAdapterRequest {
+
+        /// <inheritdoc/>
+        [Range(1, 500)]
+        [DefaultValue(10)]
+        public int PageSize { get; set; } = 10;
+
+        /// <inheritdoc/>
+        [Range(1, int.MaxValue)]
+        [DefaultValue(1)]
+        public int Page { get; set; } = 1;
+
+    }
 
 }

--- a/src/DataCore.Adapter.Core/Tags/GetTagsRequest.cs
+++ b/src/DataCore.Adapter.Core/Tags/GetTagsRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 
 using DataCore.Adapter.Common;
@@ -17,6 +18,7 @@ namespace DataCore.Adapter.Tags {
         /// </summary>
         [Required]
         [MinLength(1)]
+        [MaxLength(500)]
         public IEnumerable<string> Tags { get; set; } = Array.Empty<string>();
 
 
@@ -30,8 +32,14 @@ namespace DataCore.Adapter.Tags {
         ///   A collection of validation errors.
         /// </returns>
         protected override IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
+            foreach (var item in base.Validate(validationContext)) {
+                yield return item;
+            }
             if (Tags.Any(x => x == null)) {
                 yield return new ValidationResult(SharedResources.Error_NameOrIdCannotBeNull, new[] { nameof(Tags) });
+            }
+            if (Tags.Any(x => x?.Length > 500)) {
+                yield return new ValidationResult(string.Format(CultureInfo.CurrentCulture, SharedResources.Error_NameIsTooLong, 500), new[] { nameof(Tags) });
             }
         }
 

--- a/src/DataCore.Adapter.Core/Tags/TagDefinition.cs
+++ b/src/DataCore.Adapter.Core/Tags/TagDefinition.cs
@@ -65,11 +65,11 @@ namespace DataCore.Adapter.Tags {
         /// <param name="labels">
         ///   Labels associated with the tag.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="id"/> is <see langword="null"/>.
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="id"/> is <see langword="null"/> or white space.
         /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="name"/> is <see langword="null"/>.
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="name"/> is <see langword="null"/> or white space.
         /// </exception>
         [JsonConstructor]
         public TagDefinition(


### PR DESCRIPTION
This PR improves validation on all request types in DataCore.Adapter.Core.

It also makes PageableAdapterRequest obsolete, as inheriting from this base class meant that subclasses could not define their own page size range.

Minimal API and MVC hosting projects have been updated to apply a max length constraint to all routes that use an adapter ID in the URL. 