### PR TITLE
Hosting improvements

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,6 @@
     <PkgVersion_Microsoft_Web_LibraryManager_Build>2.1.175</PkgVersion_Microsoft_Web_LibraryManager_Build>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Asp.Versioning.Http" Version="7.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="CsvHelper" Version="30.0.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.24.0" />
@@ -37,7 +36,6 @@
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="2.2.0" />
     <PackageVersion Include="JsonSchema.Net.Generation" Version="3.3.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.10" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/AdapterMinimalApiConfigurationExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/AdapterMinimalApiConfigurationExtensions.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Extensions.DependencyInjection {
         ///   The <see cref="IServiceCollection"/>.
         /// </returns>
         public static IServiceCollection AddDataCoreAdapterApiServices(this IServiceCollection services) {
-            services.AddApiVersioning();
             services.AddTransient<IApiDescriptorProvider, ApiDescriptorProvider>();
 
             services.Configure<JsonOptions>(options => options.SerializerOptions.UseDataCoreAdapterDefaults());

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/AdapterMinimalApiEndpointRouteBuilderExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/AdapterMinimalApiEndpointRouteBuilderExtensions.cs
@@ -36,14 +36,12 @@ namespace Microsoft.AspNetCore.Builder {
         ///   The base <see cref="IEndpointConventionBuilder"/> for the adapter API routes.
         /// </returns>
         public static IEndpointConventionBuilder MapDataCoreAdapterApiRoutes(this IEndpointRouteBuilder builder, PathString? prefix) {
-            var versionedApiRouteBuilder = builder.NewVersionedApi();
-
             // Base for all versioned API routes.
             var apiBasePath = prefix == null
                 ? "/api/app-store-connect"
                 : prefix.Value.Add(new PathString("/api/app-store-connect")).ToString();
 
-            var api = versionedApiRouteBuilder.MapGroup(string.Concat(apiBasePath, "/v{version:apiVersion}")).WithOpenApi();
+            var api = builder.MapGroup(apiBasePath);
 
             // Add common error handling.
             api.AddEndpointFilter(async (context, next) => {
@@ -65,7 +63,7 @@ namespace Microsoft.AspNetCore.Builder {
             });
 
             // Base for the v2.0 API
-            var v2api = api.MapGroup("/").HasApiVersion(2, 0);
+            var v2api = api.MapGroup("/v2.0");
 
             DataCore.Adapter.AspNetCore.Routing.V2.AdapterRoutes.Register(v2api.MapGroup("/adapters")
                 .WithGroupName("Adapters"));

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/DataCore.Adapter.AspNetCore.MinimalApi.csproj
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/DataCore.Adapter.AspNetCore.MinimalApi.csproj
@@ -15,8 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Http" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="MiniValidation" />
   </ItemGroup>
 

--- a/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationBuilderExtensions.cs
+++ b/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationBuilderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 
 using DataCore.Adapter;
 using DataCore.Adapter.DependencyInjection;
@@ -74,7 +73,7 @@ namespace Microsoft.Extensions.DependencyInjection {
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
 
-            builder.Services.AddSingleton<IAdapterAccessor, T>(implementationFactory);
+            builder.Services.AddScoped<IAdapterAccessor, T>(implementationFactory);
             return builder;
         }
 
@@ -96,7 +95,7 @@ namespace Microsoft.Extensions.DependencyInjection {
             this IAdapterConfigurationBuilder builder,
             Type implementationType
         ) {
-            builder.Services.AddSingleton(typeof(IAdapterAccessor), implementationType);
+            builder.Services.AddScoped(typeof(IAdapterAccessor), implementationType);
             return builder;
         }
 


### PR DESCRIPTION
This PR modifies some authorization-related services (or services that rely on authorization services) to be scoped instead of singleton. This ensures that they integrate nicely with host applications that register ASP.NET Core services such as `IAuthorizationHandler` as scoped.

OpenAPI and API versioning has also been removed from the Minimal APIs library for the time being, with the intention that it is re-added at a later date when it can be fully implemented.