### PR TITLE
FASTER key/value store memory pinning and clean-up improvements

### DIFF
--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Shipped.txt
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore
-DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.Dispose() -> void
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.DisposeAsync() -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterKeyValueStore(DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions! options, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore!>? logger = null) -> void
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.TakeFullCheckpointAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
@@ -26,8 +25,4 @@ DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.ReadOnly.get ->
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.ReadOnly.set -> void
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.SegmentSizeBits.get -> int
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.SegmentSizeBits.set -> void
-override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.DeleteAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
-override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.GetKeysAsync(DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.Services.KVKey>!
 static DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.CreateLocalStorageCheckpointManager(string! path, bool removeOutdated = true) -> FASTER.core.ICheckpointManager!
-virtual DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.Dispose(bool disposing) -> void
-virtual DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
@@ -11,8 +11,3 @@ DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.EnableRawWrites
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.EnableRawWrites.set -> void
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.IncrementalCheckpointInterval.get -> System.TimeSpan?
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.IncrementalCheckpointInterval.set -> void
-override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.AllowRawWrites.get -> bool
-override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
-override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.ReadRawAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
-override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
-override DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.WriteRawAsync(DataCore.Adapter.Services.KVKey key, byte[]! value) -> System.Threading.Tasks.ValueTask

--- a/test/DataCore.Adapter.Tests/FasterKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/FasterKeyValueStoreTests.cs
@@ -29,7 +29,7 @@ namespace DataCore.Adapter.Tests {
             try {
                 var now = DateTime.UtcNow;
 
-                using (var store1 = new FasterKeyValueStore(new FasterKeyValueStoreOptions() { 
+                await using (var store1 = new FasterKeyValueStore(new FasterKeyValueStoreOptions() { 
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 })) {
 
@@ -39,7 +39,7 @@ namespace DataCore.Adapter.Tests {
                     // checkpoint manager.
                 }
 
-                using (var store2 = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store2 = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 })) {
                     var readResult = await ((IKeyValueStore) store2).ReadAsync<DateTime>(TestContext.TestName);
@@ -57,7 +57,7 @@ namespace DataCore.Adapter.Tests {
             var tmpPath = new DirectoryInfo(Path.Combine(Path.GetTempPath(), nameof(FasterKeyValueStoreTests), Guid.NewGuid().ToString()));
 
             try {
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 })) {
 

--- a/test/DataCore.Adapter.Tests/SnapshotTagValueManagerTests.cs
+++ b/test/DataCore.Adapter.Tests/SnapshotTagValueManagerTests.cs
@@ -22,7 +22,7 @@ namespace DataCore.Adapter.Tests {
                 var val1 = new TagValueBuilder().WithValue(99.999).Build();
                 var val2 = new TagValueBuilder().WithValue(Guid.NewGuid().ToString()).Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var stvm = ActivatorUtilities.CreateInstance<SnapshotTagValueManager>(AssemblyInitializer.ApplicationServices, new SnapshotTagValueManagerOptions() { 
@@ -68,7 +68,7 @@ namespace DataCore.Adapter.Tests {
                 var val1 = new TagValueBuilder().WithValue(99.999).Build();
                 var val2 = new TagValueBuilder().WithValue(Guid.NewGuid().ToString()).Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var stvm = ActivatorUtilities.CreateInstance<SnapshotTagValueManager>(AssemblyInitializer.ApplicationServices, new SnapshotTagValueManagerOptions() {
@@ -114,7 +114,7 @@ namespace DataCore.Adapter.Tests {
                 var val1 = new TagValueBuilder().WithValue(99.999).Build();
                 var val2 = new TagValueBuilder().WithValue(Guid.NewGuid().ToString()).Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var stvm = ActivatorUtilities.CreateInstance<SnapshotTagValueManager>(AssemblyInitializer.ApplicationServices, new SnapshotTagValueManagerOptions() {
@@ -125,7 +125,7 @@ namespace DataCore.Adapter.Tests {
                 }
 
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var stvm = ActivatorUtilities.CreateInstance<SnapshotTagValueManager>(AssemblyInitializer.ApplicationServices, new SnapshotTagValueManagerOptions() {
@@ -168,7 +168,7 @@ namespace DataCore.Adapter.Tests {
                 var val1 = new TagValueBuilder().WithValue(99.999).Build();
                 var val2 = new TagValueBuilder().WithValue(Guid.NewGuid().ToString()).Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var stvm = ActivatorUtilities.CreateInstance<SnapshotTagValueManager>(AssemblyInitializer.ApplicationServices, new SnapshotTagValueManagerOptions() {
@@ -179,7 +179,7 @@ namespace DataCore.Adapter.Tests {
                 }
 
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var stvm = ActivatorUtilities.CreateInstance<SnapshotTagValueManager>(AssemblyInitializer.ApplicationServices, new SnapshotTagValueManagerOptions() {

--- a/test/DataCore.Adapter.Tests/TagManagerTests.cs
+++ b/test/DataCore.Adapter.Tests/TagManagerTests.cs
@@ -24,7 +24,7 @@ namespace DataCore.Adapter.Tests {
             try {
                 var tag1 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName +  "-1").Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -54,7 +54,7 @@ namespace DataCore.Adapter.Tests {
             try {
                 var tag1 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName + "-1").Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -85,7 +85,7 @@ namespace DataCore.Adapter.Tests {
                 var tag1 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName + "-1").Build();
                 var tag2 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName + "-2").Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -120,7 +120,7 @@ namespace DataCore.Adapter.Tests {
             try {
                 var tag1 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName + "-1").Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -128,7 +128,7 @@ namespace DataCore.Adapter.Tests {
                     await tm.AddOrUpdateTagAsync(tag1);
                 }
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -156,7 +156,7 @@ namespace DataCore.Adapter.Tests {
             try {
                 var tag1 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName + "-1").Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -164,7 +164,7 @@ namespace DataCore.Adapter.Tests {
                     await tm.AddOrUpdateTagAsync(tag1);
                 }
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -193,7 +193,7 @@ namespace DataCore.Adapter.Tests {
                 var tag1 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName + "-1").Build();
                 var tag2 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName + "-2").Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -202,7 +202,7 @@ namespace DataCore.Adapter.Tests {
                     await tm.AddOrUpdateTagAsync(tag2);
                 }
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -234,7 +234,7 @@ namespace DataCore.Adapter.Tests {
             try {
                 var tag1 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName + "-1").Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
@@ -274,7 +274,7 @@ namespace DataCore.Adapter.Tests {
                 var tag1 = new TagDefinitionBuilder().WithId(id).WithName(TestContext.TestName + "-1").Build();
                 var tag2 = new TagDefinitionBuilder().WithId(id).WithName(TestContext.TestName + "-2").Build();
 
-                using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
                     CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
                 }))
                 using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {


### PR DESCRIPTION
As suggested [here](https://github.com/microsoft/FASTER/issues/885#issuecomment-1821922306), `GCHandle.Alloc` can be used to pin the key and value bytes during an asynchronous FASTER upsert. This avoids the need to copy the bytes into a pinned `Memory<byte>` that was added in #362.

The commit also seals the `FasterKeyValueStore` class, removes the `IDisposable` implementation and simplifies the implementation of `IAsyncDisposable.DisposeAsync`. The `IDisposable` implementation has been removed because of the sync-over-async anti-pattern required to perform a final snapshot checkpoint when disposing of the store.