### PR TITLE
Allow KeyValueStore serializer to be replaced

### DIFF
--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 ﻿#nullable enable
-abstract DataCore.Adapter.Services.KeyValueStore.GetJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions?
+abstract DataCore.Adapter.Services.KeyValueStore.GetSerializer() -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
 abstract DataCore.Adapter.Services.KeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 abstract DataCore.Adapter.Services.KeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Common.AdapterDescriptorBuilder
@@ -51,19 +51,23 @@ DataCore.Adapter.Common.HostInfoBuilder.WithVersion(string? version) -> DataCore
 DataCore.Adapter.IAdapterCallContext.Services.get -> System.IServiceProvider!
 DataCore.Adapter.Services.IKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 DataCore.Adapter.Services.IKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.IKeyValueStoreSerializer
+DataCore.Adapter.Services.IKeyValueStoreSerializer.DeserializeAsync<T>(System.IO.Stream! stream) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.IKeyValueStoreSerializer.SerializeAsync<T>(System.IO.Stream! stream, T value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.InMemoryKeyValueStore.InMemoryKeyValueStore() -> void
-DataCore.Adapter.Services.KeyValueStore.DeserializeFromBytesAsync<T>(byte[]! data, System.Text.Json.JsonSerializerOptions? jsonOptions = null) -> System.Threading.Tasks.ValueTask<T?>
-DataCore.Adapter.Services.KeyValueStore.DeserializeFromBytesAsync<T>(byte[]! data, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo) -> System.Threading.Tasks.ValueTask<T?>
-DataCore.Adapter.Services.KeyValueStore.DeserializeFromStreamAsync<T>(System.IO.Stream! stream, System.Text.Json.JsonSerializerOptions? jsonOptions = null) -> System.Threading.Tasks.ValueTask<T?>
-DataCore.Adapter.Services.KeyValueStore.DeserializeFromStreamAsync<T>(System.IO.Stream! stream, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo) -> System.Threading.Tasks.ValueTask<T?>
-DataCore.Adapter.Services.KeyValueStore.SerializeToBytesAsync<T>(T value, System.Text.Json.JsonSerializerOptions? jsonOptions = null, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
-DataCore.Adapter.Services.KeyValueStore.SerializeToBytesAsync<T>(T value, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
-DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.Text.Json.JsonSerializerOptions? jsonOptions = null, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
-DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
-DataCore.Adapter.Services.KeyValueStoreOptions.JsonOptions.get -> System.Text.Json.JsonSerializerOptions?
-DataCore.Adapter.Services.KeyValueStoreOptions.JsonOptions.set -> void
+DataCore.Adapter.Services.JsonKeyValueStoreSerializer
+DataCore.Adapter.Services.JsonKeyValueStoreSerializer.DeserializeAsync<T>(System.IO.Stream! stream) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.JsonKeyValueStoreSerializer.JsonKeyValueStoreSerializer(System.Text.Json.JsonSerializerOptions? jsonOptions) -> void
+DataCore.Adapter.Services.JsonKeyValueStoreSerializer.SerializeAsync<T>(System.IO.Stream! stream, T value) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.KeyValueStore.DeserializeFromBytesAsync<T>(byte[]! data) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.KeyValueStore.DeserializeFromStreamAsync<T>(System.IO.Stream! stream) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.KeyValueStore.SerializeToBytesAsync<T>(T value, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
+DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.get -> DataCore.Adapter.Services.IKeyValueStoreSerializer?
+DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.set -> void
 DataCore.Adapter.Services.ScopedKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 DataCore.Adapter.Services.ScopedKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
 override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetCompressionLevel() -> System.IO.Compression.CompressionLevel
-override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions?
+override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetSerializer() -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
 static DataCore.Adapter.AdapterExtensions.CreateExtendedAdapterDescriptorBuilder(this DataCore.Adapter.IAdapter! adapter) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
+static DataCore.Adapter.Services.JsonKeyValueStoreSerializer.Default.get -> DataCore.Adapter.Services.IKeyValueStoreSerializer!

--- a/src/DataCore.Adapter.Abstractions/Services/IKeyValueStoreSerializer.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/IKeyValueStoreSerializer.cs
@@ -1,0 +1,44 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+namespace DataCore.Adapter.Services {
+
+    /// <summary>
+    /// A serializer for key/value store values.
+    /// </summary>
+    public interface IKeyValueStoreSerializer {
+
+        /// <summary>
+        /// Serializes a value to a stream.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The value type.
+        /// </typeparam>
+        /// <param name="stream">
+        ///   The stream to write to.
+        /// </param>
+        /// <param name="value">
+        ///   The value to serialize.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will serialize the value.
+        /// </returns>
+        ValueTask SerializeAsync<T>(Stream stream, T value);
+
+        /// <summary>
+        /// Deserializes a value from a stream.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The value type.
+        /// </typeparam>
+        /// <param name="stream">
+        ///   The stream to read from.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask{TResult}"/> that will return the deserialized value.
+        /// </returns>
+        ValueTask<T?> DeserializeAsync<T>(Stream stream);
+
+    }
+
+}

--- a/src/DataCore.Adapter.Abstractions/Services/InMemoryKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/InMemoryKeyValueStore.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Compression;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace DataCore.Adapter.Services {
@@ -27,7 +26,9 @@ namespace DataCore.Adapter.Services {
 
 
         /// <inheritdoc/>
-        protected sealed override JsonSerializerOptions? GetJsonSerializerOptions() => null;
+        protected sealed override IKeyValueStoreSerializer GetSerializer() {
+            throw new NotImplementedException();
+        }
 
 
         /// <inheritdoc/>

--- a/src/DataCore.Adapter.Abstractions/Services/JsonKeyValueStoreSerializer.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/JsonKeyValueStoreSerializer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace DataCore.Adapter.Services {
+
+    /// <summary>
+    /// <see cref="IKeyValueStoreSerializer"/> implementation that uses <see cref="JsonSerializer"/>.
+    /// </summary>
+    public sealed class JsonKeyValueStoreSerializer : IKeyValueStoreSerializer {
+
+        /// <summary>
+        /// The JSON serializer options.
+        /// </summary>
+        private readonly JsonSerializerOptions? _jsonOptions;
+
+
+        /// <summary>
+        /// The <see cref="JsonKeyValueStoreSerializer"/> instance.
+        /// </summary>
+        public static IKeyValueStoreSerializer Default { get; } = new JsonKeyValueStoreSerializer(null);
+
+
+        /// <summary>
+        /// Creates a new <see cref="JsonKeyValueStoreSerializer"/> instance.
+        /// </summary>
+        /// <param name="jsonOptions"></param>
+        public JsonKeyValueStoreSerializer(JsonSerializerOptions? jsonOptions) {
+            _jsonOptions = jsonOptions;
+        }
+
+
+        /// <inheritdoc/>
+        public async ValueTask SerializeAsync<T>(Stream stream, T value) {
+            if (stream == null) {
+                throw new ArgumentNullException(nameof(stream));
+            }
+            await JsonSerializer.SerializeAsync(stream, value, _jsonOptions).ConfigureAwait(false);
+        }
+
+
+        /// <inheritdoc/>
+        public async ValueTask<T?> DeserializeAsync<T>(Stream stream) {
+            if (stream == null) {
+                throw new ArgumentNullException(nameof(stream));
+            }
+            return await JsonSerializer.DeserializeAsync<T>(stream, _jsonOptions).ConfigureAwait(false);
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO.Compression;
-using System.Text.Json;
 
 namespace DataCore.Adapter.Services {
 
@@ -9,9 +8,9 @@ namespace DataCore.Adapter.Services {
     public class KeyValueStoreOptions {
 
         /// <summary>
-        /// The JSON serializer options to use when serializing/deserializing values.
+        /// The serializer to use when serializing/deserializing values.
         /// </summary>
-        public JsonSerializerOptions? JsonOptions { get; set; }
+        public IKeyValueStoreSerializer? Serializer { get; set; }
 
         /// <summary>
         /// The compression level to use for data written to the store.

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreT.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreT.cs
@@ -40,7 +40,7 @@ namespace DataCore.Adapter.Services {
 
 
         /// <inheritdoc/>
-        protected sealed override JsonSerializerOptions? GetJsonSerializerOptions() => Options.JsonOptions;
+        protected sealed override IKeyValueStoreSerializer GetSerializer() => Options.Serializer ?? JsonKeyValueStoreSerializer.Default;
 
     }
 }

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/FileSystemKeyValueStore.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/FileSystemKeyValueStore.cs
@@ -393,7 +393,7 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         /// </returns>
         private async Task WriteFileAsync<T>(FileInfo file, T content, CompressionLevel? compressionLevel) {
             using (var stream = file.OpenWrite()) { 
-                await SerializeToStreamAsync(stream, content, jsonOptions: null, compressionLevel: compressionLevel).ConfigureAwait(false);
+                await SerializeToStreamAsync(stream, content, compressionLevel: compressionLevel).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Modifies `KeyValueStore` so that serialization is delegated to an `IKeyValueStoreSerializer` instead of always using System.Text.Json (although STJ is still the default serializer).

A custom serializer can now be specified via a new property on `KeyValueStoreOptions`.