### PR TITLE
KV stores must implement their own (de)serialization

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,9 +30,9 @@
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.57.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.57.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.58.0" />
-    <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="9.0.0" />
-    <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="9.0.0" />
-    <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="9.1.0" />
+    <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="9.1.0" />
+    <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="9.1.0" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="2.2.0" />
     <PackageVersion Include="JsonSchema.Net.Generation" Version="3.3.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />

--- a/docs/release-notes/v3.1.0.md
+++ b/docs/release-notes/v3.1.0.md
@@ -2,8 +2,23 @@
 
 Welcome to version 3.1.0 of the adapter toolkit for App Store Connect!
 
+# Breaking Changes
 
-# Changes
+This release contains the following breaking changes:
+
+
+## `IKeyValueStore` changes
+
+The [IKeyValueStore](../../src/DataCore.Adapter.Abstractions/Services/IKeyValueStore.cs) service contract has changed: writing and reading values is now performed using generic `WriteAsync<T>(KVKey, T)` and `ReadAsync<T>(KVKey)` methods respectively, instead of writing and reading `byte[]` instances.
+
+The reason for this change is because under the hood, `IKeyValueStore` implementations have been split into those that serialize values on write and deserialize on read and those that do not have to perform serialization (such as `InMemoryKeyValueStore`). The `KeyValueStoreOptions` type has been extended to allow a `JsonSerializerOptions` to be specified to control default (de)serialization behaviour. 
+
+The `KeyValueStoreExtensions.ReadJsonAsync<T>` and `KeyValueStoreExtensions.WriteJsonAsync<T>` extension methods are now marked as deprecated, and no longer perform (de)serialization in the method implementation; this is now delegated to `KeyValueStore` instances instead.
+
+New protected methods have been added to `KeyValueStore` to assist with serialization (and compression) in implementations that need to serialize and deserialize values. `InMemoryKeyValueStore` has been modified so that it no longer performs serialization.
+
+
+# Non-Breaking Changes
 
 This release includes the following changes and features:
 
@@ -38,6 +53,10 @@ Additionally, the identifier that the adapter host uses in its OpenTelemetry tra
 
 # Upgrading from v3.0.0 to 3.1.0
 
-To upgrade from v3.0.0 to v3.1.0, you just need to update your adapter toolkit package references to version 3.1.0.
+To upgrade from v3.0.0 to v3.1.0, you need to update your adapter toolkit package references to version 3.1.0.
+
+If you have written a custom `IKeyValueStore` implementation you will need to update your implementation to account for changes in the `IKeyValueStore` interface, and `KeyValueStore` and `KeyValueStore<TOptions>` base classes. Use the new `SerializeToBytesAsync`, `SerializeToStreamAsync`, `DeserializeFromBytesAsync` and `DeserializeFromStreamAsync` methods on `KeyValueStore` if your implementation needs to store and retrieve serialized values. If your implementation is derived from `KeyValueStore<TOptions>`, the default compression level and `JsonSerializerOptions` specified in `KeyValueStoreOptions` will be used in (de)serialization operations if the equivalent parameters in the `SerializeToXXX`/`DeserializeFromXXX` methods are not specified. 
+
+If you are using an `IKeyValueStore` in your adapter implementation, you should replace calls to the `KeyValueStoreExtensions.ReadJsonAsync<T>` and `KeyValueStoreExtensions.WriteJsonAsync<T>` extension methods with calls to `IKeyValueStore.ReadAsync<T>` and `IKeyValueStore.WriteAsync<T>` respectively. Additionally, you may wish to set the `KeyValueStoreOptions.JsonOptions` property to customise JSON serialization if you are using the Microsoft FASTER-, file system- or Sqlite-based stores.
 
 If you have installed the adapter host project template for Visual Studio and `dotnet new`, you can upgrade the template to the latest version by running `dotnet new update` from the command line.

--- a/docs/writing-an-adapter.md
+++ b/docs/writing-an-adapter.md
@@ -403,12 +403,7 @@ The following `IKeyValueStore` implementations support persistence:
 - [SQLite](../src/DataCore.Adapter.KeyValueStore.Sqlite)
 - [Microsoft FASTER](../src/DataCore.Adapter.KeyValueStore.FASTER)
 
-`IKeyValueStore` expects values to be specified as `byte[]`. Extension methods exist to automatically serialize values to/from JSON using [System.Text.Json](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/overview) e.g.
-
-```csharp
-await kvStore.WriteJsonAsync("UtcLastUpdated", DateTime.UtcNow).ConfigureAwait(false);
-```
-
+The implementations above that support persistence serialize values to/from JSON using [System.Text.Json](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/overview) and can be configured to automatically compress the serialized bytes using GZip compression.
 
 # Telemetry
 

