### PR TITLE
Dispose features before private fields

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AdapterCore.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterCore.cs
@@ -686,8 +686,12 @@ namespace DataCore.Adapter {
             }
 
             if (disposing) {
-                DisposeCommon();
-                DisposeFeatures();
+                try {
+                    DisposeFeatures();
+                }
+                finally {
+                    DisposeCommon();
+                }
             }
 
             _disposed = true;
@@ -711,8 +715,12 @@ namespace DataCore.Adapter {
                 return;
             }
 
-            DisposeCommon();
-            await DisposeFeaturesAsync().ConfigureAwait(false);
+            try {
+                await DisposeFeaturesAsync().ConfigureAwait(false);
+            }
+            finally {
+                DisposeCommon();
+            }
         }
 
 


### PR DESCRIPTION
This PR modifies `AdapterCore` so that it disposes of its features before it disposes of local fields such as `CancellationTokenSource`s.