### PR TITLE
Set min buffer size when renting memory in FASTER key/value store

### DIFF
--- a/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
@@ -504,7 +504,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
             // the memory for the duration of the upsert, as required when using SpanByte:
             // https://github.com/microsoft/FASTER/pull/349
 
-            using (var memoryOwner = MemoryPool<byte>.Shared.Rent()) {
+            using (var memoryOwner = MemoryPool<byte>.Shared.Rent(key.Length + value.Length)) {
                 if (memoryOwner == null) {
                     throw new InvalidOperationException(Resources.Error_UnableToRentSharedMemory);
                 }


### PR DESCRIPTION
Call to `MemoryBool<byte>.Shared.Rent()` now specifies a minimum buffer size that is large enough to hold the combined key and value.