### PR TITLE
Add background flush to SQLite key/value store

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,37 +26,37 @@
   <ItemGroup>
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="CsvHelper" Version="30.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.24.3" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.57.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.57.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.58.0" />
-    <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="9.1.0" />
-    <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="9.1.0" />
-    <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="9.1.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.25.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.58.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.58.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.59.0" />
+    <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="11.0.0" />
+    <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="11.0.0" />
+    <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="11.0.0" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="2.2.0" />
-    <PackageVersion Include="JsonSchema.Net.Generation" Version="3.3.2" />
+    <PackageVersion Include="JsonSchema.Net.Generation" Version="3.4.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.13" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.11" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.FASTER.Core" Version="2.6.0" />
+    <PackageVersion Include="Microsoft.FASTER.Core" Version="2.6.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="$(PkgVersion_Microsoft_Web_LibraryManager_Build)" />
-    <PackageVersion Include="MiniValidation" Version="0.8.0" />
+    <PackageVersion Include="MiniValidation" Version="0.9.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-    <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="13.20.0" />
     <PackageVersion Include="OpenTelemetry" Version="$(PkgVersion_OpenTelemetry)" />
     <PackageVersion Include="OpenTelemetry.Api" Version="$(PkgVersion_OpenTelemetry_Api)" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="$(PkgVersion_OpenTelemetry_Exporter_Console)" />

--- a/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationBuilderExtensions.cs
+++ b/src/DataCore.Adapter.DependencyInjection/AdapterConfigurationBuilderExtensions.cs
@@ -218,7 +218,8 @@ namespace Microsoft.Extensions.DependencyInjection {
                 throw new ArgumentNullException(nameof(implementationInstance));
             }
 
-            builder.Services.AddSingleton(implementationInstance);
+            builder.Services.AddSingleton(implementationInstance.GetType(), implementationInstance);
+            builder.Services.AddSingleton(typeof(IKeyValueStore), implementationInstance);
 
             return builder;
         }
@@ -244,7 +245,8 @@ namespace Microsoft.Extensions.DependencyInjection {
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.Services.AddSingleton<IKeyValueStore, T>();
+            builder.Services.AddSingleton<T>();
+            builder.Services.AddSingleton<IKeyValueStore>(sp => sp.GetRequiredService<T>());
             return builder;
         }
 
@@ -277,8 +279,9 @@ namespace Microsoft.Extensions.DependencyInjection {
             if (implementationFactory == null) {
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
-            
-            builder.Services.AddSingleton<IKeyValueStore, T>(implementationFactory);
+
+            builder.Services.AddSingleton(implementationFactory);
+            builder.Services.AddSingleton<IKeyValueStore>(sp => sp.GetRequiredService<T>());
             return builder;
         }
 

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.FlushAsync() -> System
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.WaitForNextFlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.EnableRawWrites.get -> bool
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.EnableRawWrites.set -> void
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.FlushInterval.get -> System.TimeSpan
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.FlushInterval.set -> void
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.AllowRawWrites.get -> bool
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadRawAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.Dispose() -> void
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.FlushAsync() -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.WaitForNextFlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.EnableRawWrites.get -> bool
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.EnableRawWrites.set -> void
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.AllowRawWrites.get -> bool

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/SqliteKeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/SqliteKeyValueStoreOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace DataCore.Adapter.KeyValueStore.Sqlite {
+﻿using System;
+
+namespace DataCore.Adapter.KeyValueStore.Sqlite {
 
     /// <summary>
     /// Options for <see cref="SqliteKeyValueStore"/>.
@@ -23,6 +25,15 @@
         ///   Attempting a raw write will throw an exception if this property is <see langword="false"/>.
         /// </remarks>
         public bool EnableRawWrites { get; set; }
+
+        /// <summary>
+        /// The interval at which pending writes are flushed to the database.
+        /// </summary>
+        /// <remarks>
+        ///   Specify a value less than or equal to <see cref="TimeSpan.Zero"/> to write changes 
+        ///   to the database immediately.
+        /// </remarks>
+        public TimeSpan FlushInterval { get; set; }
 
     }
 

--- a/src/DataCore.Adapter/Json/Schema/JsonSchemaUtility.cs
+++ b/src/DataCore.Adapter/Json/Schema/JsonSchemaUtility.cs
@@ -94,7 +94,7 @@ namespace DataCore.Adapter.Json.Schema {
         public static JsonElement CreateJsonSchema<T>(JsonSerializerOptions? options = null) {
             RegisterExtensions();
             var builder = new JsonSchemaBuilder().FromType<T>(new SchemaGeneratorConfiguration() {
-                PropertyNamingMethod = name => options?.PropertyNamingPolicy?.ConvertName(name) ?? name
+                PropertyNameResolver = member => options?.PropertyNamingPolicy?.ConvertName(member.Name) ?? member.Name
             });
 
             return JsonSerializer.SerializeToElement(builder.Build(), options);


### PR DESCRIPTION
This PR adds a property to `SqliteKeyValueStoreOptions` for defining a background flush interval.

When the interval is greater than `TimeSpan.Zero`, write and delete operations are no longer immediately performed. Instead, they are added to a dictionary (indexed by key). The value for the entry is the byte array for the updated value, or `null` if the key should be deleted.

When the flush interval is reached, a background task performs all of the pending changes and clears the pending operations dictionary. A flush can also be explicitly triggered using the new `FlushAsync` method on the `SqliteKeyValueStore` class.

The default behaviour is to write/delete from the database immediately, so the background flush capability is opt-in. 