### PR TITLE
Add IAdapterCallContext.Services property

### DIFF
--- a/src/DataCore.Adapter.Abstractions/IAdapterCallContext.cs
+++ b/src/DataCore.Adapter.Abstractions/IAdapterCallContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Security.Claims;
 
@@ -28,6 +29,15 @@ namespace DataCore.Adapter {
         /// The <see cref="System.Globalization.CultureInfo"/> for the caller.
         /// </summary>
         CultureInfo CultureInfo { get; }
+
+        /// <summary>
+        /// The service provider for the call context.
+        /// </summary>
+        /// <remarks>
+        ///   Adapters can use the <see cref="Services"/> property to resolve scoped services for 
+        ///   the calling user.
+        /// </remarks>
+        IServiceProvider Services { get; }
 
         /// <summary>
         /// Additional items related to the call context.

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -45,4 +45,5 @@ DataCore.Adapter.Common.HostInfoBuilder.WithProperties(System.Collections.Generi
 DataCore.Adapter.Common.HostInfoBuilder.WithProperty(string! name, DataCore.Adapter.Common.Variant value) -> DataCore.Adapter.Common.HostInfoBuilder!
 DataCore.Adapter.Common.HostInfoBuilder.WithVendor(DataCore.Adapter.Common.VendorInfo? vendor) -> DataCore.Adapter.Common.HostInfoBuilder!
 DataCore.Adapter.Common.HostInfoBuilder.WithVersion(string? version) -> DataCore.Adapter.Common.HostInfoBuilder!
+DataCore.Adapter.IAdapterCallContext.Services.get -> System.IServiceProvider!
 static DataCore.Adapter.AdapterExtensions.CreateExtendedAdapterDescriptorBuilder(this DataCore.Adapter.IAdapter! adapter) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!

--- a/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/HttpAdapterCallContext.cs
@@ -42,6 +42,11 @@ namespace DataCore.Adapter.AspNetCore {
             get { return Provider.Items; }
         }
 
+        /// <inheritdoc/>
+        public IServiceProvider Services {
+            get { return Provider.RequestServices; }
+        }
+
 
         /// <summary>
         /// Creates a new <see cref="HttpAdapterCallContext"/> object.

--- a/src/DataCore.Adapter.AspNetCore.Common/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.AspNetCore.Common/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+DataCore.Adapter.AspNetCore.HttpAdapterCallContext.Services.get -> System.IServiceProvider!
 static Microsoft.Extensions.DependencyInjection.CommonAdapterConfigurationExtensions.AddDependentProcessWatcher(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, int pid, params int[]! additionalPids) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.CommonAdapterConfigurationExtensions.AddDependentProcessWatcher(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Collections.Generic.IEnumerable<int>! pids) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.CommonAdapterConfigurationExtensions.AddHostInfo(this DataCore.Adapter.DependencyInjection.IAdapterConfigurationBuilder! builder, System.Action<DataCore.Adapter.Common.HostInfoBuilder!>! configure) -> DataCore.Adapter.DependencyInjection.IAdapterConfigurationBuilder!

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AssetModelBrowserHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AssetModelBrowserHub.cs
@@ -27,7 +27,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         ///   The matching nodes.
         /// </returns>
         public async IAsyncEnumerable<AssetModelNode> BrowseAssetModelNodes(string adapterId, BrowseAssetModelNodesRequest request, [EnumeratorCancellation] CancellationToken cancellationToken) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IAssetModelBrowse>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -53,7 +53,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         ///   The matching nodes.
         /// </returns>
         public async IAsyncEnumerable<AssetModelNode> GetAssetModelNodes(string adapterId, GetAssetModelNodesRequest request, [EnumeratorCancellation] CancellationToken cancellationToken) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IAssetModelBrowse>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -79,7 +79,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         ///   The matching nodes.
         /// </returns>
         public async IAsyncEnumerable<AssetModelNode> FindAssetModelNodes(string adapterId, FindAssetModelNodesRequest request, [EnumeratorCancellation] CancellationToken cancellationToken) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IAssetModelSearch>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/ConfigurationChangesHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/ConfigurationChangesHub.cs
@@ -33,7 +33,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IConfigurationChanges>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/CustomFunctionsHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/CustomFunctionsHub.cs
@@ -29,7 +29,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             }
             ValidateObject(request);
 
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
 
             var resolvedFeature = await ResolveAdapterAndFeature<ICustomFunctions>(
                 adapterCallContext,
@@ -62,7 +62,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             }
             ValidateObject(request);
 
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
 
             var resolvedFeature = await ResolveAdapterAndFeature<ICustomFunctions>(
                 adapterCallContext,
@@ -95,7 +95,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             }
             ValidateObject(request);
 
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
 
             var resolvedFeature = await ResolveAdapterAndFeature<ICustomFunctions>(
                 adapterCallContext,

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/EventsHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/EventsHub.cs
@@ -42,7 +42,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             CancellationToken cancellationToken
         ) {
             // Resolve the adapter and feature.
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IEventMessagePushWithTopics>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -75,7 +75,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             CancellationToken cancellationToken
         ) {
             // Resolve the adapter and feature.
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IEventMessagePush>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -109,7 +109,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IReadEventMessagesForTimeRange>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -140,7 +140,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IReadEventMessagesUsingCursor>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -178,7 +178,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IWriteEventMessages>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/ExtensionFeaturesHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/ExtensionFeaturesHub.cs
@@ -33,7 +33,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             string adapterId,
             Uri featureUri
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
 
             if (featureUri == null || !featureUri.IsAbsoluteUri) {
                 throw new ArgumentException(string.Format(adapterCallContext.CultureInfo, Resources.Error_UnsupportedInterface, featureUri), nameof(featureUri));
@@ -73,7 +73,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             string adapterId,
             Uri featureUri
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
 
             if (featureUri == null || !featureUri.IsAbsoluteUri) {
                 throw new ArgumentException(string.Format(adapterCallContext.CultureInfo, Resources.Error_UnsupportedInterface, featureUri), nameof(featureUri));
@@ -115,7 +115,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             string adapterId, 
             InvocationRequest request
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             ValidateObject(request);
 
             var operationId = request.OperationId.EnsurePathHasTrailingSlash();
@@ -160,7 +160,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             ValidateObject(request);
 
             var operationId = request.OperationId.EnsurePathHasTrailingSlash();
@@ -207,7 +207,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             ValidateObject(request);
 
             var operationId = request.OperationId.EnsurePathHasTrailingSlash();

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagAnnotationsHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagAnnotationsHub.cs
@@ -24,7 +24,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         ///   The matching annotation.
         /// </returns>
         public async Task<TagValueAnnotationExtended?> ReadAnnotation(string adapterId, ReadAnnotationRequest request) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var cancellationToken = Context.ConnectionAborted;
             var adapter = await ResolveAdapterAndFeature<IReadTagValueAnnotations>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
@@ -54,7 +54,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IReadTagValueAnnotations>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -77,7 +77,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         ///   The result of the operation.
         /// </returns>
         public async Task<WriteTagValueAnnotationResult> CreateAnnotation(string adapterId, CreateAnnotationRequest request) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var cancellationToken = Context.ConnectionAborted;
             var adapter = await ResolveAdapterAndFeature<IWriteTagValueAnnotations>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
@@ -99,7 +99,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         ///   The result of the operation.
         /// </returns>
         public async Task<WriteTagValueAnnotationResult> UpdateAnnotation(string adapterId, UpdateAnnotationRequest request) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var cancellationToken = Context.ConnectionAborted;
             var adapter = await ResolveAdapterAndFeature<IWriteTagValueAnnotations>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
@@ -121,7 +121,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         ///   The result of the operation.
         /// </returns>
         public async Task<WriteTagValueAnnotationResult> DeleteAnnotation(string adapterId, DeleteAnnotationRequest request) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var cancellationToken = Context.ConnectionAborted;
             var adapter = await ResolveAdapterAndFeature<IWriteTagValueAnnotations>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagSearchHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagSearchHub.cs
@@ -33,7 +33,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<ITagSearch>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -64,7 +64,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<ITagInfo>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -95,7 +95,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<ITagInfo>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -120,7 +120,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         public async Task<System.Text.Json.JsonElement> GetTagSchema(string adapterId, GetTagSchemaRequest request) {
             var cancellationToken = Context.ConnectionAborted;
 
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<ITagConfiguration>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -143,7 +143,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         public async Task<TagDefinition> CreateTag(string adapterId, CreateTagRequest request) {
             var cancellationToken = Context.ConnectionAborted;
 
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<ITagConfiguration>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -172,7 +172,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         public async Task<TagDefinition> UpdateTag(string adapterId, UpdateTagRequest request) {
             var cancellationToken = Context.ConnectionAborted;
 
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<ITagConfiguration>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -201,7 +201,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         public async Task<bool> DeleteTag(string adapterId, DeleteTagRequest request) {
             var cancellationToken = Context.ConnectionAborted;
 
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<ITagConfiguration>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagValuesHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagValuesHub.cs
@@ -41,7 +41,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             CancellationToken cancellationToken
         ) {
             // Resolve the adapter and feature.
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<ISnapshotTagValuePush>(adapterCallContext, adapterId, Context.ConnectionAborted).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -76,7 +76,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IReadSnapshotTagValues>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -107,7 +107,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IReadRawTagValues>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -138,7 +138,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IReadPlotTagValues>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -169,7 +169,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IReadTagValuesAtTimes>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -226,7 +226,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             // SignalR does not allow overloads of hub methods, so a different method name must be
             // used.
 
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IReadProcessedTagValues>(adapterCallContext, adapterId, Context.ConnectionAborted).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -257,7 +257,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IReadProcessedTagValues>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 
@@ -295,7 +295,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IWriteSnapshotTagValues>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
 
             ValidateObject(request);
@@ -331,7 +331,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapterCallContext = new SignalRAdapterCallContext(Context, _serviceProvider);
             var adapter = await ResolveAdapterAndFeature<IWriteHistoricalTagValues>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
             ValidateObject(request);
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/PublicAPI.Shipped.txt
@@ -2,7 +2,6 @@
 const Microsoft.Extensions.DependencyInjection.SignalRConfigurationExtensions.HubRoute = "/signalr/app-store-connect/v2.0" -> string!
 DataCore.Adapter.AspNetCore.Hubs.AdapterHub
 DataCore.Adapter.AspNetCore.Hubs.AdapterHub.AdapterAccessor.get -> DataCore.Adapter.IAdapterAccessor!
-DataCore.Adapter.AspNetCore.Hubs.AdapterHub.AdapterHub(DataCore.Adapter.Common.HostInfo! hostInfo, DataCore.Adapter.IAdapterAccessor! adapterAccessor, IntelligentPlant.BackgroundTasks.IBackgroundTaskService! taskScheduler, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions!>! jsonOptions) -> void
 DataCore.Adapter.AspNetCore.Hubs.AdapterHub.BackgroundTaskService.get -> IntelligentPlant.BackgroundTasks.IBackgroundTaskService!
 DataCore.Adapter.AspNetCore.Hubs.AdapterHub.BrowseAssetModelNodes(string! adapterId, DataCore.Adapter.AssetModel.BrowseAssetModelNodesRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.AssetModel.AssetModelNode!>!
 DataCore.Adapter.AspNetCore.Hubs.AdapterHub.CheckAdapterHealth(string! adapterId) -> System.Threading.Tasks.Task<DataCore.Adapter.Diagnostics.HealthCheckResult>!
@@ -54,7 +53,6 @@ DataCore.Adapter.AspNetCore.SignalRAdapterCallContext.ConnectionId.get -> string
 DataCore.Adapter.AspNetCore.SignalRAdapterCallContext.CorrelationId.get -> string!
 DataCore.Adapter.AspNetCore.SignalRAdapterCallContext.CultureInfo.get -> System.Globalization.CultureInfo!
 DataCore.Adapter.AspNetCore.SignalRAdapterCallContext.Items.get -> System.Collections.Generic.IDictionary<object!, object?>!
-DataCore.Adapter.AspNetCore.SignalRAdapterCallContext.SignalRAdapterCallContext(Microsoft.AspNetCore.SignalR.HubCallerContext! hubCallerContext) -> void
 DataCore.Adapter.AspNetCore.SignalRAdapterCallContext.User.get -> System.Security.Claims.ClaimsPrincipal?
 Microsoft.AspNetCore.Routing.AdapterSignalREndpointDataSourceExtensions
 Microsoft.Extensions.DependencyInjection.SignalRConfigurationExtensions

--- a/src/DataCore.Adapter.AspNetCore.SignalR/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 ﻿#nullable enable
+DataCore.Adapter.AspNetCore.Hubs.AdapterHub.AdapterHub(DataCore.Adapter.Common.HostInfo! hostInfo, DataCore.Adapter.IAdapterAccessor! adapterAccessor, IntelligentPlant.BackgroundTasks.IBackgroundTaskService! taskScheduler, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions!>! jsonOptions, System.IServiceProvider! serviceProvider) -> void
+DataCore.Adapter.AspNetCore.SignalRAdapterCallContext.Services.get -> System.IServiceProvider!
+DataCore.Adapter.AspNetCore.SignalRAdapterCallContext.SignalRAdapterCallContext(Microsoft.AspNetCore.SignalR.HubCallerContext! hubCallerContext, System.IServiceProvider! serviceProvider) -> void

--- a/src/DataCore.Adapter.AspNetCore.SignalR/SignalRAdapterCallContext.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/SignalRAdapterCallContext.cs
@@ -43,6 +43,9 @@ namespace DataCore.Adapter.AspNetCore {
             get { return _hubCallerContext.Items; }
         }
 
+        /// <inheritdoc/>
+        public IServiceProvider Services { get; }
+
 
         /// <summary>
         /// Creates a new <see cref="SignalRAdapterCallContext"/> object.
@@ -50,11 +53,18 @@ namespace DataCore.Adapter.AspNetCore {
         /// <param name="hubCallerContext">
         ///   The hub caller context.
         /// </param>
+        /// <param name="serviceProvider">
+        ///   The <see cref="IServiceProvider"/>.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="hubCallerContext"/> is <see langword="null"/>.
         /// </exception>
-        public SignalRAdapterCallContext(HubCallerContext hubCallerContext) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="serviceProvider"/> is <see langword="null"/>.
+        /// </exception>
+        public SignalRAdapterCallContext(HubCallerContext hubCallerContext, IServiceProvider serviceProvider) {
             _hubCallerContext = hubCallerContext ?? throw new ArgumentNullException(nameof(hubCallerContext));
+            Services = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         }
 
     }

--- a/src/DataCore.Adapter.Core/Common/Variant.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.cs
@@ -792,6 +792,43 @@ namespace DataCore.Adapter.Common {
         /// <param name="value">
         ///   The value.
         /// </param>
+        public Variant(JsonElement value) {
+            Value = value;
+            Type = VariantType.Json;
+            ArrayDimensions = null;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified array value.
+        /// </summary>
+        /// <param name="value">
+        ///   The array value.
+        /// </param>
+        /// <remarks>
+        ///   If <paramref name="value"/> is <see langword="null"/>, the <see cref="Variant"/> 
+        ///   will be equal to <see cref="Null"/>.
+        /// </remarks>
+        public Variant(JsonElement[]? value) {
+            if (value == null) {
+                Value = null;
+                Type = VariantType.Null;
+                ArrayDimensions = null;
+                return;
+            }
+
+            Value = value;
+            Type = VariantType.Json;
+            ArrayDimensions = GetArrayDimensions(value);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Variant"/> instance with the specified value.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
         public Variant(EncodedObject? value) {
             if (value == null) {
                 Value = null;

--- a/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ DataCore.Adapter.Common.FindAdaptersRequest.Page.get -> int
 DataCore.Adapter.Common.FindAdaptersRequest.Page.set -> void
 DataCore.Adapter.Common.FindAdaptersRequest.PageSize.get -> int
 DataCore.Adapter.Common.FindAdaptersRequest.PageSize.set -> void
+DataCore.Adapter.Common.Variant.Variant(System.Text.Json.JsonElement value) -> void
+DataCore.Adapter.Common.Variant.Variant(System.Text.Json.JsonElement[]? value) -> void
 DataCore.Adapter.DataValidation.MaxUriLengthAttribute
 DataCore.Adapter.DataValidation.MaxUriLengthAttribute.Length.get -> int
 DataCore.Adapter.DataValidation.MaxUriLengthAttribute.MaxUriLengthAttribute(int length) -> void

--- a/src/DataCore.Adapter/DefaultAdapterCallContext.cs
+++ b/src/DataCore.Adapter/DefaultAdapterCallContext.cs
@@ -26,6 +26,9 @@ namespace DataCore.Adapter {
         /// <inheritdoc/>
         public IDictionary<object, object?> Items { get; }
 
+        /// <inheritdoc/>
+        public IServiceProvider Services { get; }
+
 
         /// <summary>
         /// Creates a new <see cref="DefaultAdapterCallContext"/> object.
@@ -42,17 +45,48 @@ namespace DataCore.Adapter {
         /// <param name="cultureInfo">
         ///   The culture info.
         /// </param>
+        /// <param name="serviceProvider">
+        ///   The service provider.
+        /// </param>
         public DefaultAdapterCallContext(
             ClaimsPrincipal? user = null,
             string? connectionId = null,
             string? correlationId = null,
-            CultureInfo? cultureInfo = null
+            CultureInfo? cultureInfo = null,
+            IServiceProvider? serviceProvider = null
         ) {
             User = user;
             ConnectionId = connectionId ?? Guid.NewGuid().ToString();
             CorrelationId = correlationId ?? Guid.NewGuid().ToString();
             CultureInfo = cultureInfo ?? CultureInfo.CurrentUICulture;
             Items = new ConcurrentDictionary<object, object?>();
+            Services = serviceProvider ?? NullServiceProvider.Instance;
+        }
+
+
+        /// <summary>
+        /// Default <see cref="IServiceProvider"/> implementation that always returns <see langword="null"/> 
+        /// when resolving a service.
+        /// </summary>
+        private class NullServiceProvider : IServiceProvider {
+
+            /// <summary>
+            /// Singleton instance.
+            /// </summary>
+            public static IServiceProvider Instance { get; } = new NullServiceProvider();
+
+
+            /// <summary>
+            /// Creates a new <see cref="NullServiceProvider"/> instance.
+            /// </summary>
+            private NullServiceProvider() { }
+
+
+            /// <inheritdoc/>
+            public object GetService(Type serviceType) {
+                return null!;
+            }
+
         }
 
     }

--- a/src/DataCore.Adapter/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter/PublicAPI.Shipped.txt
@@ -110,7 +110,6 @@ DataCore.Adapter.DefaultAdapterCallContext
 DataCore.Adapter.DefaultAdapterCallContext.ConnectionId.get -> string!
 DataCore.Adapter.DefaultAdapterCallContext.CorrelationId.get -> string!
 DataCore.Adapter.DefaultAdapterCallContext.CultureInfo.get -> System.Globalization.CultureInfo!
-DataCore.Adapter.DefaultAdapterCallContext.DefaultAdapterCallContext(System.Security.Claims.ClaimsPrincipal? user = null, string? connectionId = null, string? correlationId = null, System.Globalization.CultureInfo? cultureInfo = null) -> void
 DataCore.Adapter.DefaultAdapterCallContext.Items.get -> System.Collections.Generic.IDictionary<object!, object?>!
 DataCore.Adapter.DefaultAdapterCallContext.User.get -> System.Security.Claims.ClaimsPrincipal?
 DataCore.Adapter.DefaultRetryPolicy

--- a/src/DataCore.Adapter/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+DataCore.Adapter.DefaultAdapterCallContext.DefaultAdapterCallContext(System.Security.Claims.ClaimsPrincipal? user = null, string? connectionId = null, string? correlationId = null, System.Globalization.CultureInfo? cultureInfo = null, System.IServiceProvider? serviceProvider = null) -> void
+DataCore.Adapter.DefaultAdapterCallContext.Services.get -> System.IServiceProvider!
 DataCore.Adapter.RealTimeData.TagValueBuilder.WithSteppedTransition(bool stepped) -> DataCore.Adapter.RealTimeData.TagValueBuilder!
 static DataCore.Adapter.AdapterAccessorExtensions.GetAdapterDescriptorAsync(this DataCore.Adapter.IAdapterAccessor! adapterAccessor, DataCore.Adapter.IAdapterCallContext! context, string! adapterId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<DataCore.Adapter.Common.AdapterDescriptorExtended?>!
 static DataCore.Adapter.ChannelExtensions.ToEnumerable<T>(this System.Collections.Generic.IAsyncEnumerable<T>! enumerable, int maxItems, int expectedItems, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<T>!>!

--- a/test/DataCore.Adapter.Tests/ExampleCallContext.cs
+++ b/test/DataCore.Adapter.Tests/ExampleCallContext.cs
@@ -1,23 +1,22 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Security.Claims;
 using System.Security.Principal;
 
 namespace DataCore.Adapter.Tests {
     public class ExampleCallContext : DefaultAdapterCallContext {
 
-        private ExampleCallContext(ClaimsPrincipal user) : base(user) { }
+        private ExampleCallContext(ClaimsPrincipal user, IServiceProvider serviceProvider) : base(user, serviceProvider: serviceProvider) { }
 
 
-        public static ExampleCallContext ForPrincipal(ClaimsPrincipal principal) {
-            return new ExampleCallContext(principal);
+        public static ExampleCallContext ForPrincipal(ClaimsPrincipal principal, IServiceProvider serviceProvider = null) {
+            return new ExampleCallContext(principal, serviceProvider);
         }
 
 
-        public static ExampleCallContext ForIdentity(IIdentity user) {
+        public static ExampleCallContext ForIdentity(IIdentity user, IServiceProvider serviceProvider = null) {
             return new ExampleCallContext(user == null
                 ? null
-                : new ClaimsPrincipal(user));
+                : new ClaimsPrincipal(user), serviceProvider);
         }
 
     }


### PR DESCRIPTION
Adds an `IServiceProvider` property to `IAdapterCallContext` to allow adapters to resolve scoped services in feature invocations if required.