### PR TITLE
Add key/value store write buffer helper

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,14 +27,14 @@
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="CsvHelper" Version="30.0.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.25.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.58.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.58.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.59.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.59.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.59.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="11.0.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="11.0.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="11.0.0" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="2.2.0" />
-    <PackageVersion Include="JsonSchema.Net.Generation" Version="3.4.1" />
+    <PackageVersion Include="JsonSchema.Net.Generation" Version="3.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.13" />
@@ -47,7 +47,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.FASTER.Core" Version="2.6.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="$(PkgVersion_Microsoft_Web_LibraryManager_Build)" />

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -71,6 +71,27 @@ DataCore.Adapter.Services.KeyValueStore.SerializeToBytesAsync<T>(T value, System
 DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.get -> DataCore.Adapter.Services.IKeyValueStoreSerializer?
 DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.set -> void
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.DeleteAsync(DataCore.Adapter.Services.KVKey key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.Dispose() -> void
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.FlushAsync() -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.KeyValueStoreWriteBuffer(DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions! options, System.Func<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<DataCore.Adapter.Services.KVKey, byte[]?>>!, System.Threading.Tasks.Task!>! callback, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.Services.KeyValueStoreWriteBuffer!>? logger = null) -> void
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.ReadAsync(DataCore.Adapter.Services.KVKey key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<DataCore.Adapter.Services.KeyValueStoreWriteBuffer.ReadResult>
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.ReadResult
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.ReadResult.Found.get -> bool
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.ReadResult.ReadResult() -> void
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.ReadResult.ReadResult(bool found, byte[]? value) -> void
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.ReadResult.Value.get -> byte[]?
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.WaitForNextFlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.KeyValueStoreWriteBuffer.WriteAsync(DataCore.Adapter.Services.KVKey key, byte[]! value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions
+DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions.FlushInterval.get -> System.TimeSpan
+DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions.FlushInterval.set -> void
+DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions.KeyLimit.get -> int
+DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions.KeyLimit.set -> void
+DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions.KeyValueStoreWriteBufferOptions() -> void
+DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions.SizeLimit.get -> int
+DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions.SizeLimit.set -> void
 DataCore.Adapter.Services.RawKeyValueStore<TOptions>
 DataCore.Adapter.Services.RawKeyValueStore<TOptions>.RawKeyValueStore(TOptions? options, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
 DataCore.Adapter.Services.ScopedKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreWriteBuffer.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreWriteBuffer.cs
@@ -1,0 +1,392 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+namespace DataCore.Adapter.Services {
+
+    /// <summary>
+    /// A helper class that caches write and delete operations for an <see cref="IRawKeyValueStore"/> 
+    /// and flushes changes on a periodic basis, or when maximum key or size limits are exceeded.
+    /// </summary>
+    /// <remarks>
+    ///   Use <see cref="KeyValueStoreWriteBuffer"/> with <see cref="IRawKeyValueStore"/> 
+    ///   implementations that will benefit from writing or deleting keys in batches.
+    /// </remarks>
+    public sealed partial class KeyValueStoreWriteBuffer : IDisposable {
+
+        /// <summary>
+        /// Specifies if the object has been disposed.
+        /// </summary>
+        private bool _disposed;
+
+        /// <summary>
+        /// The options for the buffer.
+        /// </summary>
+        private readonly KeyValueStoreWriteBufferOptions _options;
+
+        /// <summary>
+        /// The callback to invoke when the buffer is flushed.
+        /// </summary>
+        private readonly Func<IEnumerable<KeyValuePair<KVKey, byte[]?>>, Task> _callback;
+
+        /// <summary>
+        /// The pending writes to the store.
+        /// </summary>
+        /// <remarks>
+        ///   An entry with a <see langword="null"/> value indicates that the entry will be deleted.
+        /// </remarks>
+        private readonly Dictionary<KVKey, byte[]?> _pendingChanges = new Dictionary<KVKey, byte[]?>();
+
+        /// <summary>
+        /// The size of all pending writes to the store.
+        /// </summary>
+        private long _pendingWritesSize;
+
+        /// <summary>
+        /// Used to signal when a flush has completed.
+        /// </summary>
+        private readonly Nito.AsyncEx.AsyncManualResetEvent _flushEvent = new Nito.AsyncEx.AsyncManualResetEvent(false);
+
+        /// <summary>
+        /// A cancellation token source that is cancelled when the object is disposed.
+        /// </summary>
+        private readonly CancellationTokenSource _disposedTokenSource = new CancellationTokenSource();
+
+        /// <summary>
+        /// A lock for accessing <see cref="_pendingChanges"/> and <see cref="_pendingWritesSize"/>.
+        /// </summary>
+        private readonly Nito.AsyncEx.AsyncReaderWriterLock _lock = new Nito.AsyncEx.AsyncReaderWriterLock();
+
+        /// <summary>
+        /// Logging.
+        /// </summary>
+        private readonly ILogger<KeyValueStoreWriteBuffer> _logger;
+
+
+        /// <summary>
+        /// Creates a new <see cref="KeyValueStoreWriteBuffer"/> instance.
+        /// </summary>
+        /// <param name="options">
+        ///   The buffer options.
+        /// </param>
+        /// <param name="callback">
+        ///   The callback to invoke when the buffer is flushed.
+        /// </param>
+        /// <param name="logger">
+        ///   The logger to use for the buffer.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public KeyValueStoreWriteBuffer(
+            KeyValueStoreWriteBufferOptions options,
+            Func<IEnumerable<KeyValuePair<KVKey, byte[]?>>, Task> callback,
+            ILogger<KeyValueStoreWriteBuffer>? logger = null
+        ) {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _callback = callback ?? throw new ArgumentNullException(nameof(callback));
+            _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KeyValueStoreWriteBuffer>.Instance;
+
+            _ = Task.Run(() => RunPeriodicFlushAsync(_disposedTokenSource.Token));
+        }
+
+
+        /// <summary>
+        /// Reads a serialized value from the buffer.
+        /// </summary>
+        /// <param name="key">
+        ///   The key.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask{TResult}"/> that will return the value from the buffer, or 
+        ///   <see langword="null"/>.
+        /// </returns>
+        public async ValueTask<ReadResult> ReadAsync(KVKey key, CancellationToken cancellationToken = default) {
+            if (_disposed) {
+                return default;
+            }
+
+            using (await _lock.ReaderLockAsync(cancellationToken).ConfigureAwait(false)) {
+                if (_disposed) {
+                    return default;
+                }
+
+                if (_pendingChanges.TryGetValue(key, out byte[]? value)) {
+                    return new ReadResult(true, value);
+                }
+
+                return default;
+            }
+        }
+
+
+        /// <summary>
+        /// Adds a pending write to the buffer.
+        /// </summary>
+        /// <param name="key">
+        ///   The key to write to.
+        /// </param>
+        /// <param name="value">
+        ///   The serialized value.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will add the operation to the buffer.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="value"/> is <see langword="null"/>.
+        /// </exception>
+        public async ValueTask WriteAsync(KVKey key, byte[] value, CancellationToken cancellationToken = default) {
+            if (value == null) {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (_disposed) {
+                return;
+            }
+
+            var immediateFlush = false;
+            var immediateFlushReason = "";
+
+            using (await _lock.WriterLockAsync(cancellationToken).ConfigureAwait(false)) {
+                if (_disposed) {
+                    return;
+                }
+
+                if (_pendingChanges.TryGetValue(key, out var bytes) && bytes != null) {
+                    _pendingWritesSize -= bytes.Length;
+                }
+                _pendingChanges[key] = value;
+                _pendingWritesSize += value.Length;
+
+                if (_options.KeyLimit > 0 && _pendingChanges.Count >= _options.KeyLimit) {
+                    immediateFlush = true;
+                    immediateFlushReason = "key limit exceeded";
+                }
+                else if (_options.SizeLimit > 0 && _pendingWritesSize >= _options.SizeLimit) {
+                    immediateFlush = true;
+                    immediateFlushReason = "size limit exceeded";
+                }
+            }
+
+            if (immediateFlush) {
+                await FlushCoreAsync(immediateFlushReason).ConfigureAwait(false);
+            }
+        }
+
+
+        /// <summary>
+        /// Adds a pending delete to the buffer.
+        /// </summary>
+        /// <param name="key">
+        ///   The key to delete.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will add the operation to the buffer.
+        /// </returns>
+        public async ValueTask DeleteAsync(KVKey key, CancellationToken cancellationToken = default) {
+            if (_disposed) {
+                return;
+            }
+
+            var immediateFlush = false;
+
+            using (await _lock.WriterLockAsync(cancellationToken).ConfigureAwait(false)) {
+                if (_disposed) {
+                    return;
+                }
+
+                if (_pendingChanges.TryGetValue(key, out var bytes) && bytes != null) {
+                    _pendingWritesSize -= bytes.Length;
+                }
+                _pendingChanges[key] = null;
+
+                if (_options.KeyLimit > 0 && _pendingChanges.Count >= _options.KeyLimit) {
+                    immediateFlush = true;
+                }
+            }
+
+            if (immediateFlush) {
+                await FlushCoreAsync("key limit exceeded").ConfigureAwait(false);
+            }
+        }
+
+
+        /// <summary>
+        /// Runs the periodic flush task.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task"/> that will run the periodic flush task.
+        /// </returns>
+        private async Task RunPeriodicFlushAsync(CancellationToken cancellationToken) {
+            var interval = _options.FlushInterval;
+            if (interval <= TimeSpan.Zero) {
+                interval = TimeSpan.FromSeconds(5);
+            }
+
+            LogFlushEnabled(interval);
+
+            while (!cancellationToken.IsCancellationRequested) {
+                try {
+                    await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+                    await FlushCoreAsync("periodic flush").ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception e) {
+                    LogFlushError(e);
+                }
+            }
+
+            // Final flush once cancellation has been requested.
+            try {
+                await FlushCoreAsync("periodic flush cancelled").ConfigureAwait(false);
+            }
+            catch (Exception e) {
+                LogFlushError(e);
+            }
+        }
+
+
+        /// <summary>
+        /// Flushes pending changes to the store.
+        /// </summary>
+        /// <param name="reason">
+        ///   The reason for the flush.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will flush pending changes to the store.
+        /// </returns>
+        private async ValueTask FlushCoreAsync(string reason) {
+            try {
+                using (await _lock.WriterLockAsync().ConfigureAwait(false)) {
+                    if (_pendingChanges.Count == 0) {
+                        return;
+                    }
+
+                    LogFlushStarted(_pendingChanges.Count, reason);
+
+                    await _callback(_pendingChanges).ConfigureAwait(false);
+                    _pendingChanges.Clear();
+                }
+            }
+            finally {
+                _flushEvent.Set();
+                _flushEvent.Reset();
+            }
+        }
+
+
+        /// <summary>
+        /// Manually flushes pending changes to the store.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will flush pending changes to the store.
+        /// </returns>
+        public async ValueTask FlushAsync() {
+            if (_disposed) {
+                return;
+            }
+
+            await FlushCoreAsync("manual flush requested").ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Waits for the next flush to complete.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///   The cancellation token to use for the operation.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>
+        ///   If the store is configured to flush pending writes to the database immediately, 
+        ///   <see cref="WaitForNextFlushAsync"/> will return immediately.
+        /// </remarks>
+        public async ValueTask WaitForNextFlushAsync(CancellationToken cancellationToken = default) {
+            if (_disposed) {
+                return;
+            }
+
+            Task t;
+            using (await _lock.ReaderLockAsync(cancellationToken)) {
+                if (_disposed) {
+                    return;
+                }
+                t = _flushEvent.WaitAsync(cancellationToken);
+            }
+            await t.ConfigureAwait(false);
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+
+            _disposedTokenSource.Cancel();
+            _disposedTokenSource.Dispose();
+
+            _disposed = true;
+        }
+
+
+        [LoggerMessage(1, LogLevel.Information, "Changes will be flushed to the store at an interval of {flushInterval}.")]
+        partial void LogFlushEnabled(TimeSpan flushInterval);
+
+        [LoggerMessage(2, LogLevel.Trace, "Flushing {count} pending changes to the store. Reason: {reason}")]
+        partial void LogFlushStarted(int count, string reason);
+
+        [LoggerMessage(3, LogLevel.Error, "Error while flushing pending changes to the store.")]
+        partial void LogFlushError(Exception e);
+
+
+        /// <summary>
+        /// The result of a call to <see cref="ReadAsync"/>
+        /// </summary>
+        public readonly struct ReadResult {
+
+            /// <summary>
+            /// Specifies if the key was found in the <see cref="KeyValueStoreWriteBuffer"/>
+            /// </summary>
+            public bool Found { get; }
+
+            /// <summary>
+            /// The value, if found.
+            /// </summary>
+            public byte[]? Value { get; }
+
+
+            /// <summary>
+            /// Creates a new <see cref="ReadResult"/> instance.
+            /// </summary>
+            /// <param name="found">
+            ///   <see langword="true"/> if the key was found in the <see cref="KeyValueStoreWriteBuffer"/>; 
+            ///   otherwise, <see langword="false"/>.
+            /// </param>
+            /// <param name="value">
+            ///   The value, if found.
+            /// </param>
+            public ReadResult(bool found, byte[]? value) {
+                Found = found;
+                Value = value;
+            }
+
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreWriteBufferOptions.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStoreWriteBufferOptions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace DataCore.Adapter.Services {
+
+    /// <summary>
+    /// Options for <see cref="KeyValueStoreWriteBuffer"/>.
+    /// </summary>
+    public class KeyValueStoreWriteBufferOptions {
+
+        /// <summary>
+        /// The interval at which pending writes are flushed to the store.
+        /// </summary>
+        /// <remarks>
+        ///   If <see cref="FlushInterval"/> is less than or equal to <see cref="TimeSpan.Zero"/> 
+        ///   a default flush interval will be used.
+        /// </remarks>
+        public TimeSpan FlushInterval { get; set; }
+
+        /// <summary>
+        /// The maximum number of keys that can be stored in the cache.
+        /// </summary>
+        /// <remarks>
+        ///   If the number of keys in the cache exceeds this value, an immediate flush will be 
+        ///   performed. Specify less than one for no limit.
+        /// </remarks>
+        public int KeyLimit { get; set; }
+
+        /// <summary>
+        /// The maximum number of bytes that can be stored in the cache.
+        /// </summary>
+        /// <remarks>
+        ///   If the size of all pending writes exceeds this value, an immediate flush will be 
+        ///   performed. Specify less than one for no limit.
+        /// </remarks>
+        public int SizeLimit { get; set; }
+
+    }
+}

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/FileSystemKeyValueStore.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/FileSystemKeyValueStore.cs
@@ -21,7 +21,7 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
     /// <summary>
     /// <see cref="IKeyValueStore"/> implementation that persists files to disk.
     /// </summary>
-    public class FileSystemKeyValueStore : KeyValueStore<FileSystemKeyValueStoreOptions>, IDisposable {
+    public sealed partial class FileSystemKeyValueStore : KeyValueStore<FileSystemKeyValueStoreOptions>, IDisposable {
 
         /// <summary>
         /// SHA256 for creating distinct, fixed-length file names.
@@ -39,16 +39,6 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         private bool _disposed;
 
         /// <summary>
-        /// Cancellation token source that fires when the store is disposed.
-        /// </summary>
-        private readonly CancellationTokenSource _disposedTokenSource = new CancellationTokenSource();
-
-        /// <summary>
-        /// Cancellation token from <see cref="_disposedTokenSource"/>.
-        /// </summary>
-        private readonly CancellationToken _disposedToken;
-
-        /// <summary>
         /// The base directory for the persisted files.
         /// </summary>
         private readonly DirectoryInfo _baseDirectory;
@@ -59,9 +49,9 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         private readonly int _hashBuckets;
 
         /// <summary>
-        /// Holds read/write locks for each individual key (file).
+        /// Lock for the store.
         /// </summary>
-        private readonly ConcurrentDictionary<string, AsyncReaderWriterLock> _fileLocks = new ConcurrentDictionary<string, AsyncReaderWriterLock>();
+        private readonly AsyncReaderWriterLock _lock = new AsyncReaderWriterLock();
 
         /// <summary>
         /// Lookup from key to file name.
@@ -74,14 +64,14 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         private readonly Lazy<Task> _indexLoader;
 
         /// <summary>
-        /// Indicates if an index save is pending.
+        /// Write buffer for the store, if configured.
         /// </summary>
-        private int _indexSavePending;
+        private readonly KeyValueStoreWriteBuffer? _writeBuffer;
 
         /// <summary>
-        /// Indicates if an index save is in progress.
+        /// Specifies if the store uses a write buffer.
         /// </summary>
-        private readonly ManualResetEventSlim _indexSaveInProgress = new ManualResetEventSlim();
+        private bool UseWriteBuffer => _writeBuffer != null;
 
 
         /// <summary>
@@ -96,13 +86,11 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="options"/> is <see langword="null"/>.
         /// </exception>
-        public FileSystemKeyValueStore(FileSystemKeyValueStoreOptions options, ILogger<FileSystemKeyValueStore>? logger = null) : base(options, logger) {
+        public FileSystemKeyValueStore(FileSystemKeyValueStoreOptions options, ILoggerFactory? logger = null) : base(options, logger?.CreateLogger<FileSystemKeyValueStore>()) {
             if (options == null) {
                 throw new ArgumentNullException(nameof(options));
             }
 
-            _disposedToken = _disposedTokenSource.Token;
-            
             var path = string.IsNullOrWhiteSpace(options.Path)
                 ? FileSystemKeyValueStoreOptions.DefaultPath
                 : options.Path;
@@ -121,31 +109,27 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
             _indexLoader = new Lazy<Task>(async () => {
                 await LoadIndexAsync().ConfigureAwait(false);
             }, LazyThreadSafetyMode.ExecutionAndPublication);
+
+            if (Options.WriteBuffer?.Enabled ?? false) {
+                _writeBuffer = new KeyValueStoreWriteBuffer(options.WriteBuffer, OnFlushAsync, logger?.CreateLogger<KeyValueStoreWriteBuffer>());
+            }
+            else {
+                LogFlushDisabled(Logger);
+            }
         }
 
 
         /// <summary>
-        /// Gets the <see cref="AsyncReaderWriterLock"/> for the specified file name.
+        /// Converts the specified bytes to base64url encoding.
         /// </summary>
-        /// <param name="fileName">
-        ///   The file name.
+        /// <param name="bytes">
+        ///   The bytes.
         /// </param>
         /// <returns>
-        ///   The associated lock.
+        ///   The base64url representation of the bytes.
         /// </returns>
-        private AsyncReaderWriterLock GetOrAddLockForFile(string fileName) {
-            return _fileLocks.GetOrAdd(fileName, _ = new AsyncReaderWriterLock());
-        }
-
-
-        /// <summary>
-        /// Removes the <see cref="AsyncReaderWriterLock"/> for the specified file name.
-        /// </summary>
-        /// <param name="fileName">
-        ///   The file name.
-        /// </param>
-        private void RemoveLockForFile(string fileName) {
-            _fileLocks.TryRemove(fileName, out _);
+        private string ToBase64Url(byte[] bytes) {
+            return Convert.ToBase64String(bytes).TrimEnd('=').Replace('/', '_').Replace('+', '-');
         }
 
 
@@ -186,7 +170,7 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         /// </returns>
         private async ValueTask LoadIndexAsync() {
             try {
-                var index = await ReadFileAsync<IDictionary<string, string>>(IndexFileName).ConfigureAwait(false);
+                var index = await ReadFromFileAsync<IDictionary<string, string>>(IndexFileName).ConfigureAwait(false);
 
                 if (index == null || index.Count == 0) {
                     _fileIndex = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
@@ -205,47 +189,13 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         /// <summary>
         /// Serializes the index and saves it to disk.
         /// </summary>
-        /// <param name="delay">
-        ///   The delay to apply before saving the index.
-        /// </param>
-        /// <param name="cancellationToken">
-        ///   The cancellation token that will cause the index to be saved immediately, event if 
-        ///   the delay has not completed.
-        /// </param>
         /// <returns>
         ///   A task that will save the index.
         /// </returns>
-        private async Task SaveIndexAsync(TimeSpan delay, CancellationToken cancellationToken) {
-            if (_disposed) {
-                return;
-            }
-
-            _indexSaveInProgress.Reset();
-
+        private async ValueTask SaveIndexAsync() {
             try {
-                // If the cancellation token fires before the delay has completed, we will save
-                // the index immediately, as this indicates that the store is being disposed.
-                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) { }
-
-            await SaveIndexCoreAsync().ConfigureAwait(false);
-            _indexSaveInProgress.Set();
-        }
-
-
-        /// <summary>
-        /// Serializes the index and saves it to disk.
-        /// </summary>
-        /// <returns>
-        ///   A task that will save the index.
-        /// </returns>
-        private async ValueTask SaveIndexCoreAsync() {
-            try {
-                var bytes = JsonSerializer.SerializeToUtf8Bytes(_fileIndex);
-
                 // Always use fastest possible compression for index.
-                await WriteFileAsync(IndexFileName, bytes, CompressionLevel.Fastest).ConfigureAwait(false);
+                await WriteToFileAsync(IndexFileName, _fileIndex, CompressionLevel.Fastest).ConfigureAwait(false);
             }
             catch (Exception e) {
                 Logger.LogError(e, Resources.Log_ErrorDuringIndexSave);
@@ -253,60 +203,120 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         }
 
 
-        /// <summary>
-        /// Converts the specified bytes to base64url encoding.
-        /// </summary>
-        /// <param name="bytes">
-        ///   The bytes.
-        /// </param>
-        /// <returns>
-        ///   The base64url representation of the bytes.
-        /// </returns>
-        private string ToBase64Url(byte[] bytes) {
-            return Convert.ToBase64String(bytes).TrimEnd('=').Replace('/', '_').Replace('+', '-');
+        private async Task OnFlushAsync(IEnumerable<KeyValuePair<KVKey, byte[]?>> changes) {
+            await _indexLoader.Value.ConfigureAwait(false);
+
+            var indexModified = false;
+
+            using (await _lock.WriterLockAsync().ConfigureAwait(false)) {
+                try {
+                    foreach (var change in changes) {
+                        if (change.Value == null) {
+                            if (TryRemoveKeyFromIndex(change.Key, out var fileName)) {
+                                indexModified = true;
+                                DeleteFile(fileName!);
+                            }
+                        }
+                        else {
+                            if (TryAddKeyToIndex(change.Key, out var fileName)) {
+                                indexModified = true;
+                            }
+                            await WriteBytesToFileAsync(fileName, change.Value).ConfigureAwait(false);
+                        }
+                    }
+                }
+                finally {
+                    if (indexModified) {
+                        await SaveIndexAsync().ConfigureAwait(false);
+                    }
+                }
+            }
         }
 
 
-        /// <summary>
-        /// Gets the file name to use for the specified key.
-        /// </summary>
-        /// <param name="key">
-        ///   The key.
-        /// </param>
-        /// <returns>
-        ///   A <see cref="ValueTask{TResult}"/> that will return the name of the file for the key 
-        ///   (relative to the base directory).
-        /// </returns>
-        private async ValueTask<string> GetFileNameForKeyAsync(KVKey key) {
-            await _indexLoader.Value.ConfigureAwait(false);
+        private bool TryGetFileNameForKey(KVKey key, out string? fileName) {
+            var keyAsHex = ConvertBytesToHexString(key);
+            return _fileIndex.TryGetValue(keyAsHex, out fileName);
+        }
+
+
+        private bool TryAddKeyToIndex(KVKey key, out string fileName) {
             var keyAsHex = ConvertBytesToHexString(key);
 
             var dirty = false;
-            var result = _fileIndex.GetOrAdd(keyAsHex, _ => {
+            fileName = _fileIndex.GetOrAdd(keyAsHex, _ => {
                 dirty = true;
                 lock (s_hash) {
                     return Path.Combine(
-                        Math.Abs((keyAsHex.GetHashCode() % _hashBuckets)).ToString("X"), 
+                        Math.Abs((keyAsHex.GetHashCode() % _hashBuckets)).ToString("X"),
                         string.Concat(
-                            ToBase64Url(s_hash.ComputeHash(key)), 
+                            ToBase64Url(s_hash.ComputeHash(key)),
                             ".data"
                         )
                     );
                 }
             });
 
-            if (dirty && Interlocked.CompareExchange(ref _indexSavePending, 1, 0) == 0) {
-                _ = Task.Run(async () => {
-                    try {
-                        await SaveIndexAsync(TimeSpan.FromSeconds(1), _disposedToken).ConfigureAwait(false);
-                    }
-                    finally {
-                        _indexSavePending = 0;
-                    }
-                });
+            return dirty;
+        }
+
+
+        private bool TryRemoveKeyFromIndex(KVKey key, out string? fileName) {
+            var keyAsHex = ConvertBytesToHexString(key);
+            return _fileIndex.TryRemove(keyAsHex, out fileName);
+        }
+
+
+        private string GetFullPathForDataFileName(string fileName) {
+            return Path.Combine(_baseDirectory.FullName, fileName);
+        }
+
+
+        private async ValueTask WriteToFileCoreAsync(string fileName, Func<FileInfo, ValueTask> callback) {
+            var file = new FileInfo(GetFullPathForDataFileName(fileName));
+
+            // Ensure that containing directory exists.
+            file.Directory.Create();
+
+            if (!file.Exists) {
+                // Fast path when file does not exist yet.
+                await callback(file).ConfigureAwait(false);
+                return;
             }
 
-            return result;
+            // File already exists.
+
+            // Save the data to a temporary file.
+            var tempFile = new FileInfo(GetFullPathForDataFileName(string.Concat("~", Guid.NewGuid().ToString(), ".tmp")));
+            await callback(tempFile).ConfigureAwait(false);
+
+            // We will create a backup of the original file prior to writing to it in case
+            // something goes wrong.
+            var backupFile = new FileInfo(string.Concat(file.FullName, ".bak"));
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                // On Windows, we can use FileInfo.Replace to replace the original file with
+                // the temporary file, creating a backup of the original file in the process.
+                tempFile.Replace(file.FullName, backupFile.FullName, true);
+            }
+            else {
+                // FileInfo.Replace throws PlatformNotSupportedException on non-Windows platforms,
+                // so we have to perform a similar process ourselves.
+
+                // Create a backup copy of the original file.
+                file.CopyTo(backupFile.FullName, true);
+
+                // Replace the original file with the temporary file.
+                tempFile.CopyTo(file.FullName, true);
+
+                // Delete the temporary file.
+                tempFile.Refresh();
+                tempFile.Delete();
+            }
+
+            // We can now safely delete the backup copy.
+            backupFile.Refresh();
+            backupFile.Delete();
         }
 
 
@@ -325,76 +335,48 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         /// <returns>
         ///   The operation status.
         /// </returns>
-        private async ValueTask WriteFileAsync<T>(string fileName, T value, CompressionLevel? compressionLevel) {
-            var @lock = GetOrAddLockForFile(fileName);
-            using (await @lock.WriterLockAsync().ConfigureAwait(false)) {
-                var file = new FileInfo(Path.Combine(_baseDirectory.FullName, fileName));
-
-                // Ensure that containing directory exists.
-                file.Directory.Create();
-
-                if (!file.Exists) {
-                    // Fast path when file does not exist yet.
-                    await WriteFileAsync(file, value, compressionLevel).ConfigureAwait(false);
-                    return;
+        private async ValueTask WriteToFileAsync<T>(string fileName, T value, CompressionLevel? compressionLevel = null) {
+            await WriteToFileCoreAsync(fileName, async file => {
+                using (var stream = file.OpenWrite()) {
+                    await SerializeToStreamAsync(stream, value, compressionLevel: compressionLevel).ConfigureAwait(false);
                 }
-
-                // File already exists.
-
-                // Save the data to a temporary file.
-                var tempFile = new FileInfo(Path.Combine(_baseDirectory.FullName, string.Concat("~", Guid.NewGuid().ToString(), ".tmp")));
-                await WriteFileAsync(tempFile, value, compressionLevel).ConfigureAwait(false);
-
-                // We will create a backup of the original file prior to writing to it in case
-                // something goes wrong.
-                var backupFile = new FileInfo(string.Concat(file.FullName, ".bak"));
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                    // On Windows, we can use FileInfo.Replace to replace the original file with
-                    // the temporary file, creating a backup of the original file in the process.
-                    tempFile.Replace(file.FullName, backupFile.FullName, true);
-                }
-                else {
-                    // FileInfo.Replace throws PlatformNotSupportedException on non-Windows platforms,
-                    // so we have to perform a similar process ourselves.
-
-                    // Create a backup copy of the original file.
-                    file.CopyTo(backupFile.FullName, true);
-
-                    // Replace the original file with the temporary file.
-                    tempFile.CopyTo(file.FullName, true);
-
-                    // Delete the temporary file.
-                    tempFile.Refresh();
-                    tempFile.Delete();
-                }
-
-                // We can now safely delete the backup copy.
-                backupFile.Refresh();
-                backupFile.Delete();
-            }
+            });
         }
 
 
-        /// <summary>
-        /// Writes a file to disk.
-        /// </summary>
-        /// <param name="file">
-        ///   The file to write.
-        /// </param>
-        /// <param name="content">
-        ///   The content to write.
-        /// </param>
-        /// <param name="compressionLevel">
-        ///   The compression level.
-        /// </param>
-        /// <returns>
-        ///   A task that will perform the write.
-        /// </returns>
-        private async Task WriteFileAsync<T>(FileInfo file, T content, CompressionLevel? compressionLevel) {
-            using (var stream = file.OpenWrite()) { 
-                await SerializeToStreamAsync(stream, content, compressionLevel: compressionLevel).ConfigureAwait(false);
+        private async ValueTask WriteBytesToFileAsync(string fileName, byte[] bytes) {
+            await WriteToFileCoreAsync(fileName, async file => {
+                using (var stream = file.OpenWrite()) {
+                    await stream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
+                }
+            });
+        }
+
+
+        private bool DeleteFile(string fileName) {
+            var file = new FileInfo(GetFullPathForDataFileName(fileName));
+            var backupFile = new FileInfo(string.Concat(file.FullName, ".bak"));
+            if (!file.Exists && !backupFile.Exists) {
+                return false;
             }
+
+            // The file might have been deleted while we were waiting for the lock.
+            file.Refresh();
+            backupFile.Refresh();
+
+            if (!file.Exists && !backupFile.Exists) {
+                return false;
+            }
+
+            if (file.Exists) {
+                file.Delete();
+            }
+
+            if (backupFile.Exists) {
+                backupFile.Delete();
+            }
+
+            return true;
         }
 
 
@@ -407,42 +389,25 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         /// <returns>
         ///   The content of the file.
         /// </returns>
-        private async ValueTask<T?> ReadFileAsync<T>(string fileName) {
-            var file = new FileInfo(Path.Combine(_baseDirectory.FullName, fileName));
+        private async ValueTask<T?> ReadFromFileAsync<T>(string fileName) {
+            var file = new FileInfo(GetFullPathForDataFileName(fileName));
             var backupFile = new FileInfo(string.Concat(file.FullName, ".bak"));
 
             if (!file.Exists && !backupFile.Exists) {
                 return default;
             }
 
-            var @lock = GetOrAddLockForFile(fileName);
-            using (await @lock.ReaderLockAsync().ConfigureAwait(false)) {
-                // The file might have been deleted while we were waiting for the lock.
-                file.Refresh();
-                backupFile.Refresh();
+            // The file might have been deleted while we were waiting for the lock.
+            file.Refresh();
+            backupFile.Refresh();
 
-                if (!file.Exists && !backupFile.Exists) {
-                    return default;
-                }
-
-                // Use the backup file if the original file does not exist.
-                var f = file.Exists ? file : backupFile;
-                return await ReadFileAsync<T>(f).ConfigureAwait(false);
+            if (!file.Exists && !backupFile.Exists) {
+                return default;
             }
-        }
 
-
-        /// <summary>
-        /// Reads a file from disk.
-        /// </summary>
-        /// <param name="file">
-        ///   The file to read.
-        /// </param>
-        /// <returns>
-        ///   The content of the file.
-        /// </returns>
-        private async Task<T?> ReadFileAsync<T>(FileInfo file) {
-            using (var stream = file.OpenRead()) { 
+            // Use the backup file if the original file does not exist.
+            var f = file.Exists ? file : backupFile;
+            using (var stream = f.OpenRead()) {
                 return await DeserializeFromStreamAsync<T>(stream).ConfigureAwait(false);
             }
         }
@@ -450,53 +415,57 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
 
         /// <inheritdoc/>
         protected override async ValueTask WriteAsync<T>(KVKey key, T value) {
-            var fileName = await GetFileNameForKeyAsync(key).ConfigureAwait(false);
-            await WriteFileAsync(fileName, value, null).ConfigureAwait(false);
+            if (UseWriteBuffer) {
+                await _writeBuffer!.WriteAsync(key, await SerializeToBytesAsync(value).ConfigureAwait(false)).ConfigureAwait(false);
+                return;
+            }
+
+            await _indexLoader.Value.ConfigureAwait(false);
+            using (await _lock.WriterLockAsync().ConfigureAwait(false)) {
+                if (TryAddKeyToIndex(key, out var fileName)) {
+                    await SaveIndexAsync();
+                }
+                await WriteToFileAsync(fileName, value, null).ConfigureAwait(false);
+            }
         }
 
 
         /// <inheritdoc/>
         protected override async ValueTask<T?> ReadAsync<T>(KVKey key) where T : default {
+            if (UseWriteBuffer) {
+                var readResult = await _writeBuffer!.ReadAsync(key).ConfigureAwait(false);
+                if (readResult.Found) {
+                    return readResult.Value == null
+                        ? default
+                        : await DeserializeFromBytesAsync<T>(readResult.Value).ConfigureAwait(false);
+                }
+            }
+
             await _indexLoader.Value.ConfigureAwait(false);
-            var fileName = await GetFileNameForKeyAsync(key).ConfigureAwait(false);
-            return await ReadFileAsync<T>(fileName).ConfigureAwait(false);
+            using (await _lock.ReaderLockAsync().ConfigureAwait(false)) {
+                if (!TryGetFileNameForKey(key, out var fileName)) {
+                    return default;
+                }
+                return await ReadFromFileAsync<T>(fileName!).ConfigureAwait(false);
+            }
         }
 
 
         /// <inheritdoc/>
         protected override async ValueTask<bool> DeleteAsync(KVKey key) {
-            await _indexLoader.Value.ConfigureAwait(false);
-            var fileName = await GetFileNameForKeyAsync(key).ConfigureAwait(false);
-            var file = new FileInfo(Path.Combine(_baseDirectory.FullName, fileName));
-            var backupFile = new FileInfo(string.Concat(file.FullName, ".bak"));
-            if (!file.Exists && !backupFile.Exists) {
-                return false;
+            if (UseWriteBuffer) {
+                await _writeBuffer!.DeleteAsync(key).ConfigureAwait(false);
+                return true;
             }
 
-            var @lock = GetOrAddLockForFile(fileName);
-            using (await @lock.WriterLockAsync().ConfigureAwait(false)) {
-                // The file might have been deleted while we were waiting for the lock.
-                file.Refresh();
-                backupFile.Refresh();
-
-                if (!file.Exists && !backupFile.Exists) {
-                    return false;
+            await _indexLoader.Value.ConfigureAwait(false);
+            using (await _lock.WriterLockAsync().ConfigureAwait(false)) {
+                if (TryRemoveKeyFromIndex(key, out var fileName)) {
+                    await SaveIndexAsync();
+                    return DeleteFile(fileName!);
                 }
 
-                try {
-                    if (file.Exists) {
-                        file.Delete();
-                    }
-
-                    if (backupFile.Exists) {
-                        backupFile.Delete();
-                    }
-
-                    return true;
-                }
-                finally {
-                    RemoveLockForFile(fileName);
-                }
+                return false;
             }
         }
 
@@ -509,13 +478,52 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
                 ? null
                 : ConvertBytesToHexString(prefix.Value);
 
-            var keys = prefix == null || prefix.Value.Length == 0
-                ? _fileIndex.Keys
-                : _fileIndex.Keys.Where(x => x.StartsWith(prefixAsHex, StringComparison.Ordinal));
+            using (await _lock.ReaderLockAsync().ConfigureAwait(false)) {
+                var keys = prefix == null || prefix.Value.Length == 0
+                    ? _fileIndex.Keys
+                    : _fileIndex.Keys.Where(x => x.StartsWith(prefixAsHex, StringComparison.Ordinal));
 
-            foreach (var key in keys) {
-                yield return ConvertHexStringToBytes(key);
+                foreach (var key in keys) {
+                    yield return ConvertHexStringToBytes(key);
+                }
             }
+        }
+
+
+        /// <summary>
+        /// Flushes pending writes to the database.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will process the operation.
+        /// </returns>
+        /// <remarks>
+        ///   Calling <see cref="FlushAsync"/> has no effect if the store is not configured to use 
+        ///   a write buffer.
+        /// </remarks>
+        public async ValueTask FlushAsync() {
+            if (!UseWriteBuffer || _disposed) {
+                return;
+            }
+
+            await _writeBuffer!.FlushAsync().ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Waits until pending writes have been flushed to the database.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <remarks>
+        ///   <see cref="WaitForNextFlushAsync"/> will return immediately if the store is not 
+        ///   configured to use a write buffer.
+        /// </remarks>
+        public async ValueTask WaitForNextFlushAsync(CancellationToken cancellationToken = default) {
+            if (!UseWriteBuffer || _disposed) {
+                return;
+            }
+
+            await _writeBuffer!.WaitForNextFlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -525,15 +533,14 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
                 return;
             }
 
-            _disposedTokenSource.Cancel();
-            _disposedTokenSource.Dispose();
-
-            // Wait for ongoing save to complete.
-            _indexSaveInProgress.Wait();
-            _indexSaveInProgress.Dispose();
+            _writeBuffer?.Dispose();
 
             _disposed = true;
         }
+
+
+        [LoggerMessage(100, LogLevel.Information, "Changes will be flushed to the file system immediately.")]
+        static partial void LogFlushDisabled(ILogger logger);
 
     }
 }

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/FileSystemKeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/FileSystemKeyValueStoreOptions.cs
@@ -31,6 +31,11 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         /// </summary>
         public int HashBuckets { get; set; } = DefaultHashBuckets;
 
+        /// <summary>
+        /// The options for the write buffer.
+        /// </summary>
+        public FileSystemKeyValueStoreWriteBufferOptions WriteBuffer { get; set; } = new FileSystemKeyValueStoreWriteBufferOptions();
+
 
         /// <summary>
         /// Creates a new <see cref="FileSystemKeyValueStoreOptions"/> object.
@@ -38,6 +43,19 @@ namespace DataCore.Adapter.KeyValueStore.FileSystem {
         public FileSystemKeyValueStoreOptions() {
             CompressionLevel = CompressionLevel.NoCompression;
         }
+
+    }
+
+
+    /// <summary>
+    /// Options for <see cref="FileSystemKeyValueStore"/> write buffer.
+    /// </summary>
+    public class FileSystemKeyValueStoreWriteBufferOptions : Services.KeyValueStoreWriteBufferOptions {
+
+        /// <summary>
+        /// Specifies if the write buffer is enabled.
+        /// </summary>
+        public bool Enabled { get; set; }
 
     }
 

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/PublicAPI.Shipped.txt
@@ -3,12 +3,9 @@ const DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.D
 const DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.DefaultPath = "./KeyValueStore" -> string!
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.Dispose() -> void
-DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.FileSystemKeyValueStore(DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions! options, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore!>? logger = null) -> void
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.FileSystemKeyValueStoreOptions() -> void
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.HashBuckets.get -> int
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.HashBuckets.set -> void
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.Path.get -> string!
 DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.Path.set -> void
-override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.DeleteAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
-override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.GetKeysAsync(DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.Services.KVKey>!

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/PublicAPI.Unshipped.txt
@@ -1,3 +1,10 @@
 ﻿#nullable enable
-override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
-override DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.FileSystemKeyValueStore(DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions! options, Microsoft.Extensions.Logging.ILoggerFactory? logger = null) -> void
+DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.FlushAsync() -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStore.WaitForNextFlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.WriteBuffer.get -> DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreWriteBufferOptions!
+DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreOptions.WriteBuffer.set -> void
+DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreWriteBufferOptions
+DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreWriteBufferOptions.Enabled.get -> bool
+DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreWriteBufferOptions.Enabled.set -> void
+DataCore.Adapter.KeyValueStore.FileSystem.FileSystemKeyValueStoreWriteBufferOptions.FileSystemKeyValueStoreWriteBufferOptions() -> void

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Shipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 const DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.DefaultConnectionString = "Data Source=adapter-kvstore.db" -> string!
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore
-DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.SqliteKeyValueStore(DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions! options, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore!>? logger = null) -> void
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.ConnectionString.get -> string!
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.ConnectionString.set -> void

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
@@ -1,11 +1,16 @@
 ﻿#nullable enable
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.Dispose() -> void
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.FlushAsync() -> System.Threading.Tasks.ValueTask
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.SqliteKeyValueStore(DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions! options, Microsoft.Extensions.Logging.ILoggerFactory? logger = null) -> void
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.WaitForNextFlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.EnableRawWrites.get -> bool
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.EnableRawWrites.set -> void
-DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.FlushInterval.get -> System.TimeSpan
-DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.FlushInterval.set -> void
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.WriteBuffer.get -> DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreWriteBufferOptions!
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreOptions.WriteBuffer.set -> void
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreWriteBufferOptions
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreWriteBufferOptions.Enabled.get -> bool
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreWriteBufferOptions.Enabled.set -> void
+DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreWriteBufferOptions.SqliteKeyValueStoreWriteBufferOptions() -> void
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.AllowRawWrites.get -> bool
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadRawAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/SqliteKeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/SqliteKeyValueStoreOptions.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using DataCore.Adapter.Services;
 
 namespace DataCore.Adapter.KeyValueStore.Sqlite {
 
     /// <summary>
     /// Options for <see cref="SqliteKeyValueStore"/>.
     /// </summary>
-    public class SqliteKeyValueStoreOptions : Services.KeyValueStoreOptions {
+    public class SqliteKeyValueStoreOptions : KeyValueStoreOptions {
 
         /// <summary>
         /// Default Sqlite connection string.
@@ -18,7 +18,7 @@ namespace DataCore.Adapter.KeyValueStore.Sqlite {
         public string ConnectionString { get; set; } = DefaultConnectionString;
 
         /// <summary>
-        /// When <see langword="true"/>, enables the use of <see cref="Services.IRawKeyValueStore.WriteRawAsync"/> 
+        /// When <see langword="true"/>, enables the use of <see cref="IRawKeyValueStore.WriteRawAsync"/> 
         /// to write raw byte data to the store.
         /// </summary>
         /// <remarks>
@@ -27,13 +27,22 @@ namespace DataCore.Adapter.KeyValueStore.Sqlite {
         public bool EnableRawWrites { get; set; }
 
         /// <summary>
-        /// The interval at which pending writes are flushed to the database.
+        /// The options for the write buffer.
         /// </summary>
-        /// <remarks>
-        ///   Specify a value less than or equal to <see cref="TimeSpan.Zero"/> to write changes 
-        ///   to the database immediately.
-        /// </remarks>
-        public TimeSpan FlushInterval { get; set; }
+        public SqliteKeyValueStoreWriteBufferOptions WriteBuffer { get; set; } = new SqliteKeyValueStoreWriteBufferOptions();
+
+    }
+
+
+    /// <summary>
+    /// Options for <see cref="SqliteKeyValueStore"/> write buffer.
+    /// </summary>
+    public class SqliteKeyValueStoreWriteBufferOptions : KeyValueStoreWriteBufferOptions {
+
+        /// <summary>
+        /// Specifies if the write buffer is enabled.
+        /// </summary>
+        public bool Enabled { get; set; }
 
     }
 


### PR DESCRIPTION
Adds a new `KeyValueStoreWriteBuffer` class to `DataCore.Adapter.Abstractions`.

`KeyValueStoreWriteBuffer` allows `IKeyValueStore` implementations to put pending write and delete actions in an in-memory buffer that invokes a callback to flush the pending changes on a periodic basis, or if the number of pending changes or the overall byte size of the changes hit their respective limits.

The SQLite-based store has been modified to replace its own write buffer with `KeyValueStoreWriteBuffer` and the file system-based store can now use the same write buffer.