### PR TITLE
.NET 8.0 update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,19 +16,19 @@
     <PkgVersion_OpenTelemetry_Exporter_OpenTelemetryProtocol>1.6.0</PkgVersion_OpenTelemetry_Exporter_OpenTelemetryProtocol>
     <PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>1.6.0-rc.1</PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>
     <PkgVersion_OpenTelemetry_Extensions_Hosting>1.6.0</PkgVersion_OpenTelemetry_Extensions_Hosting>
-    <PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>1.5.1-beta.1</PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>
-    <PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>1.5.1-beta.1</PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>
-    <PkgVersion_OpenTelemetry_Instrumentation_Http>1.5.1-beta.1</PkgVersion_OpenTelemetry_Instrumentation_Http>
+    <PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>1.6.0-beta.3</PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>
+    <PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>1.6.0-beta.3</PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>
+    <PkgVersion_OpenTelemetry_Instrumentation_Http>1.6.0-beta.3</PkgVersion_OpenTelemetry_Instrumentation_Http>
     <PkgVersion_OpenTelemetry_Instrumentation_Runtime>1.5.1</PkgVersion_OpenTelemetry_Instrumentation_Runtime>
-    <PkgVersion_OpenTelemetry_Instrumentation_SqlClient>1.5.1-beta.1</PkgVersion_OpenTelemetry_Instrumentation_SqlClient>
+    <PkgVersion_OpenTelemetry_Instrumentation_SqlClient>1.6.0-beta.3</PkgVersion_OpenTelemetry_Instrumentation_SqlClient>
     <PkgVersion_Microsoft_Web_LibraryManager_Build>2.1.175</PkgVersion_Microsoft_Web_LibraryManager_Build>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="CsvHelper" Version="30.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.25.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.58.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.58.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.25.1" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.59.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.59.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.59.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="11.0.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="11.0.0" />
@@ -37,19 +37,19 @@
     <PackageVersion Include="JsonSchema.Net.Generation" Version="3.4.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.13" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.13" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.FASTER.Core" Version="2.6.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="$(PkgVersion_Microsoft_Web_LibraryManager_Build)" />
     <PackageVersion Include="MiniValidation" Version="0.9.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
@@ -71,12 +71,12 @@
     <PackageVersion Include="Semver" Version="2.3.0" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.6" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Net.Http.Json" Version="7.0.1" />
-    <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="7.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
-    <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
+    <PackageVersion Include="System.Net.Http.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/examples/DataCore.Adapter.AspNetCoreExample/DataCore.Adapter.AspNetCoreExample.csproj
+++ b/examples/DataCore.Adapter.AspNetCoreExample/DataCore.Adapter.AspNetCoreExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSwag.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
+++ b/examples/DataCore.Adapter.AspNetCoreExample/Startup.cs
@@ -106,49 +106,49 @@ namespace DataCore.Adapter.AspNetCoreExample {
                     .AddDataCoreAdapterInstrumentation()
                     .AddOtlpExporter());
 
-            services.AddOpenApiDocument(options => {
-                options.DocumentName = "v2.0";
-                options.Title = "App Store Connect Adapters";
-                options.Description = "HTTP API for querying an App Store Connect adapters host.";
-                options.Version = "2.0.0";
-                options.AddOperationFilter(context => {
-                    // Don't include the legacy routes.
-                    return !context.OperationDescription.Path.StartsWith("/api/data-core/");
-                });
-                options.OperationProcessors.Add(new NSwag.Generation.Processors.OperationProcessor(context => { 
-                    string RemoveWhiteSpace(string s) {
-                        return s.Replace("\n", "").Trim();
-                    }
+            //services.AddOpenApiDocument(options => {
+            //    options.DocumentName = "v2.0";
+            //    options.Title = "App Store Connect Adapters";
+            //    options.Description = "HTTP API for querying an App Store Connect adapters host.";
+            //    options.Version = "2.0.0";
+            //    options.AddOperationFilter(context => {
+            //        // Don't include the legacy routes.
+            //        return !context.OperationDescription.Path.StartsWith("/api/data-core/");
+            //    });
+            //    options.OperationProcessors.Add(new NSwag.Generation.Processors.OperationProcessor(context => { 
+            //        string RemoveWhiteSpace(string s) {
+            //            return s.Replace("\n", "").Trim();
+            //        }
 
-                    if (context.OperationDescription.Operation.Summary != null) {
-                        context.OperationDescription.Operation.Summary = RemoveWhiteSpace(context.OperationDescription.Operation.Summary);
-                    }
+            //        if (context.OperationDescription.Operation.Summary != null) {
+            //            context.OperationDescription.Operation.Summary = RemoveWhiteSpace(context.OperationDescription.Operation.Summary);
+            //        }
 
-                    if (context.OperationDescription.Operation.Description != null) {
-                        context.OperationDescription.Operation.Description = RemoveWhiteSpace(context.OperationDescription.Operation.Description);
-                    }
+            //        if (context.OperationDescription.Operation.Description != null) {
+            //            context.OperationDescription.Operation.Description = RemoveWhiteSpace(context.OperationDescription.Operation.Description);
+            //        }
 
-                    foreach (var parameter in context.OperationDescription.Operation.Parameters) {
-                        if (parameter.Description == null) {
-                            continue;
-                        }
-                        parameter.Description = RemoveWhiteSpace(parameter.Description);
-                    }
+            //        foreach (var parameter in context.OperationDescription.Operation.Parameters) {
+            //            if (parameter.Description == null) {
+            //                continue;
+            //            }
+            //            parameter.Description = RemoveWhiteSpace(parameter.Description);
+            //        }
 
-                    if (context.OperationDescription.Operation.RequestBody?.Description != null) {
-                        context.OperationDescription.Operation.RequestBody.Description = RemoveWhiteSpace(context.OperationDescription.Operation.RequestBody.Description);
-                    }
+            //        if (context.OperationDescription.Operation.RequestBody?.Description != null) {
+            //            context.OperationDescription.Operation.RequestBody.Description = RemoveWhiteSpace(context.OperationDescription.Operation.RequestBody.Description);
+            //        }
 
-                    foreach (var response in context.OperationDescription.Operation.Responses.Values) {
-                        if (response.Description == null) {
-                            continue;
-                        }
-                        response.Description = RemoveWhiteSpace(response.Description);
-                    }
+            //        foreach (var response in context.OperationDescription.Operation.Responses.Values) {
+            //            if (response.Description == null) {
+            //                continue;
+            //            }
+            //            response.Description = RemoveWhiteSpace(response.Description);
+            //        }
 
-                    return true;
-                }));
-            });
+            //        return true;
+            //    }));
+            //});
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -162,8 +162,8 @@ namespace DataCore.Adapter.AspNetCoreExample {
             }
 
             app.UseHttpsRedirection();
