### PR TITLE
Add IRawKeyValueStore

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AbstractionsResources.Designer.cs
+++ b/src/DataCore.Adapter.Abstractions/AbstractionsResources.Designer.cs
@@ -826,6 +826,15 @@ namespace DataCore.Adapter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Raw writes are not enabled for this store..
+        /// </summary>
+        public static string Error_KeyValueStore_RawWritesDisabled {
+            get {
+                return ResourceManager.GetString("Error_KeyValueStore_RawWritesDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} feature is not implemented by the adapter..
         /// </summary>
         public static string Error_MissingAdapterFeature {

--- a/src/DataCore.Adapter.Abstractions/AbstractionsResources.resx
+++ b/src/DataCore.Adapter.Abstractions/AbstractionsResources.resx
@@ -372,6 +372,9 @@
   <data name="Error_KeyValueStore_InvalidKey" xml:space="preserve">
     <value>Zero byte keys are not allowed.</value>
   </data>
+  <data name="Error_KeyValueStore_RawWritesDisabled" xml:space="preserve">
+    <value>Raw writes are not enabled for this store.</value>
+  </data>
   <data name="Error_MissingAdapterFeature" xml:space="preserve">
     <value>The {0} feature is not implemented by the adapter.</value>
     <comment>{0} - IAdapterFeature name</comment>

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -2,6 +2,9 @@
 abstract DataCore.Adapter.Services.KeyValueStore.GetSerializer() -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
 abstract DataCore.Adapter.Services.KeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 abstract DataCore.Adapter.Services.KeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
+abstract DataCore.Adapter.Services.RawKeyValueStore<TOptions>.AllowRawWrites.get -> bool
+abstract DataCore.Adapter.Services.RawKeyValueStore<TOptions>.ReadRawAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
+abstract DataCore.Adapter.Services.RawKeyValueStore<TOptions>.WriteRawAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Common.AdapterDescriptorBuilder
 DataCore.Adapter.Common.AdapterDescriptorBuilder.AdapterDescriptorBuilder(DataCore.Adapter.Common.AdapterDescriptor! descriptor) -> void
 DataCore.Adapter.Common.AdapterDescriptorBuilder.AdapterDescriptorBuilder(DataCore.Adapter.Common.AdapterDescriptorExtended! descriptor) -> void
@@ -55,6 +58,9 @@ DataCore.Adapter.Services.IKeyValueStoreSerializer
 DataCore.Adapter.Services.IKeyValueStoreSerializer.DeserializeAsync<T>(System.IO.Stream! stream) -> System.Threading.Tasks.ValueTask<T?>
 DataCore.Adapter.Services.IKeyValueStoreSerializer.SerializeAsync<T>(System.IO.Stream! stream, T value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.InMemoryKeyValueStore.InMemoryKeyValueStore() -> void
+DataCore.Adapter.Services.IRawKeyValueStore
+DataCore.Adapter.Services.IRawKeyValueStore.ReadRawAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
+DataCore.Adapter.Services.IRawKeyValueStore.WriteRawAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.JsonKeyValueStoreSerializer
 DataCore.Adapter.Services.JsonKeyValueStoreSerializer.DeserializeAsync<T>(System.IO.Stream! stream) -> System.Threading.Tasks.ValueTask<T?>
 DataCore.Adapter.Services.JsonKeyValueStoreSerializer.JsonKeyValueStoreSerializer(System.Text.Json.JsonSerializerOptions? jsonOptions) -> void
@@ -65,9 +71,12 @@ DataCore.Adapter.Services.KeyValueStore.SerializeToBytesAsync<T>(T value, System
 DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.get -> DataCore.Adapter.Services.IKeyValueStoreSerializer?
 DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.set -> void
+DataCore.Adapter.Services.RawKeyValueStore<TOptions>
+DataCore.Adapter.Services.RawKeyValueStore<TOptions>.RawKeyValueStore(TOptions? options, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
 DataCore.Adapter.Services.ScopedKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 DataCore.Adapter.Services.ScopedKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
 override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetCompressionLevel() -> System.IO.Compression.CompressionLevel
 override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetSerializer() -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
 static DataCore.Adapter.AdapterExtensions.CreateExtendedAdapterDescriptorBuilder(this DataCore.Adapter.IAdapter! adapter) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
 static DataCore.Adapter.Services.JsonKeyValueStoreSerializer.Default.get -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
+~static DataCore.Adapter.AbstractionsResources.Error_KeyValueStore_RawWritesDisabled.get -> string

--- a/src/DataCore.Adapter.Abstractions/Services/IRawKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/IRawKeyValueStore.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace DataCore.Adapter.Services {
+
+    /// <summary>
+    /// Extends <see cref="IKeyValueStore"/> to allow raw byte data for keys to be read/written.
+    /// </summary>
+    public interface IRawKeyValueStore : IKeyValueStore {
+
+        /// <summary>
+        /// Reads raw byte data for a key.
+        /// </summary>
+        /// <param name="key">
+        ///   The key.
+        /// </param>
+        /// <returns>
+        ///   The raw byte data for the key, or <see langword="null"/> if the key does not exist.
+        /// </returns>
+        ValueTask<byte[]?> ReadRawAsync(KVKey key);
+
+
+        /// <summary>
+        /// Writes raw byte data for a key.
+        /// </summary>
+        /// <param name="key">
+        ///   The key.
+        /// </param>
+        /// <param name="value">
+        ///   The raw byte data.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will process the operation.
+        /// </returns>
+        ValueTask WriteRawAsync(KVKey key, byte[] value);
+
+    }
+}

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreT.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreT.cs
@@ -22,7 +22,7 @@ namespace DataCore.Adapter.Services {
 
 
         /// <summary>
-        /// Creates a new <see cref="KeyValueStore"/> with the specified key prefix.
+        /// Creates a new <see cref="KeyValueStore{TOptions}"/>.
         /// </summary>
         /// <param name="options">
         ///   Store options.

--- a/src/DataCore.Adapter.Abstractions/Services/RawKeyValueStoreT.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/RawKeyValueStoreT.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+namespace DataCore.Adapter.Services {
+
+    /// <summary>
+    /// Base implementation of <see cref="IRawKeyValueStore"/>.
+    /// </summary>
+    /// <typeparam name="TOptions">
+    ///   The store options type.
+    /// </typeparam>
+    public abstract class RawKeyValueStore<TOptions> : KeyValueStore<TOptions>, IRawKeyValueStore where TOptions : KeyValueStoreOptions, new() {
+
+        /// <summary>
+        /// Specifies if raw writes are allowed.
+        /// </summary>
+        protected abstract bool AllowRawWrites { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="RawKeyValueStore{TOptions}"/>.
+        /// </summary>
+        /// <param name="options">
+        ///   Store options.
+        /// </param>
+        /// <param name="logger">
+        ///   The logger for the store.
+        /// </param>
+        protected RawKeyValueStore(TOptions? options, ILogger? logger = null) : base(options, logger) { }
+
+
+        /// <inheritdoc/>
+        async ValueTask<byte[]?> IRawKeyValueStore.ReadRawAsync(KVKey key) {
+            if (key.Length == 0) {
+                throw new ArgumentException(AbstractionsResources.Error_KeyValueStore_InvalidKey, nameof(key));
+            }
+
+            var data = await ReadRawAsync(key).ConfigureAwait(false);
+            if (data == null) {
+                return null;
+            }
+
+            return await DecompressRawBytesAsync(data).ConfigureAwait(false);
+        }
+
+
+        /// <inheritdoc/>
+        async ValueTask IRawKeyValueStore.WriteRawAsync(KVKey key, byte[] value) {
+            if (key.Length == 0) {
+                throw new ArgumentException(AbstractionsResources.Error_KeyValueStore_InvalidKey, nameof(key));
+            }
+            if (value == null) {
+                throw new ArgumentNullException(nameof(value));
+            }
+            if (!AllowRawWrites) {
+                throw new InvalidOperationException(AbstractionsResources.Error_KeyValueStore_RawWritesDisabled);
+            }
+
+            var data = await CompressRawBytesAsync(value, GetCompressionLevel()).ConfigureAwait(false);
+            await WriteRawAsync(key, data).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Reads raw byte data for a key.
+        /// </summary>
+        /// <param name="key">
+        ///   The key.
+        /// </param>
+        /// <returns>
+        ///   The raw byte data for the key, or <see langword="null"/> if the key does not exist.
+        /// </returns>
+        protected abstract ValueTask<byte[]?> ReadRawAsync(KVKey key);
+
+
+        /// <summary>
+        /// Writes raw byte data to a key.
+        /// </summary>
+        /// <param name="key">
+        ///   The key.
+        /// </param>
+        /// <param name="value">
+        ///   The raw byte data.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will process the operation.
+        /// </returns>
+        protected abstract ValueTask WriteRawAsync(KVKey key, byte[] value);
+
+
+        /// <summary>
+        /// Compresses raw byte data.
+        /// </summary>
+        /// <param name="data">
+        ///   The raw byte data.
+        /// </param>
+        /// <param name="compressionLevel">
+        ///   The compression level to use. If <see langword="null"/>, the default compression 
+        ///   level is used.
+        /// </param>
+        /// <returns>
+        ///   A byte array containing the compressed raw data.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="data"/> is <see langword="null"/>.
+        /// </exception>
+        private async ValueTask<byte[]> CompressRawBytesAsync(byte[] data, CompressionLevel? compressionLevel = null) {
+            if (data == null) {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            var level = compressionLevel ?? GetCompressionLevel();
+
+            using (var ms = new MemoryStream())
+            using (var compressStream = new GZipStream(ms, level, leaveOpen: true)) {
+                await compressStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                compressStream.Close();
+                return ms.ToArray();
+            }
+        }
+
+
+        private async ValueTask<byte[]> DecompressRawBytesAsync(byte[] data) {
+            if (data == null) {
+                throw new ArgumentNullException(nameof(data));
+            }
+            using (var ms1 = new MemoryStream(data))
+            using (var decompressStream = new GZipStream(ms1, CompressionMode.Decompress, leaveOpen: true))
+            using (var ms2 = new MemoryStream()) {
+                await decompressStream.CopyToAsync(ms2).ConfigureAwait(false);
+                return ms2.ToArray();
+            }
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStoreOptions.cs
@@ -21,6 +21,15 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         public bool ReadOnly { get; set; }
 
         /// <summary>
+        /// When <see langword="true"/>, enables the use of <see cref="Services.IRawKeyValueStore.WriteRawAsync"/> 
+        /// to write raw byte data to the store.
+        /// </summary>
+        /// <remarks>
+        ///   Attempting a raw write will throw an exception if this property is <see langword="false"/>.
+        /// </remarks>
+        public bool EnableRawWrites { get; set; }
+
+        /// <summary>
         /// A factory for creating an <see cref="IDevice"/> for use with the FASTER log.
         /// </summary>
         /// <remarks>

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
 ﻿#nullable enable
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.EnableRawWrites.get -> bool
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.EnableRawWrites.set -> void
+override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.AllowRawWrites.get -> bool
 override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
+override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.ReadRawAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
 override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
+override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.WriteRawAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
 ﻿#nullable enable
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.EnableRawWrites.get -> bool
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.EnableRawWrites.set -> void
+override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.AllowRawWrites.get -> bool
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
+override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadRawAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
+override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.WriteRawAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/SqliteKeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/SqliteKeyValueStoreOptions.cs
@@ -15,6 +15,15 @@
         /// </summary>
         public string ConnectionString { get; set; } = DefaultConnectionString;
 
+        /// <summary>
+        /// When <see langword="true"/>, enables the use of <see cref="Services.IRawKeyValueStore.WriteRawAsync"/> 
+        /// to write raw byte data to the store.
+        /// </summary>
+        /// <remarks>
+        ///   Attempting a raw write will throw an exception if this property is <see langword="false"/>.
+        /// </remarks>
+        public bool EnableRawWrites { get; set; }
+
     }
 
 }

--- a/test/DataCore.Adapter.Tests/FasterKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/FasterKeyValueStoreTests.cs
@@ -17,8 +17,8 @@ namespace DataCore.Adapter.Tests {
 
     [TestClass]
     public class FasterKeyValueStoreTests : KeyValueStoreTests<FasterKeyValueStore> {
-        protected override FasterKeyValueStore CreateStore(CompressionLevel compressionLevel) {
-            return new FasterKeyValueStore(new FasterKeyValueStoreOptions() { CompressionLevel = compressionLevel });
+        protected override FasterKeyValueStore CreateStore(CompressionLevel compressionLevel, bool enableRawWrites = false) {
+            return new FasterKeyValueStore(new FasterKeyValueStoreOptions() { CompressionLevel = compressionLevel, EnableRawWrites = enableRawWrites });
         }
 
 

--- a/test/DataCore.Adapter.Tests/FileSystemKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/FileSystemKeyValueStoreTests.cs
@@ -40,7 +40,7 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected override FileSystemKeyValueStore CreateStore(CompressionLevel compressionLevel) {
+        protected override FileSystemKeyValueStore CreateStore(CompressionLevel compressionLevel, bool enableRawWrites = false) {
             return CreateStore(Path.Combine(s_baseDirectory.FullName, Guid.NewGuid().ToString()), compressionLevel);
         }
 

--- a/test/DataCore.Adapter.Tests/InMemoryKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/InMemoryKeyValueStoreTests.cs
@@ -10,7 +10,7 @@ namespace DataCore.Adapter.Tests {
     [TestClass]
     public class InMemoryKeyValueStoreTests : KeyValueStoreTests<InMemoryKeyValueStore> {
 
-        protected override InMemoryKeyValueStore CreateStore(CompressionLevel compressionLevel) {
+        protected override InMemoryKeyValueStore CreateStore(CompressionLevel compressionLevel, bool enableRawWrites = false) {
             return new InMemoryKeyValueStore();
         }
 

--- a/test/DataCore.Adapter.Tests/SqliteKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/SqliteKeyValueStoreTests.cs
@@ -37,10 +37,11 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        private static SqliteKeyValueStore CreateStore(string fileName, CompressionLevel compressionLevel) {
+        private static SqliteKeyValueStore CreateStore(string fileName, CompressionLevel compressionLevel, bool enableRawWrites) {
             return new SqliteKeyValueStore(new SqliteKeyValueStoreOptions() { 
                 ConnectionString = $"Data Source={fileName};Cache=Shared",
-                CompressionLevel = compressionLevel
+                CompressionLevel = compressionLevel,
+                EnableRawWrites = enableRawWrites
             });
         }
 
@@ -50,8 +51,8 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected override SqliteKeyValueStore CreateStore(CompressionLevel compressionLevel) {
-            return CreateStore(GetDatabaseFileName(), compressionLevel);
+        protected override SqliteKeyValueStore CreateStore(CompressionLevel compressionLevel, bool enableRawWrites = false) {
+            return CreateStore(GetDatabaseFileName(), compressionLevel, enableRawWrites);
         }
 
 
@@ -66,10 +67,10 @@ namespace DataCore.Adapter.Tests {
             var now = DateTime.UtcNow;
             var path = GetDatabaseFileName();
 
-            var store1 = CreateStore(path, compressionLevel);
+            var store1 = CreateStore(path, compressionLevel, false);
             await ((IKeyValueStore) store1).WriteAsync(TestContext.TestName, now);
 
-            var store2 = CreateStore(path, compressionLevel);
+            var store2 = CreateStore(path, compressionLevel, false);
             var readResult = await ((IKeyValueStore) store2).ReadAsync<DateTime>(TestContext.TestName);
 
             Assert.AreEqual(now, readResult);


### PR DESCRIPTION
`IRawKeyValueStore` extends `IKeyValueStore` to provide methods for reading/writing raw bytes instead of deserializing/serializing values.

FASTER and Sqlite implementations have been updated to implement this interface; raw writes are only allowed when an `EnableRawWrites` flag on the stores' options types is set.