### PR TITLE
Add ChannelExtensions.ToEnumerable overload with expected item count

### DIFF
--- a/src/DataCore.Adapter/ChannelExtensions.cs
+++ b/src/DataCore.Adapter/ChannelExtensions.cs
@@ -2151,19 +2151,24 @@ namespace DataCore.Adapter {
         ///   The maximum number of items to read from the <see cref="IAsyncEnumerable{T}"/>. 
         ///   Specify less than one to read all items.
         /// </param>
+        /// <param name="expectedItems">
+        ///   The expected number of items that will be read. Specify less than one if this is 
+        ///   unknown.
+        /// </param>
         /// <param name="cancellationToken">
         ///   The cancellation token for the operation.
         /// </param>
         /// <returns>
         ///   The items that were read.
         /// </returns>
-        public static async Task<IEnumerable<T>> ToEnumerable<T>(this IAsyncEnumerable<T> enumerable, int maxItems, CancellationToken cancellationToken = default) {
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+        public static async Task<IEnumerable<T>> ToEnumerable<T>(this IAsyncEnumerable<T> enumerable, int maxItems, int expectedItems, CancellationToken cancellationToken = default) {
             if (enumerable == null) {
                 throw new ArgumentNullException(nameof(enumerable));
             }
-            
-            var result = maxItems > 0
-                ? new List<T>(maxItems)
+
+            var result = expectedItems > 0
+                ? new List<T>(expectedItems)
                 : new List<T>(500);
 
             using (var ctSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)) {
@@ -2181,6 +2186,33 @@ namespace DataCore.Adapter {
             }
 
             return result;
+        }
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+
+
+
+        /// <summary>
+        /// Asynchronously reads items from the <see cref="IAsyncEnumerable{T}"/> and returns them 
+        /// as an <see cref="IEnumerable{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The item type.
+        /// </typeparam>
+        /// <param name="enumerable">
+        ///   The <see cref="IAsyncEnumerable{T}"/>.
+        /// </param>
+        /// <param name="maxItems">
+        ///   The maximum number of items to read from the <see cref="IAsyncEnumerable{T}"/>. 
+        ///   Specify less than one to read all items.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   The items that were read.
+        /// </returns>
+        public static Task<IEnumerable<T>> ToEnumerable<T>(this IAsyncEnumerable<T> enumerable, int maxItems, CancellationToken cancellationToken = default) {
+            return enumerable.ToEnumerable(maxItems, -1, cancellationToken);
         }
 
 
@@ -2203,6 +2235,7 @@ namespace DataCore.Adapter {
         /// <returns>
         ///   The items that were read.
         /// </returns>
+        [Obsolete("Use ToEnumerable<T>(IAsyncEnumerable<T>,int,CancellationToken) instead.", true)]
         public static async Task<IEnumerable<T>> ToEnumerable<T>(this ChannelReader<T> channel, int maxItems = -1, CancellationToken cancellationToken = default) {
             if (channel == null) {
                 throw new ArgumentNullException(nameof(channel));

--- a/src/DataCore.Adapter/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
 DataCore.Adapter.RealTimeData.TagValueBuilder.WithSteppedTransition(bool stepped) -> DataCore.Adapter.RealTimeData.TagValueBuilder!
 static DataCore.Adapter.AdapterAccessorExtensions.GetAdapterDescriptorAsync(this DataCore.Adapter.IAdapterAccessor! adapterAccessor, DataCore.Adapter.IAdapterCallContext! context, string! adapterId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<DataCore.Adapter.Common.AdapterDescriptorExtended?>!
+static DataCore.Adapter.ChannelExtensions.ToEnumerable<T>(this System.Collections.Generic.IAsyncEnumerable<T>! enumerable, int maxItems, int expectedItems, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<T>!>!
 static DataCore.Adapter.Security.CertificateUtilities.TryLoadCertificateFromStore(string! path, bool requirePrivateKey, bool allowInvalid, out System.Security.Cryptography.X509Certificates.X509Certificate2? certificate) -> bool


### PR DESCRIPTION
Adds a new `ChannelExtensions.ToEnumerable` overload that accepts an `expectedItems` parameter.

The `expectedItems` parameter is used to configure the initial capacity of the `List<T>` that items are added to instead of the `maxItems` parameter. This is to allow for scenarios where the maximum number of items allowed to be read from the `IAsyncEnumerable<T>` is high but the expected number of items is much lower. For example, a tag data query might be allowed to return up to 20 000 samples, but the average number of samples returned by a query might only be 1000. It therefore makes more sense to initialise the list with a capacity of 1000 rather than 20 000.