--- a/src/DataCore.Adapter.Abstractions/DataCore.Adapter.Abstractions.csproj
+++ b/src/DataCore.Adapter.Abstractions/DataCore.Adapter.Abstractions.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net48</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
     <RootNamespace>DataCore.Adapter</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Abstractions</PackageId>
     <Description>Base types for App Store Connect adapters.</Description>

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Shipped.txt
@@ -4,8 +4,6 @@ abstract DataCore.Adapter.AdapterCore.StopAsyncCore(System.Threading.Cancellatio
 abstract DataCore.Adapter.Services.KeyValueStore.DeleteAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
 abstract DataCore.Adapter.Services.KeyValueStore.GetCompressionLevel() -> System.IO.Compression.CompressionLevel
 abstract DataCore.Adapter.Services.KeyValueStore.GetKeysAsync(DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.Services.KVKey>!
-abstract DataCore.Adapter.Services.KeyValueStore.ReadAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
-abstract DataCore.Adapter.Services.KeyValueStore.WriteAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask
 const DataCore.Adapter.AdapterCallContextExtensions.ValidateRequestsItemName = "adapter:validate-request-objects" -> string!
 const DataCore.Adapter.Diagnostics.AdapterEventSource.EventIds.AdapterDisposed = 4 -> int
 const DataCore.Adapter.Diagnostics.AdapterEventSource.EventIds.AdapterOperationCompleted = 6 -> int
@@ -259,11 +257,8 @@ DataCore.Adapter.RealTimeData.IWriteTagValueAnnotations.UpdateAnnotation(DataCor
 DataCore.Adapter.Services.IKeyValueStore
 DataCore.Adapter.Services.IKeyValueStore.DeleteAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
 DataCore.Adapter.Services.IKeyValueStore.GetKeysAsync(DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.Services.KVKey>!
-DataCore.Adapter.Services.IKeyValueStore.ReadAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
-DataCore.Adapter.Services.IKeyValueStore.WriteAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.InMemoryKeyValueStore
 DataCore.Adapter.Services.InMemoryKeyValueStore.Dispose() -> void
-DataCore.Adapter.Services.InMemoryKeyValueStore.InMemoryKeyValueStore(System.IO.Compression.CompressionLevel compressionLevel = System.IO.Compression.CompressionLevel.NoCompression) -> void
 DataCore.Adapter.Services.KeyValueStore
 DataCore.Adapter.Services.KeyValueStore.ConvertBytesToHexString(byte[]! bytes) -> string!
 DataCore.Adapter.Services.KeyValueStore.ConvertHexStringToBytes(string! hexString) -> byte[]!
@@ -286,9 +281,7 @@ DataCore.Adapter.Services.KVKey.Value.get -> byte[]!
 DataCore.Adapter.Services.ScopedKeyValueStore
 DataCore.Adapter.Services.ScopedKeyValueStore.DeleteAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
 DataCore.Adapter.Services.ScopedKeyValueStore.GetKeysAsync(DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.Services.KVKey>!
-DataCore.Adapter.Services.ScopedKeyValueStore.ReadAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
 DataCore.Adapter.Services.ScopedKeyValueStore.ScopedKeyValueStore(DataCore.Adapter.Services.KVKey prefix, DataCore.Adapter.Services.IKeyValueStore! inner) -> void
-DataCore.Adapter.Services.ScopedKeyValueStore.WriteAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Tags.ITagConfiguration
 DataCore.Adapter.Tags.ITagConfiguration.CreateTagAsync(DataCore.Adapter.IAdapterCallContext! context, DataCore.Adapter.Tags.CreateTagRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<DataCore.Adapter.Tags.TagDefinition!>!
 DataCore.Adapter.Tags.ITagConfiguration.DeleteTagAsync(DataCore.Adapter.IAdapterCallContext! context, DataCore.Adapter.Tags.DeleteTagRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
@@ -313,7 +306,6 @@ DataCore.Adapter.WellKnownFeatures.Events
 DataCore.Adapter.WellKnownFeatures.Extensions
 DataCore.Adapter.WellKnownFeatures.RealTimeData
 DataCore.Adapter.WellKnownFeatures.Tags
-override DataCore.Adapter.Services.KeyValueStore<TOptions>.GetCompressionLevel() -> System.IO.Compression.CompressionLevel
 override DataCore.Adapter.Services.KVKey.Equals(object! obj) -> bool
 override DataCore.Adapter.Services.KVKey.GetHashCode() -> int
 static DataCore.Adapter.AdapterCallContextExtensions.SetItem<TKey, TValue>(this DataCore.Adapter.IAdapterCallContext! context, TKey key, TValue? value) -> void

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+abstract DataCore.Adapter.Services.KeyValueStore.GetJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions?
+abstract DataCore.Adapter.Services.KeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
+abstract DataCore.Adapter.Services.KeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Common.AdapterDescriptorBuilder
 DataCore.Adapter.Common.AdapterDescriptorBuilder.AdapterDescriptorBuilder(DataCore.Adapter.Common.AdapterDescriptor! descriptor) -> void
 DataCore.Adapter.Common.AdapterDescriptorBuilder.AdapterDescriptorBuilder(DataCore.Adapter.Common.AdapterDescriptorExtended! descriptor) -> void
@@ -46,4 +49,21 @@ DataCore.Adapter.Common.HostInfoBuilder.WithProperty(string! name, DataCore.Adap
 DataCore.Adapter.Common.HostInfoBuilder.WithVendor(DataCore.Adapter.Common.VendorInfo? vendor) -> DataCore.Adapter.Common.HostInfoBuilder!
 DataCore.Adapter.Common.HostInfoBuilder.WithVersion(string? version) -> DataCore.Adapter.Common.HostInfoBuilder!
 DataCore.Adapter.IAdapterCallContext.Services.get -> System.IServiceProvider!
+DataCore.Adapter.Services.IKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.IKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.InMemoryKeyValueStore.InMemoryKeyValueStore() -> void
+DataCore.Adapter.Services.KeyValueStore.DeserializeFromBytesAsync<T>(byte[]! data, System.Text.Json.JsonSerializerOptions? jsonOptions = null) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.KeyValueStore.DeserializeFromBytesAsync<T>(byte[]! data, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.KeyValueStore.DeserializeFromStreamAsync<T>(System.IO.Stream! stream, System.Text.Json.JsonSerializerOptions? jsonOptions = null) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.KeyValueStore.DeserializeFromStreamAsync<T>(System.IO.Stream! stream, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.KeyValueStore.SerializeToBytesAsync<T>(T value, System.Text.Json.JsonSerializerOptions? jsonOptions = null, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
+DataCore.Adapter.Services.KeyValueStore.SerializeToBytesAsync<T>(T value, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
+DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.Text.Json.JsonSerializerOptions? jsonOptions = null, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.KeyValueStoreOptions.JsonOptions.get -> System.Text.Json.JsonSerializerOptions?
+DataCore.Adapter.Services.KeyValueStoreOptions.JsonOptions.set -> void
+DataCore.Adapter.Services.ScopedKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.ScopedKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
+override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetCompressionLevel() -> System.IO.Compression.CompressionLevel
+override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions?
 static DataCore.Adapter.AdapterExtensions.CreateExtendedAdapterDescriptorBuilder(this DataCore.Adapter.IAdapter! adapter) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!

--- a/src/DataCore.Adapter.Abstractions/Services/IKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/IKeyValueStore.cs
@@ -15,12 +15,13 @@ namespace DataCore.Adapter.Services {
     /// </para>  
     /// 
     /// <para>
-    ///   Implementations should extend <see cref="KeyValueStore"/> rather than implementing 
-    ///   <see cref="IKeyValueStore"/> directly.
+    ///   Implementations should extend <see cref="KeyValueStore"/> or <see cref="KeyValueStore{TOptions}"/> 
+    ///   rather than implementing <see cref="IKeyValueStore"/> directly.
     /// </para>
     /// 
     /// </remarks>
     /// <seealso cref="KeyValueStore"/>
+    /// <seealso cref="KeyValueStore{TOptions}"/>
     /// <seealso cref="InMemoryKeyValueStore"/>
     /// <seealso cref="ScopedKeyValueStore"/>
     /// <seealso cref="KeyValueStoreExtensions"/>
@@ -29,6 +30,9 @@ namespace DataCore.Adapter.Services {
         /// <summary>
         /// Writes a value to the store.
         /// </summary>
+        /// <typeparam name="T">
+        ///   The type of the value
+        /// </typeparam>
         /// <param name="key">
         ///   The key for the value.
         /// </param>
@@ -38,12 +42,15 @@ namespace DataCore.Adapter.Services {
         /// <returns>
         ///   A <see cref="ValueTask"/> that will process the operation.
         /// </returns>
-        ValueTask WriteAsync(KVKey key, byte[] value);
+        ValueTask WriteAsync<T>(KVKey key, T value);
 
 
         /// <summary>
         /// Reads a value from the store.
         /// </summary>
+        /// <typeparam name="T">
+        ///   The type of the value.
+        /// </typeparam>
         /// <param name="key">
         ///   The key for the value.
         /// </param>
@@ -51,7 +58,7 @@ namespace DataCore.Adapter.Services {
         ///   A <see cref="ValueTask{TResult}"/> that will return the value of the key, or 
         ///   <see langword="null"/> if the key does not exist.
         /// </returns>
-        ValueTask<byte[]?> ReadAsync(KVKey key);
+        ValueTask<T?> ReadAsync<T>(KVKey key);
 
 
         /// <summary>

--- a/src/DataCore.Adapter.Abstractions/Services/InMemoryKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/InMemoryKeyValueStore.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Compression;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace DataCore.Adapter.Services {
@@ -13,37 +14,39 @@ namespace DataCore.Adapter.Services {
     /// <remarks>
     ///   This implementation does not provide any persistence of data.
     /// </remarks>
-    public sealed class InMemoryKeyValueStore : KeyValueStore<KeyValueStoreOptions>, IDisposable {
+    public sealed class InMemoryKeyValueStore : KeyValueStore, IDisposable {
 
         /// <summary>
         /// The value store.
         /// </summary>
-        private readonly ConcurrentDictionary<string, byte[]> _values = new ConcurrentDictionary<string, byte[]>(StringComparer.Ordinal);
-
-
-        /// <summary>
-        /// Creats a new <see cref="InMemoryKeyValueStore"/> object.
-        /// </summary>
-        public InMemoryKeyValueStore(CompressionLevel compressionLevel = CompressionLevel.NoCompression) 
-            : base(new KeyValueStoreOptions() { CompressionLevel = compressionLevel }, null) { }
+        private readonly ConcurrentDictionary<string, object?> _values = new ConcurrentDictionary<string, object?>(StringComparer.Ordinal);
 
 
         /// <inheritdoc/>
-        protected override ValueTask WriteAsync(KVKey key, byte[] value) {
+        protected sealed override CompressionLevel GetCompressionLevel() => CompressionLevel.NoCompression;
+
+
+        /// <inheritdoc/>
+        protected sealed override JsonSerializerOptions? GetJsonSerializerOptions() => null;
+
+
+        /// <inheritdoc/>
+        protected override ValueTask WriteAsync<T>(KVKey key, T value) {
             var keyAsString = System.Text.Encoding.UTF8.GetString(key);
             _values[keyAsString] = value;
+
             return default;
         }
 
 
         /// <inheritdoc/>
-        protected override ValueTask<byte[]?> ReadAsync(KVKey key) {
+        protected override ValueTask<T?> ReadAsync<T>(KVKey key) where T : default {
             var keyAsString = System.Text.Encoding.UTF8.GetString(key);
-            if (!_values.TryGetValue(keyAsString, out var value)) {
-                return new ValueTask<byte[]?>((byte[]?) null);
+            if (!_values.TryGetValue(keyAsString, out var value) || value is not T valueActual) {
+                return default;
             }
 
-            return new ValueTask<byte[]?>(value);
+            return new ValueTask<T?>(valueActual);
         }
 
 
@@ -58,16 +61,16 @@ namespace DataCore.Adapter.Services {
         protected override async IAsyncEnumerable<KVKey> GetKeysAsync(KVKey? prefix) {
             await Task.Yield();
 
-            var utf8Prefix = prefix == null || prefix.Value.Length == 0
+            var prefixString = prefix == null || prefix.Value.Length == 0
                 ? null
                 : System.Text.Encoding.UTF8.GetString(prefix.Value);
 
-            foreach (var item in _values.Keys) {
-                if (utf8Prefix != null && !item.StartsWith(utf8Prefix, StringComparison.Ordinal)) {
+            foreach (var key in _values.Keys) {
+                if (prefixString != null && !key.StartsWith(prefixString, StringComparison.Ordinal)) {
                     continue;
                 }
 
-                yield return System.Text.Encoding.UTF8.GetBytes(item);
+                yield return key;
             };
         }
 

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreExtensions.cs
@@ -145,12 +145,13 @@ namespace DataCore.Adapter.Services {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="store"/> is <see langword="null"/>.
         /// </exception>
+        [Obsolete("This method will be removed in a future release. Use IKeyValueStore.WriteAsync<T> instead.", false)]
         public static async ValueTask WriteJsonAsync<TValue>(this IKeyValueStore store, KVKey key, TValue value, JsonSerializerOptions? options = null) {
             if (store == null) {
                 throw new ArgumentNullException(nameof(store));
             }
 
-            await store.WriteAsync(key, JsonSerializer.SerializeToUtf8Bytes(value, options)).ConfigureAwait(false);
+            await store.WriteAsync(key, value).ConfigureAwait(false);
         }
 
 
@@ -181,6 +182,7 @@ namespace DataCore.Adapter.Services {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="jsonTypeInfo"/> is <see langword="null"/>.
         /// </exception>
+        [Obsolete("This method will be removed in a future release. Use IKeyValueStore.WriteAsync<T> instead.", false)]
         public static async ValueTask WriteJsonAsync<TValue>(this IKeyValueStore store, KVKey key, TValue value, JsonTypeInfo<TValue> jsonTypeInfo) {
             if (store == null) {
                 throw new ArgumentNullException(nameof(store));
@@ -189,7 +191,7 @@ namespace DataCore.Adapter.Services {
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            await store.WriteAsync(key, JsonSerializer.SerializeToUtf8Bytes(value, jsonTypeInfo)).ConfigureAwait(false);
+            await store.WriteAsync(key, value).ConfigureAwait(false);
         }
 
 
@@ -214,15 +216,13 @@ namespace DataCore.Adapter.Services {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="store"/> is <see langword="null"/>.
         /// </exception>
+        [Obsolete("This method will be removed in a future release. Use IKeyValueStore.ReadAsync<T> instead.", false)]
         public static async ValueTask<TValue?> ReadJsonAsync<TValue>(this IKeyValueStore store, KVKey key, JsonSerializerOptions? options = null) {
             if (store == null) {
                 throw new ArgumentNullException(nameof(store));
             }
 
-            var result = await store.ReadAsync(key).ConfigureAwait(false);
-            return result == null
-                ? default
-                : JsonSerializer.Deserialize<TValue>(result, options);
+            return await store.ReadAsync<TValue>(key).ConfigureAwait(false);
         }
 
 
@@ -250,6 +250,7 @@ namespace DataCore.Adapter.Services {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="jsonTypeInfo"/> is <see langword="null"/>.
         /// </exception>
+        [Obsolete("This method will be removed in a future release. Use IKeyValueStore.ReadAsync<T> instead.", false)]
         public static async ValueTask<TValue?> ReadJsonAsync<TValue>(this IKeyValueStore store, KVKey key, JsonTypeInfo<TValue> jsonTypeInfo) {
             if (store == null) {
                 throw new ArgumentNullException(nameof(store));
@@ -258,10 +259,7 @@ namespace DataCore.Adapter.Services {
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            var result = await store.ReadAsync(key).ConfigureAwait(false);
-            return result == null
-                ? default
-                : JsonSerializer.Deserialize(result, jsonTypeInfo);
+            return await store.ReadAsync<TValue>(key).ConfigureAwait(false);
         }
 
     }

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreOptions.cs
@@ -1,11 +1,17 @@
 ﻿using System.IO.Compression;
+using System.Text.Json;
 
 namespace DataCore.Adapter.Services {
 
     /// <summary>
-    /// Options for <see cref="KeyValueStore"/>.
+    /// Options for <see cref="KeyValueStore{TOptions}"/>.
     /// </summary>
     public class KeyValueStoreOptions {
+
+        /// <summary>
+        /// The JSON serializer options to use when serializing/deserializing values.
+        /// </summary>
+        public JsonSerializerOptions? JsonOptions { get; set; }
 
         /// <summary>
         /// The compression level to use for data written to the store.

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreT.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreT.cs
@@ -1,0 +1,46 @@
+﻿using System.IO.Compression;
+using System.Text.Json;
+
+using Microsoft.Extensions.Logging;
+
+namespace DataCore.Adapter.Services {
+
+    /// <summary>
+    /// Base implementation of <see cref="IKeyValueStore"/>.
+    /// </summary>
+    /// <remarks>
+    ///   Implementations should extend <see cref="KeyValueStore"/> or <see cref="KeyValueStore{TOptions}"/> 
+    ///   rather than implementing <see cref="IKeyValueStore"/> directly.
+    /// </remarks>
+    /// <seealso cref="KeyValueStore"/>
+    public abstract class KeyValueStore<TOptions> : KeyValueStore where TOptions : KeyValueStoreOptions, new() {
+
+        /// <summary>
+        /// The options for the store.
+        /// </summary>
+        protected TOptions Options { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="KeyValueStore"/> with the specified key prefix.
+        /// </summary>
+        /// <param name="options">
+        ///   Store options.
+        /// </param>
+        /// <param name="logger">
+        ///   The logger for the store.
+        /// </param>
+        protected KeyValueStore(TOptions? options, ILogger? logger = null) : base(logger) {
+            Options = options ?? new TOptions();
+        }
+
+
+        /// <inheritdoc/>
+        protected sealed override CompressionLevel GetCompressionLevel() => Options.CompressionLevel;
+
+
+        /// <inheritdoc/>
+        protected sealed override JsonSerializerOptions? GetJsonSerializerOptions() => Options.JsonOptions;
+
+    }
+}

--- a/src/DataCore.Adapter.Abstractions/Services/ScopedKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/ScopedKeyValueStore.cs
@@ -48,16 +48,16 @@ namespace DataCore.Adapter.Services {
 
 
         /// <inheritdoc/>
-        public ValueTask WriteAsync(KVKey key, byte[] value) {
+        public ValueTask WriteAsync<T>(KVKey key, T value) {
             var k = KeyValueStore.AddPrefix(Prefix, key);
             return Inner.WriteAsync(k, value);
         }
 
 
         /// <inheritdoc/>
-        public ValueTask<byte[]?> ReadAsync(KVKey key) {
+        public ValueTask<T?> ReadAsync<T>(KVKey key) {
             var k = KeyValueStore.AddPrefix(Prefix, key);
-            return Inner.ReadAsync(k);
+            return Inner.ReadAsync<T>(k);
         }
 
 

--- a/src/DataCore.Adapter.AspNetCore.HealthChecks/Diagnostics/HealthChecks/AdapterHealthCheck.cs
+++ b/src/DataCore.Adapter.AspNetCore.HealthChecks/Diagnostics/HealthChecks/AdapterHealthCheck.cs
@@ -43,7 +43,7 @@ namespace DataCore.Adapter.AspNetCore.Diagnostics.HealthChecks {
 
             await foreach (var item in adapters.ConfigureAwait(false)) {
                 try {
-                    var feature = item.GetFeature<Adapter.Diagnostics.IHealthCheck>(WellKnownFeatures.Diagnostics.HealthCheck);
+                    var feature = item.GetFeature<Adapter.Diagnostics.IHealthCheck>(string.Intern(WellKnownFeatures.Diagnostics.HealthCheck));
                     if (feature == null) {
                         healthChecks[item.Descriptor.Id] = item.IsRunning
                             ? Adapter.Diagnostics.HealthCheckResult.Healthy(null)

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/DataCore.Adapter.KeyValueStore.FASTER.csproj
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/DataCore.Adapter.KeyValueStore.FASTER.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net48;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
     <RootNamespace>DataCore.Adapter.KeyValueStore.FASTER</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.KeyValueStore.FASTER</PackageId>
     <Description>Key-value store for App Store Connect adapters using Microsoft FASTER.</Description>

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Shipped.txt
@@ -28,8 +28,6 @@ DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.SegmentSizeBits
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.SegmentSizeBits.set -> void
 override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.DeleteAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
 override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.GetKeysAsync(DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.Services.KVKey>!
-override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.ReadAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
-override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.WriteAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask
 static DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.CreateLocalStorageCheckpointManager(string! path, bool removeOutdated = true) -> FASTER.core.ICheckpointManager!
 virtual DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.Dispose(bool disposing) -> void
 virtual DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
+override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/PublicAPI.Shipped.txt
@@ -11,7 +11,4 @@ DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.HashBuc
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.Path.get -> string!
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.Path.set -> void
 override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.DeleteAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
-override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.GetCompressionLevel() -> System.IO.Compression.CompressionLevel
 override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.GetKeysAsync(DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.Services.KVKey>!
-override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.ReadAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
-override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.WriteAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
+override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Shipped.txt
@@ -8,5 +8,3 @@ DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.ConnectionStrin
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.SqliteKeyValueStoreOptions() -> void
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.DeleteAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.GetKeysAsync(DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.Services.KVKey>!
-override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
-override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.WriteAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
+override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask

--- a/src/DataCore.Adapter/AssetModel/AssetModelManager.cs
+++ b/src/DataCore.Adapter/AssetModel/AssetModelManager.cs
@@ -179,7 +179,7 @@ namespace DataCore.Adapter.AssetModel {
             // "nodes" key contains an array of the defined node IDs.
             var readResult = _keyValueStore == null 
                 ? null 
-                : await _keyValueStore.ReadJsonAsync<string[]>("nodes").ConfigureAwait(false);
+                : await _keyValueStore.ReadAsync<string[]>("nodes").ConfigureAwait(false);
             
             if (cancellationToken.IsCancellationRequested) {
                 return;
@@ -198,7 +198,7 @@ namespace DataCore.Adapter.AssetModel {
                     }
 
                     // "nodes:{id}" key contains the the definition with ID {id}.
-                    var nodeReadResult = await _keyValueStore!.ReadJsonAsync<AssetModelNode>(string.Concat("nodes:", nodeId)).ConfigureAwait(false);
+                    var nodeReadResult = await _keyValueStore!.ReadAsync<AssetModelNode>(string.Concat("nodes:", nodeId)).ConfigureAwait(false);
                     if (nodeReadResult == null) {
                         continue;
                     }
@@ -353,7 +353,7 @@ namespace DataCore.Adapter.AssetModel {
             try {
                 if (_keyValueStore != null) {
                     // "nodes:{id}" key contains the definition with ID {id}.
-                    await _keyValueStore.WriteJsonAsync(string.Concat("nodes:", node.Id), node).ConfigureAwait(false);
+                    await _keyValueStore.WriteAsync(string.Concat("nodes:", node.Id), node).ConfigureAwait(false);
                 }
 
                 // Flags if the keys in _nodesById have been modified by this operation. We will
@@ -372,7 +372,7 @@ namespace DataCore.Adapter.AssetModel {
                 if (indexHasChanged) {
                     if (_keyValueStore != null) {
                         // "nodes" key contains an array of the defined node IDs.
-                        await _keyValueStore.WriteJsonAsync("nodes", _nodesById.Keys.ToArray()).ConfigureAwait(false);
+                        await _keyValueStore.WriteAsync("nodes", _nodesById.Keys.ToArray()).ConfigureAwait(false);
                     }
                     await OnConfigurationChangeAsync(node, ConfigurationChangeType.Created, cancellationToken).ConfigureAwait(false);
                 }
@@ -488,7 +488,7 @@ namespace DataCore.Adapter.AssetModel {
 
                     if (_keyValueStore != null) {
                         // "nodes" key contains an array of the defined node IDs.
-                        await _keyValueStore.WriteJsonAsync("nodes", _nodesById.Keys.ToArray()).ConfigureAwait(false);
+                        await _keyValueStore.WriteAsync("nodes", _nodesById.Keys.ToArray()).ConfigureAwait(false);
                     }
 
                     await OnConfigurationChangeAsync(node, ConfigurationChangeType.Deleted, cancellationToken).ConfigureAwait(false);

--- a/src/DataCore.Adapter/RealTimeData/SnapshotTagValueManager.cs
+++ b/src/DataCore.Adapter/RealTimeData/SnapshotTagValueManager.cs
@@ -112,7 +112,7 @@ namespace DataCore.Adapter.RealTimeData {
             if (_keyValueStore == null) {
                 return null;
             }
-            return await _keyValueStore.ReadJsonAsync<string[]>("tags").ConfigureAwait(false);
+            return await _keyValueStore.ReadAsync<string[]>("tags").ConfigureAwait(false);
         }
 
 
@@ -126,7 +126,7 @@ namespace DataCore.Adapter.RealTimeData {
             if (_keyValueStore == null) {
                 return;
             }
-            await _keyValueStore.WriteJsonAsync("tags", _valuesById.Keys.ToArray()).ConfigureAwait(false);
+            await _keyValueStore.WriteAsync("tags", _valuesById.Keys.ToArray()).ConfigureAwait(false);
         }
 
 
@@ -143,7 +143,7 @@ namespace DataCore.Adapter.RealTimeData {
             if (_keyValueStore == null) {
                 return null;
             }
-            return await _keyValueStore.ReadJsonAsync<TagValueQueryResult>($"value:{tagId}").ConfigureAwait(false);
+            return await _keyValueStore.ReadAsync<TagValueQueryResult>($"value:{tagId}").ConfigureAwait(false);
         }
 
 
@@ -160,7 +160,7 @@ namespace DataCore.Adapter.RealTimeData {
             if (_keyValueStore == null) {
                 return;
             }
-            await _keyValueStore.WriteJsonAsync($"value:{value.TagId}", value).ConfigureAwait(false);
+            await _keyValueStore.WriteAsync($"value:{value.TagId}", value).ConfigureAwait(false);
         }
 
 

--- a/src/DataCore.Adapter/Tags/TagManager.cs
+++ b/src/DataCore.Adapter/Tags/TagManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -49,11 +48,6 @@ namespace DataCore.Adapter.Tags {
         /// The <see cref="IKeyValueStore"/> where the tag definitions are persisted.
         /// </summary>
         private readonly IKeyValueStore? _keyValueStore;
-
-        /// <summary>
-        /// Options for serializing/deserializing tags.
-        /// </summary>
-        private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
 
         /// <summary>
         /// Flags if the class has been initialised.
@@ -194,7 +188,7 @@ namespace DataCore.Adapter.Tags {
             _tagsByName.Clear();
 
             // "tags" key contains an array of the defined tag IDs.
-            var readResult = await _keyValueStore.ReadJsonAsync<string[]>("tags", _jsonOptions).ConfigureAwait(false);
+            var readResult = await _keyValueStore.ReadAsync<string[]>("tags").ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) {
                 return;
             }
@@ -212,7 +206,7 @@ namespace DataCore.Adapter.Tags {
                     }
 
                     // "tags:{id}" key contains the the definition with ID {id}.
-                    var tagReadResult = await _keyValueStore.ReadJsonAsync<TagDefinition>(string.Concat("tags:", tagId), _jsonOptions).ConfigureAwait(false);
+                    var tagReadResult = await _keyValueStore.ReadAsync<TagDefinition>(string.Concat("tags:", tagId)).ConfigureAwait(false);
                     if (tagReadResult == null) {
                         continue;
                     }
@@ -345,7 +339,7 @@ namespace DataCore.Adapter.Tags {
 
             if (_keyValueStore != null) {
                 // "tags:{id}" key contains the the definition with ID {id}.
-                await _keyValueStore.WriteJsonAsync(string.Concat("tags:", tag.Id), tag, _jsonOptions).ConfigureAwait(false);
+                await _keyValueStore.WriteAsync(string.Concat("tags:", tag.Id), tag).ConfigureAwait(false);
             }
 
             // Check if we are renaming the tag.
@@ -373,7 +367,7 @@ namespace DataCore.Adapter.Tags {
             if (indexHasChanged) {
                 if (_keyValueStore != null) {
                     // "tags" key contains an array of the defined tag IDs.
-                    await _keyValueStore.WriteJsonAsync("tags", _tagsById.Keys.ToArray(), _jsonOptions).ConfigureAwait(false);
+                    await _keyValueStore.WriteAsync("tags", _tagsById.Keys.ToArray()).ConfigureAwait(false);
                 }
                 await OnConfigurationChangeAsync(tag, ConfigurationChangeType.Created, cancellationToken).ConfigureAwait(false);
             }
@@ -430,7 +424,7 @@ namespace DataCore.Adapter.Tags {
 
                 if (_keyValueStore != null) {
                     // "tags" key contains an array of the defined tag IDs.
-                    await _keyValueStore.WriteJsonAsync("tags", _tagsById.Keys.ToArray(), _jsonOptions).ConfigureAwait(false);
+                    await _keyValueStore.WriteAsync("tags", _tagsById.Keys.ToArray()).ConfigureAwait(false);
                 }
             }
 

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -67,7 +67,7 @@
   </Choose>
 
   <!-- Minimal API project is only supported on >= net7.0 -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net48' And '$(TargetFramework)' != 'net6.0' ">
     <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.MinimalApi\DataCore.Adapter.AspNetCore.MinimalApi.csproj" />
   </ItemGroup>
   

--- a/test/DataCore.Adapter.Tests/FasterKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/FasterKeyValueStoreTests.cs
@@ -33,7 +33,7 @@ namespace DataCore.Adapter.Tests {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 })) {
 
-                    await store1.WriteJsonAsync(TestContext.TestName, now);
+                    await ((IKeyValueStore) store1).WriteAsync(TestContext.TestName, now);
                     
                     // Checkpoint should be created when we dispose because we have specified a
                     // checkpoint manager.
@@ -42,7 +42,7 @@ namespace DataCore.Adapter.Tests {
                 using (var store2 = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 })) {
-                    var readResult = await store2.ReadJsonAsync<DateTime>(TestContext.TestName);
+                    var readResult = await ((IKeyValueStore) store2).ReadAsync<DateTime>(TestContext.TestName);
                     Assert.AreEqual(now, readResult);
                 }
             }
@@ -61,7 +61,7 @@ namespace DataCore.Adapter.Tests {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 })) {
 
-                    await store.WriteJsonAsync(TestContext.TestName, DateTime.UtcNow);
+                    await ((IKeyValueStore) store).WriteAsync(TestContext.TestName, DateTime.UtcNow);
                     
                     // Create checkpoint - should succeed
                     var cp1 = await store.TakeFullCheckpointAsync();
@@ -71,7 +71,7 @@ namespace DataCore.Adapter.Tests {
                     var cp2 = await store.TakeFullCheckpointAsync();
                     Assert.IsFalse(cp2);
 
-                    await store.WriteJsonAsync(TestContext.TestName, DateTime.UtcNow);
+                    await ((IKeyValueStore) store).WriteAsync(TestContext.TestName, DateTime.UtcNow);
                     
                     // Create a final checkpoint - should succeed
                     var cp3 = await store.TakeFullCheckpointAsync();

--- a/test/DataCore.Adapter.Tests/FileSystemKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/FileSystemKeyValueStoreTests.cs
@@ -57,10 +57,10 @@ namespace DataCore.Adapter.Tests {
             var baseDir = Path.Combine(s_baseDirectory.FullName, Guid.NewGuid().ToString());
 
             var store1 = CreateStore(baseDir, compressionLevel);
-            await store1.WriteJsonAsync(TestContext.TestName, now);
+            await ((IKeyValueStore) store1).WriteAsync(TestContext.TestName, now);
 
             var store2 = CreateStore(baseDir, compressionLevel);
-            var readResult = await store2.ReadJsonAsync<DateTime>(TestContext.TestName);
+            var readResult = await ((IKeyValueStore) store2).ReadAsync<DateTime>(TestContext.TestName);
 
             Assert.AreEqual(now, readResult);
 

--- a/test/DataCore.Adapter.Tests/InMemoryKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/InMemoryKeyValueStoreTests.cs
@@ -11,7 +11,7 @@ namespace DataCore.Adapter.Tests {
     public class InMemoryKeyValueStoreTests : KeyValueStoreTests<InMemoryKeyValueStore> {
 
         protected override InMemoryKeyValueStore CreateStore(CompressionLevel compressionLevel) {
-            return new InMemoryKeyValueStore(compressionLevel);
+            return new InMemoryKeyValueStore();
         }
 
     }

--- a/test/DataCore.Adapter.Tests/KeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/KeyValueStoreTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 using DataCore.Adapter.Services;
@@ -28,7 +27,7 @@ namespace DataCore.Adapter.Tests {
 
             var store = CreateStore(compressionLevel);
             try {
-                await store.WriteJsonAsync(TestContext.TestName, now);
+                await store.WriteAsync(TestContext.TestName, now);
             }
             finally {
                 if (store is IDisposable disposable) {
@@ -50,9 +49,9 @@ namespace DataCore.Adapter.Tests {
 
             var store = CreateStore(compressionLevel);
             try {
-                await store.WriteJsonAsync(TestContext.TestName, now);
+                await store.WriteAsync(TestContext.TestName, now);
                 
-                var value = await store.ReadJsonAsync<DateTime>(TestContext.TestName);
+                var value = await store.ReadAsync<DateTime>(TestContext.TestName);
                 Assert.AreEqual(now, value);
             }
             finally {
@@ -75,15 +74,15 @@ namespace DataCore.Adapter.Tests {
 
             var store = CreateStore(compressionLevel);
             try {
-                await store.WriteJsonAsync(TestContext.TestName, now);
+                await store.WriteAsync(TestContext.TestName, now);
                 
-                var value = await store.ReadJsonAsync<DateTime>(TestContext.TestName);
+                var value = await store.ReadAsync<DateTime>(TestContext.TestName);
                 Assert.AreEqual(now, value);
 
                 var delete = await store.DeleteAsync(TestContext.TestName);
                 Assert.IsTrue(delete);
 
-                var value2 = await store.ReadJsonAsync<DateTime>(TestContext.TestName);
+                var value2 = await store.ReadAsync<DateTime>(TestContext.TestName);
                 Assert.AreEqual(default(DateTime), value2);
             }
             finally {
@@ -107,7 +106,7 @@ namespace DataCore.Adapter.Tests {
                 var keys = Enumerable.Range(1, 10).Select(x => $"key:{x}").ToArray();
 
                 foreach (var key in keys) {
-                    await store.WriteJsonAsync(key, 0);
+                    await store.WriteAsync(key, 0);
                 }
 
                 var keysActual = await store.GetKeysAsStrings().ToEnumerable();
@@ -141,12 +140,12 @@ namespace DataCore.Adapter.Tests {
                     .CreateScopedStore("INNER 1:")
                     .CreateScopedStore("INNER 2:");
 
-                await scopedStore.WriteJsonAsync(TestContext.TestName, now);
+                await scopedStore.WriteAsync(TestContext.TestName, now);
                 
-                var value = await scopedStore.ReadJsonAsync<DateTime>(TestContext.TestName);
+                var value = await scopedStore.ReadAsync<DateTime>(TestContext.TestName);
                 Assert.AreEqual(now, value);
 
-                var value2 = await store.ReadJsonAsync<DateTime>("INNER 1:INNER 2:" + TestContext.TestName);
+                var value2 = await store.ReadAsync<DateTime>("INNER 1:INNER 2:" + TestContext.TestName);
                 Assert.AreEqual(now, value2);
             }
             finally {
@@ -171,7 +170,7 @@ namespace DataCore.Adapter.Tests {
             try {
                 var scopedStore = store.CreateScopedStore("INNER:");
 
-                await scopedStore.WriteJsonAsync(TestContext.TestName, now);
+                await scopedStore.WriteAsync(TestContext.TestName, now);
                 
                 var keys = await scopedStore.GetKeysAsStrings().ToEnumerable();
                 Assert.IsTrue(keys.Contains(TestContext.TestName));

--- a/test/DataCore.Adapter.Tests/SqliteKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/SqliteKeyValueStoreTests.cs
@@ -67,10 +67,10 @@ namespace DataCore.Adapter.Tests {
             var path = GetDatabaseFileName();
 
             var store1 = CreateStore(path, compressionLevel);
-            await store1.WriteJsonAsync(TestContext.TestName, now);
+            await ((IKeyValueStore) store1).WriteAsync(TestContext.TestName, now);
 
             var store2 = CreateStore(path, compressionLevel);
-            var readResult = await store2.ReadJsonAsync<DateTime>(TestContext.TestName);
+            var readResult = await ((IKeyValueStore) store2).ReadAsync<DateTime>(TestContext.TestName);
 
             Assert.AreEqual(now, readResult);
 


### PR DESCRIPTION
- `IKeyValueStore` read/write method signatures have changed and no longer expect to receive or return `byte[]` (unless explicitly requested by a caller).
- `KeyValueStore` no longer (de)serializes values by default but defines new helper methods that can be used in implementations to serialize values to JSON and compress the resulting bytes and to deserialize compressed JSON bytes.
- `KeyValueStoreOptions` has a new `JsonOptions` property for defining default JSON options to use when (de)serializing values if no options are passed to the (de)serialize helper method.
- `KeyValueStore<TOptions>` now seals the overridden `GetCompressionLevel()` method to always use the compression level from the `TOptions`.
- Microsoft FASTER, file system and SQLite stores have been updated to use new (de)serialization helper methods.