### PR TITLE
Key/value store optimisations

### DIFF
--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
@@ -1,4 +1,11 @@
 ﻿#nullable enable
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.FasterRecord() -> void
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.Key.get -> DataCore.Adapter.Services.KVKey
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.Metadata.get -> FASTER.core.RecordMetadata
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.Mutable.get -> bool
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.Value.get -> System.ReadOnlyMemory<byte>
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.GetRecordsAsync(DataCore.Adapter.Services.KVKey? prefix = null) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord>!
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.TakeIncrementalCheckpointAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.EnableRawWrites.get -> bool
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.EnableRawWrites.set -> void

--- a/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
+++ b/src/DataCore.Adapter/RealTimeData/TagValueBuilder.cs
@@ -14,7 +14,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// <summary>
         /// The UTC sample time.
         /// </summary>
-        private DateTime _utcSampleTime = DateTime.UtcNow;
+        private DateTime? _utcSampleTime;
 
         /// <summary>
         /// The value for the sample.
@@ -137,7 +137,7 @@ namespace DataCore.Adapter.RealTimeData {
         ///   A new <see cref="TagValueExtended"/> object.
         /// </returns>
         public TagValueExtended Build() {
-            return new TagValueExtended(_utcSampleTime, _value, _status, _units, _notes, _error, _properties);
+            return new TagValueExtended(_utcSampleTime ??= DateTime.UtcNow, _value, _status, _units, _notes, _error, _properties);
         }
 
 

--- a/test/DataCore.Adapter.Tests/KeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/KeyValueStoreTests.cs
@@ -45,6 +45,35 @@ namespace DataCore.Adapter.Tests {
 #if NET6_0_OR_GREATER
         [DataRow(CompressionLevel.SmallestSize)]
 #endif
+        public async Task ShouldUpdateValue(CompressionLevel compressionLevel) {
+            var before = DateTime.UtcNow.AddDays(-1);
+            var after = DateTime.UtcNow;
+
+            var store = CreateStore(compressionLevel);
+            try {
+                await store.WriteAsync(TestContext.TestName, before);
+                var value = await store.ReadAsync<DateTime>(TestContext.TestName);
+                Assert.AreEqual(before, value);
+
+                await store.WriteAsync(TestContext.TestName, after);
+                value = await store.ReadAsync<DateTime>(TestContext.TestName);
+                Assert.AreEqual(after, value);
+            }
+            finally {
+                if (store is IDisposable disposable) {
+                    disposable.Dispose();
+                }
+            }
+        }
+
+
+        [DataTestMethod]
+        [DataRow(CompressionLevel.NoCompression)]
+        [DataRow(CompressionLevel.Fastest)]
+        [DataRow(CompressionLevel.Optimal)]
+#if NET6_0_OR_GREATER
+        [DataRow(CompressionLevel.SmallestSize)]
+#endif
         public async Task ShouldReadValueFromStore(CompressionLevel compressionLevel) {
             var now = DateTime.UtcNow;
 


### PR DESCRIPTION
Modifies the SQLite key/value store to use BLOB I/O when reading/writing values.

Updates the FASTER key/value store to allow all records in the store to be iterated over.

Makes a small tweak to `TagValueBuilder` to prevent redundant calls to `DateTime.UtcNow`.