-            app.UseOpenApi();
-            app.UseSwaggerUi3();
+            //app.UseOpenApi();
+            //app.UseSwaggerUi3();
 
             app.UseRequestLocalization();
             app.UseRouting();

--- a/examples/DataCore.Adapter.ExampleAdapter/DataCore.Adapter.ExampleAdapter.csproj
+++ b/examples/DataCore.Adapter.ExampleAdapter/DataCore.Adapter.ExampleAdapter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.Example</RootNamespace>
   </PropertyGroup>
 

--- a/examples/ExampleHostedAdapter/ExampleHostedAdapter.csproj
+++ b/examples/ExampleHostedAdapter/ExampleHostedAdapter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/examples/ExampleHostedAdapter/libman.json
+++ b/examples/ExampleHostedAdapter/libman.json
@@ -5,7 +5,7 @@
 
     {
       "provider": "cdnjs",
-      "library": "bootstrap@5.3.0",
+      "library": "bootstrap@5.3.2",
       "destination": "wwwroot/lib/bootstrap/",
       "files": [
         "js/*",
@@ -14,7 +14,7 @@
     },
     {
       "provider": "cdnjs",
-      "library": "jquery@3.7.0",
+      "library": "jquery@3.7.1",
       "destination": "wwwroot/lib/jquery/",
       "files": [
         "*.js"
@@ -31,7 +31,7 @@
     },
     {
       "provider": "cdnjs",
-      "library": "jquery-validate@1.19.5",
+      "library": "jquery-validate@1.20.0",
       "destination": "wwwroot/lib/jquery-validate/",
       "files": [
         "jquery.validate.js",
@@ -39,7 +39,7 @@
       ]
     },
     {
-      "library": "font-awesome@6.4.0",
+      "library": "font-awesome@6.4.2",
       "destination": "wwwroot/lib/font-awesome/",
       "files": [
         "js/all.min.js",

--- a/examples/MinimalApiExample/MinimalApiExample.csproj
+++ b/examples/MinimalApiExample/MinimalApiExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.Common</PackageId>
     <Description>Common ASP.NET Core types for hosting App Store Connect adapters.</Description>

--- a/src/DataCore.Adapter.AspNetCore.Grpc/DataCore.Adapter.AspNetCore.Grpc.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/DataCore.Adapter.AspNetCore.Grpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.Grpc</PackageId>
     <Description>ASP.NET Core types for hosting App Store Connect adapter gRPC services.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/DataCore.Adapter.AspNetCore.HealthChecks/DataCore.Adapter.AspNetCore.HealthChecks.csproj
+++ b/src/DataCore.Adapter.AspNetCore.HealthChecks/DataCore.Adapter.AspNetCore.HealthChecks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.HealthChecks</PackageId>
     <Description>ASP.NET Core health checks for App Store Connect adapters.</Description>

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/DataCore.Adapter.AspNetCore.MinimalApi.csproj
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/DataCore.Adapter.AspNetCore.MinimalApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.MinimalApi</PackageId>
     <Description>ASP.NET Core types for hosting App Store Connect adapter APIs.</Description>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/DataCore.Adapter.AspNetCore.Mvc.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/DataCore.Adapter.AspNetCore.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.Mvc</PackageId>
     <Description>ASP.NET Core types for hosting App Store Connect adapter MVC controllers.</Description>

--- a/src/DataCore.Adapter.AspNetCore.SignalR/DataCore.Adapter.AspNetCore.SignalR.csproj
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/DataCore.Adapter.AspNetCore.SignalR.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.SignalR</PackageId>
     <Description>ASP.NET Core SignalR hubs for App Store Connect adapters.</Description>

--- a/src/DataCore.Adapter.Templates/templates/aschostedadapter/.template.config/template.json
+++ b/src/DataCore.Adapter.Templates/templates/aschostedadapter/.template.config/template.json
@@ -33,7 +33,7 @@
           "description": ".NET 8.0"
         }
       ],
-      "defaultValue": "net6.0",
+      "defaultValue": "net8.0",
       "replaces": "net6.0"
     },
     "IsNet7OrLater": {

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds `net8.0` targets to ASP.NET Core-related projects and updates referenced packages to latest versions (including updating Microsoft.* and System.* packages to v8.0.0 where applicable).