### PR TITLE
Pin memory during FASTER upserts

### DIFF
--- a/src/DataCore.Adapter.KeyValueStore.FASTER/Resources.Designer.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/Resources.Designer.cs
@@ -77,5 +77,14 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
                 return ResourceManager.GetString("Error_StoreIsReadOnly", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to rent memory from the shared buffer..
+        /// </summary>
+        internal static string Error_UnableToRentSharedMemory {
+            get {
+                return ResourceManager.GetString("Error_UnableToRentSharedMemory", resourceCulture);
+            }
+        }
     }
 }

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/Resources.resx
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/Resources.resx
@@ -123,4 +123,7 @@
   <data name="Error_StoreIsReadOnly" xml:space="preserve">
     <value>This operation cannot be performed on a read-only store.</value>
   </data>
+  <data name="Error_UnableToRentSharedMemory" xml:space="preserve">
+    <value>Unable to rent memory from the shared buffer.</value>
+  </data>
 </root>


### PR DESCRIPTION
[This FASTER ticket](https://github.com/microsoft/FASTER/issues/885) (raised by yours truly) discusses spurious key/value entries being created following upserts. As per [this comment](https://github.com/microsoft/FASTER/issues/885#issuecomment-1819325384) in the ticket and [this FASTER PR](https://github.com/microsoft/FASTER/pull/349), we need to ensure that `SpanByte` instances are always created using memory that is fixed for the duration of the operation.

To facilitate this, `WriteCoreAsync` now uses `MemoryPool<byte>.Shared.Rent()` to rent a `Memory<byte>` that the key and value bytes are written to. We can then use `Memory<byte>.Pin()` to pin the memory while we construct the key and value `SpanByte`s and perform the upsert.