### PR TITLE
Check for existing key and add FASTER size tracking metrics

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -30,6 +30,35 @@ SOFTWARE.
 * * *
 
 
+# Microsoft Corporation
+
+Some code in this repository is based on [Microsoft FASTER](https://github.com/microsoft/FASTER).
+
+MIT License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+* * *
+
+
 # Jering.KeyValueStore
 
 Some code in this repository is based on [Jering.KeyValueStore](https://github.com/JeringTech/KeyValueStore).

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Shipped.txt
@@ -278,10 +278,6 @@ DataCore.Adapter.Services.KVKey.KVKey() -> void
 DataCore.Adapter.Services.KVKey.KVKey(byte[]? value) -> void
 DataCore.Adapter.Services.KVKey.Length.get -> int
 DataCore.Adapter.Services.KVKey.Value.get -> byte[]!
-DataCore.Adapter.Services.ScopedKeyValueStore
-DataCore.Adapter.Services.ScopedKeyValueStore.DeleteAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
-DataCore.Adapter.Services.ScopedKeyValueStore.GetKeysAsync(DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.Services.KVKey>!
-DataCore.Adapter.Services.ScopedKeyValueStore.ScopedKeyValueStore(DataCore.Adapter.Services.KVKey prefix, DataCore.Adapter.Services.IKeyValueStore! inner) -> void
 DataCore.Adapter.Tags.ITagConfiguration
 DataCore.Adapter.Tags.ITagConfiguration.CreateTagAsync(DataCore.Adapter.IAdapterCallContext! context, DataCore.Adapter.Tags.CreateTagRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<DataCore.Adapter.Tags.TagDefinition!>!
 DataCore.Adapter.Tags.ITagConfiguration.DeleteTagAsync(DataCore.Adapter.IAdapterCallContext! context, DataCore.Adapter.Tags.DeleteTagRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+abstract DataCore.Adapter.Services.KeyValueStore.ExistsAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
 abstract DataCore.Adapter.Services.KeyValueStore.GetSerializer() -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
 abstract DataCore.Adapter.Services.KeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 abstract DataCore.Adapter.Services.KeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
@@ -52,6 +53,7 @@ DataCore.Adapter.Common.HostInfoBuilder.WithProperty(string! name, DataCore.Adap
 DataCore.Adapter.Common.HostInfoBuilder.WithVendor(DataCore.Adapter.Common.VendorInfo? vendor) -> DataCore.Adapter.Common.HostInfoBuilder!
 DataCore.Adapter.Common.HostInfoBuilder.WithVersion(string? version) -> DataCore.Adapter.Common.HostInfoBuilder!
 DataCore.Adapter.IAdapterCallContext.Services.get -> System.IServiceProvider!
+DataCore.Adapter.Services.IKeyValueStore.ExistsAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
 DataCore.Adapter.Services.IKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 DataCore.Adapter.Services.IKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.IKeyValueStoreSerializer
@@ -94,15 +96,13 @@ DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions.SizeLimit.get -> int
 DataCore.Adapter.Services.KeyValueStoreWriteBufferOptions.SizeLimit.set -> void
 DataCore.Adapter.Services.RawKeyValueStore<TOptions>
 DataCore.Adapter.Services.RawKeyValueStore<TOptions>.RawKeyValueStore(TOptions? options, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
-DataCore.Adapter.Services.ScopedKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
-DataCore.Adapter.Services.ScopedKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask
 override DataCore.Adapter.Services.KVKey.ToString() -> string!
 override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetCompressionLevel() -> System.IO.Compression.CompressionLevel
 override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetSerializer() -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
 static DataCore.Adapter.AdapterExtensions.CreateExtendedAdapterDescriptorBuilder(this DataCore.Adapter.IAdapter! adapter) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
 static DataCore.Adapter.Services.JsonKeyValueStoreSerializer.Default.get -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
-static DataCore.Adapter.Services.KeyValueStoreExtensions.BulkCopyFromAsync(this DataCore.Adapter.Services.IRawKeyValueStore! destination, DataCore.Adapter.Services.IRawKeyValueStore! source, DataCore.Adapter.Services.KVKey? keyPrefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
-static DataCore.Adapter.Services.KeyValueStoreExtensions.BulkCopyToAsync(this DataCore.Adapter.Services.IRawKeyValueStore! source, DataCore.Adapter.Services.IRawKeyValueStore! destination, DataCore.Adapter.Services.KVKey? keyPrefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+static DataCore.Adapter.Services.KeyValueStoreExtensions.BulkCopyFromAsync(this DataCore.Adapter.Services.IRawKeyValueStore! destination, DataCore.Adapter.Services.IRawKeyValueStore! source, DataCore.Adapter.Services.KVKey? keyPrefix = null, bool overwrite = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+static DataCore.Adapter.Services.KeyValueStoreExtensions.BulkCopyToAsync(this DataCore.Adapter.Services.IRawKeyValueStore! source, DataCore.Adapter.Services.IRawKeyValueStore! destination, DataCore.Adapter.Services.KVKey? keyPrefix = null, bool overwrite = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 static DataCore.Adapter.Services.KeyValueStoreExtensions.CopyFromAsync(this DataCore.Adapter.Services.IRawKeyValueStore! destination, DataCore.Adapter.Services.IRawKeyValueStore! source, System.Collections.Generic.IEnumerable<DataCore.Adapter.Services.KVKey>! keys, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 static DataCore.Adapter.Services.KeyValueStoreExtensions.CopyToAsync(this DataCore.Adapter.Services.IRawKeyValueStore! source, DataCore.Adapter.Services.IRawKeyValueStore! destination, System.Collections.Generic.IEnumerable<DataCore.Adapter.Services.KVKey>! keys, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 static DataCore.Adapter.Services.KeyValueStoreExtensions.GetKeysAsStringsAsync(this DataCore.Adapter.Services.IKeyValueStore! store) -> System.Collections.Generic.IAsyncEnumerable<string!>!

--- a/src/DataCore.Adapter.Abstractions/Services/IKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/IKeyValueStore.cs
@@ -62,6 +62,18 @@ namespace DataCore.Adapter.Services {
 
 
         /// <summary>
+        /// Tests if a key exists in the store.
+        /// </summary>
+        /// <param name="key">
+        ///   The key to test.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the key exists; otherwise, <see langword="false"/>.
+        /// </returns>
+        ValueTask<bool> ExistsAsync(KVKey key);
+
+
+        /// <summary>
         /// Deletes a value from the store.
         /// </summary>
         /// <param name="key">

--- a/src/DataCore.Adapter.Abstractions/Services/InMemoryKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/InMemoryKeyValueStore.cs
@@ -52,6 +52,13 @@ namespace DataCore.Adapter.Services {
 
 
         /// <inheritdoc/>
+        protected override ValueTask<bool> ExistsAsync(KVKey key) {
+            var keyAsString = System.Text.Encoding.UTF8.GetString(key);
+            return new ValueTask<bool>(_values.ContainsKey(keyAsString));
+        }
+
+
+        /// <inheritdoc/>
         protected override ValueTask<bool> DeleteAsync(KVKey key) {
             var keyAsString = System.Text.Encoding.UTF8.GetString(key);
             return new ValueTask<bool>(_values.TryRemove(keyAsString, out _));

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStore.cs
@@ -54,6 +54,15 @@ namespace DataCore.Adapter.Services {
 
 
         /// <inheritdoc/>
+        async ValueTask<bool> IKeyValueStore.ExistsAsync(KVKey key) {
+            if (key.Length == 0) {
+                throw new ArgumentException(AbstractionsResources.Error_KeyValueStore_InvalidKey, nameof(key));
+            }
+            return await ExistsAsync(key).ConfigureAwait(false);
+        }
+
+
+        /// <inheritdoc/>
         async ValueTask<bool> IKeyValueStore.DeleteAsync(KVKey key) {
             if (key.Length == 0) {
                 throw new ArgumentException(AbstractionsResources.Error_KeyValueStore_InvalidKey, nameof(key));
@@ -102,6 +111,18 @@ namespace DataCore.Adapter.Services {
         ///   The value, or <see langword="null"/> if the key does not exist.
         /// </returns>
         protected abstract ValueTask<T?> ReadAsync<T>(KVKey key);
+
+
+        /// <summary>
+        /// Tests if a key exists in the store.
+        /// </summary>
+        /// <param name="key">
+        ///   The key to test.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the key exists; otherwise, <see langword="false"/>.
+        /// </returns>
+        protected abstract ValueTask<bool> ExistsAsync(KVKey key);
 
 
         /// <summary>

--- a/src/DataCore.Adapter.Abstractions/Services/ScopedRawKeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/ScopedRawKeyValueStore.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+
+namespace DataCore.Adapter.Services {
+
+    /// <summary>
+    /// <see cref="IRawKeyValueStore"/> that wraps an existing <see cref="IRawKeyValueStore"/> and 
+    /// automatically modifies keys passed in or out of the store using a scoped prefix.
+    /// </summary>
+    internal class ScopedRawKeyValueStore : ScopedKeyValueStore, IRawKeyValueStore {
+
+        /// <summary>
+        /// The inner <see cref="IRawKeyValueStore"/>.
+        /// </summary>
+        internal new IRawKeyValueStore Inner => (IRawKeyValueStore) base.Inner;
+
+
+        /// <summary>
+        /// Creates a new <see cref="ScopedRawKeyValueStore"/> object.
+        /// </summary>
+        /// <param name="prefix">
+        ///   The key prefix for the store.
+        /// </param>
+        /// <param name="inner">
+        ///   The inner <see cref="IRawKeyValueStore"/> to wrap.
+        /// </param>
+        public ScopedRawKeyValueStore(KVKey prefix, IRawKeyValueStore inner) 
+            : base(prefix, inner) { }
+
+
+        /// <inheritdoc/>
+        public ValueTask<byte[]?> ReadRawAsync(KVKey key) {
+            var k = KeyValueStore.AddPrefix(Prefix, key);
+            return Inner.ReadRawAsync(k);
+        }
+
+
+        /// <inheritdoc/>
+        public ValueTask WriteRawAsync(KVKey key, byte[] value) {
+            var k = KeyValueStore.AddPrefix(Prefix, key);
+            return Inner.WriteRawAsync(k, value);
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/CacheSizeTracker.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/CacheSizeTracker.cs
@@ -1,0 +1,114 @@
+﻿using System;
+
+using FASTER.core;
+
+namespace DataCore.Adapter.KeyValueStore.FASTER {
+
+    /// <summary>
+    /// Tracks memory usage in a <see cref="FasterKV{Key, Value}"/>.
+    /// </summary>
+    internal class CacheSizeTracker : IDisposable {
+
+        /// <summary>
+        /// Flags if the object has been disposed.
+        /// </summary>
+        private bool _disposed;
+
+        /// <summary>
+        /// The underlying FASTER store.
+        /// </summary>
+        private readonly FasterKV<SpanByte, SpanByte> _store;
+
+        /// <summary>
+        /// The size tracker for the FASTER log.
+        /// </summary>
+        private readonly LogSizeTracker _logSizeTracker;
+
+        /// <summary>
+        /// The size tracker for the FASTER read cache.
+        /// </summary>
+        private readonly LogSizeTracker? _readCacheSizeTracker;
+
+
+        /// <summary>
+        /// Creates a new <see cref="CacheSizeTracker"/> instance.
+        /// </summary>
+        /// <param name="store">
+        ///   The underlying FASTER store.
+        /// </param>
+        public CacheSizeTracker(FasterKV<SpanByte, SpanByte> store) {
+            _store = store;
+
+            _logSizeTracker = new LogSizeTracker(_store.Log);
+            if (_store.ReadCache != null) {
+                _readCacheSizeTracker = new LogSizeTracker(_store.ReadCache);
+            }
+        }
+
+
+        /// <summary>
+        /// Gets the total in-memory size of the FASTER store.
+        /// </summary>
+        /// <returns>
+        ///   The total in-memory size of the FASTER store, in bytes.
+        /// </returns>
+        internal long GetTotalSize() => GetIndexSize() + GetLogSize() + GetReadCacheSize();
+
+        /// <summary>
+        /// Gets the size of the FASTER index.
+        /// </summary>
+        /// <returns>
+        ///   The size of the FASTER index, in bytes.
+        /// </returns>
+        internal long GetIndexSize() => (_store.IndexSize * 64) + (_store.OverflowBucketCount * 64);
+
+        /// <summary>
+        /// Gets the size of the in-memory portion of the FASTER log.
+        /// </summary>
+        /// <returns>
+        ///   The size of the in-memory portion of the FASTER log, in bytes.
+        /// </returns>
+        internal long GetLogSize() => _logSizeTracker.TotalMemorySize;
+
+        /// <summary>
+        /// Gets the size of the FASTER read cache.
+        /// </summary>
+        /// <returns>
+        ///   The size of the FASTER read cache, in bytes.
+        /// </returns>
+        internal long GetReadCacheSize() => _readCacheSizeTracker?.TotalMemorySize ?? 0;
+
+
+        /// <summary>
+        /// Updates the heap size of the FASTER store.
+        /// </summary>
+        /// <param name="delta">
+        ///   The change in heap size.
+        /// </param>
+        /// <param name="isReadCache">
+        ///   <see langword="true"/> if the change is for the read cache; otherwise, <see langword="false"/>.
+        /// </param>
+        internal void UpdateHeapSize(int delta, bool isReadCache = false) {
+            if (isReadCache) {
+                _readCacheSizeTracker?.UpdateHeapSize(delta);
+            }
+            else {
+                _logSizeTracker.UpdateHeapSize(delta);
+            }
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+
+            _logSizeTracker.Dispose();
+            _readCacheSizeTracker?.Dispose();
+
+            _disposed = true;
+        }
+    }
+
+}

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStoreOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 using FASTER.core;
 
@@ -8,6 +9,16 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
     /// Options for <see cref="FasterKeyValueStore"/>.
     /// </summary>
     public class FasterKeyValueStoreOptions : Services.KeyValueStoreOptions {
+
+        /// <summary>
+        /// The name for the <see cref="FasterKeyValueStore"/> instance.
+        /// </summary>
+        /// <remarks>
+        ///   The name is used to identify the store in telemetry data. If not specified, a 
+        ///   default name will be used.
+        /// </remarks>
+        [MaxLength(50)]
+        public string? Name { get; set; }
 
         /// <summary>
         /// Specifies if the <see cref="FasterKeyValueStore"/> is read-only.

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/FasterRecord.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/FasterRecord.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+using DataCore.Adapter.Services;
+
+using FASTER.core;
+
+namespace DataCore.Adapter.KeyValueStore.FASTER {
+    /// <summary>
+    /// A record in the FASTER store.
+    /// </summary>
+    public readonly struct FasterRecord {
+
+        /// <summary>
+        /// The key.
+        /// </summary>
+        public KVKey Key { get; }
+
+        /// <summary>
+        /// The metadata for the record.
+        /// </summary>
+        public RecordMetadata Metadata { get; }
+
+        /// <summary>
+        /// Specifies if the record is located in the mutable portion of the FASTER log.
+        /// </summary>
+        public bool Mutable { get; }
+
+        /// <summary>
+        /// The value for the record.
+        /// </summary>
+        public ReadOnlyMemory<byte> Value { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="FasterRecord"/> instance
+        /// </summary>
+        /// <param name="key">
+        ///   The key.
+        /// </param>
+        /// <param name="metadata">
+        ///   The metadata for the record.
+        /// </param>
+        /// <param name="mutable">
+        ///   Specifies if the record is located in the mutable portion of the FASTER log.
+        /// </param>
+        /// <param name="value">
+        ///   The record value.
+        /// </param>
+        internal FasterRecord(KVKey key, RecordMetadata metadata, bool mutable, ReadOnlyMemory<byte> value) {
+            Key = key;
+            Metadata = metadata;
+            Mutable = mutable;
+            Value = value;
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/LogSizeTracker.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/LogSizeTracker.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Threading;
+
+using FASTER.core;
+
+namespace DataCore.Adapter.KeyValueStore.FASTER {
+
+    /// <summary>
+    /// Tracks memory usage in a FASTER <see cref="LogAccessor{Key, Value}"/>.
+    /// </summary>
+    internal class LogSizeTracker : IObserver<IFasterScanIterator<SpanByte, SpanByte>>, IDisposable {
+
+        /// <summary>
+        /// Flags if the object has been disposed.
+        /// </summary>
+        private bool _disposed;
+
+        /// <summary>
+        /// The <see cref="LogAccessor{Key, Value}"/> to track.
+        /// </summary>
+        private readonly LogAccessor<SpanByte, SpanByte> _log;
+
+        /// <summary>
+        /// The subscription that receives eviction notifications from the <see cref="_log"/>.
+        /// </summary>
+        private readonly IDisposable _subscription;
+
+        /// <summary>
+        /// The size of the heap allocated by the <see cref="_log"/>.
+        /// </summary>
+        private int _heapSize;
+
+        /// <summary>
+        /// The number of records in the heap for the <see cref="_log"/>.
+        /// </summary>
+        private int _recordCount;
+
+        /// <summary>
+        /// The total size of the <see cref="_log"/> and heap.
+        /// </summary>
+        public long TotalMemorySize => _log.MemorySizeBytes + _heapSize;
+
+        /// <summary>
+        /// The number of records in the heap for the <see cref="LogAccessor{Key, Value}"/>.
+        /// </summary>
+        public int RecordCount => _recordCount;
+
+
+        /// <summary>
+        /// Creates a new <see cref="LogSizeTracker"/> instance.
+        /// </summary>
+        /// <param name="log">
+        ///   The <see cref="LogAccessor{Key, Value}"/> to track.
+        /// </param>
+        public LogSizeTracker(LogAccessor<SpanByte, SpanByte> log) {
+            _log = log;
+            _subscription = _log.SubscribeEvictions(this);
+        }
+
+
+        /// <inheritdoc/>
+        public void OnCompleted() {
+            // No-op
+        }
+
+
+        /// <inheritdoc/>
+        public void OnError(Exception error) {
+            // No-op
+        }
+
+
+        /// <inheritdoc/>
+        public void OnNext(IFasterScanIterator<SpanByte, SpanByte> iterator) {
+            // We are only subscribed to be notified when items are evicted from the log, so we
+            // will always decrement the tracked log size.
+
+            var size = 0;
+
+            while (iterator.GetNext(out var recordInfo, out var key, out var value)) {
+                size += key.TotalSize;
+                if (!recordInfo.Tombstone) {
+                    // The record has not been deleted (e.g. it has been evicted and replaced
+                    // due to an update), so we need to account for the value size that was
+                    // replaced.
+                    size += value.TotalSize;
+                }
+            }
+
+            Interlocked.Add(ref _heapSize, -size);
+        }
+
+
+        /// <summary>
+        /// Updates the known heap size of the <see cref="LogAccessor{Key, Value}"/>.
+        /// </summary>
+        /// <param name="delta">
+        ///   The change in heap size, in bytes.
+        /// </param>
+        internal void UpdateHeapSize(int delta) {
+            Interlocked.Add(ref _heapSize, delta);
+            // If the delta is positive, we have added a new record to the heap; otherwise, we
+            // have removed a record.
+            if (delta > 0) {
+                Interlocked.Increment(ref _recordCount);
+            }
+            else {
+                Interlocked.Decrement(ref _recordCount);
+            }
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+
+            _subscription.Dispose();
+            _disposed = true;
+        }
+
+    }
+
+}

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
@@ -1,13 +1,15 @@
 ﻿#nullable enable
-DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord
-DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.FasterRecord() -> void
-DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.Key.get -> DataCore.Adapter.Services.KVKey
-DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.Metadata.get -> FASTER.core.RecordMetadata
-DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.Mutable.get -> bool
-DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord.Value.get -> System.ReadOnlyMemory<byte>
-DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.GetRecordsAsync(DataCore.Adapter.Services.KVKey? prefix = null) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterRecord>!
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.GetRecordsAsync(DataCore.Adapter.Services.KVKey? prefix = null) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.KeyValueStore.FASTER.FasterRecord>!
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.TakeIncrementalCheckpointAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.EnableRawWrites.get -> bool
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.EnableRawWrites.set -> void
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.IncrementalCheckpointInterval.get -> System.TimeSpan?
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.IncrementalCheckpointInterval.set -> void
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.Name.get -> string?
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.Name.set -> void
+DataCore.Adapter.KeyValueStore.FASTER.FasterRecord
+DataCore.Adapter.KeyValueStore.FASTER.FasterRecord.FasterRecord() -> void
+DataCore.Adapter.KeyValueStore.FASTER.FasterRecord.Key.get -> DataCore.Adapter.Services.KVKey
+DataCore.Adapter.KeyValueStore.FASTER.FasterRecord.Metadata.get -> FASTER.core.RecordMetadata
+DataCore.Adapter.KeyValueStore.FASTER.FasterRecord.Mutable.get -> bool
+DataCore.Adapter.KeyValueStore.FASTER.FasterRecord.Value.get -> System.ReadOnlyMemory<byte>

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/ScanIteratorFunctions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/ScanIteratorFunctions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Threading.Channels;
+
+using FASTER.core;
+
+namespace DataCore.Adapter.KeyValueStore.FASTER {
+
+    /// <summary>
+    /// <see cref="IScanIteratorFunctions{Key, Value}"/> implementation that allows us to use 
+    /// FASTER's "push" key iteration: https://microsoft.github.io/FASTER/docs/fasterkv-basics/#key-iteration
+    /// </summary>
+    internal struct ScanIteratorFunctions : IScanIteratorFunctions<SpanByte, SpanByte> {
+
+        /// <summary>
+        /// The channel to publish keys to as they are iterated over.
+        /// </summary>
+        private readonly Channel<FasterRecord> _channel;
+
+        /// <summary>
+        /// Specifies if the iterator should include record values.
+        /// </summary>
+        private readonly bool _includeValues;
+
+        /// <summary>
+        /// The channel reader.
+        /// </summary>
+        public ChannelReader<FasterRecord> Reader => _channel?.Reader!;
+
+
+        /// <summary>
+        /// Creates a new <see cref="ScanIteratorFunctions"/> instance.
+        /// </summary>
+        /// <param name="includeValues">
+        ///   Specifies if the iterator should include record values.
+        /// </param>
+        internal ScanIteratorFunctions(bool includeValues) {
+            _includeValues = includeValues;
+            _channel = Channel.CreateUnbounded<FasterRecord>(new UnboundedChannelOptions() {
+                AllowSynchronousContinuations = false,
+                SingleReader = true,
+                SingleWriter = true
+            });
+        }
+
+
+        /// <inheritdoc/>
+        public bool OnStart(long beginAddress, long endAddress) => true;
+
+
+        /// <inheritdoc/>
+        public bool SingleReader(ref SpanByte key, ref SpanByte value, RecordMetadata recordMetadata, long numberOfRecords) {
+            return _channel.Writer.TryWrite(new FasterRecord(key.ToByteArray(), recordMetadata, false, _includeValues ? new ReadOnlyMemory<byte>(value.ToByteArray()) : default));
+        }
+
+
+        /// <inheritdoc/>
+        public bool ConcurrentReader(ref SpanByte key, ref SpanByte value, RecordMetadata recordMetadata, long numberOfRecords) {
+            return _channel.Writer.TryWrite(new FasterRecord(key.ToByteArray(), recordMetadata, true, _includeValues ? new ReadOnlyMemory<byte>(value.ToByteArray()) : default));
+        }
+
+
+        /// <inheritdoc/>
+        public void OnStop(bool completed, long numberOfRecords) {
+            _channel.Writer.TryComplete();
+        }
+
+
+        /// <inheritdoc/>
+        public void OnException(Exception exception, long numberOfRecords) {
+            _channel.Writer.TryComplete(exception);
+        }
+
+    }
+
+}

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/SizeTrackingSpanByteFunctions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/SizeTrackingSpanByteFunctions.cs
@@ -49,11 +49,13 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         public override bool ConcurrentDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo) {
             var delta = value.TotalSize;
             if (base.ConcurrentDeleter(ref key, ref value, ref deleteInfo)) {
-                if (deleteInfo.RecordInfo.Invalid) {
-                    delta += key.TotalSize;
-                }
-
                 _sizeTracker.UpdateHeapSize(-delta);
+                if (deleteInfo.RecordInfo.Invalid) {
+                    // Record was marked as invalid. FASTER example code indicates that this means
+                    // that the record was not inserted, so deduct the size of the key from the
+                    // heap as well.
+                    _sizeTracker.UpdateHeapSize(-key.TotalSize);
+                }
                 return true;
             }
 

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/SizeTrackingSpanByteFunctions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/SizeTrackingSpanByteFunctions.cs
@@ -1,0 +1,65 @@
+﻿using FASTER.core;
+
+namespace DataCore.Adapter.KeyValueStore.FASTER {
+
+    /// <summary>
+    /// Extends <see cref="SpanByteFunctions{Context}"/> to notify a <see cref="CacheSizeTracker"/> 
+    /// instance about upserts, deletes and copies to the FASTER read cache.
+    /// </summary>
+    internal sealed class SizeTrackingSpanByteFunctions : SpanByteFunctions<Empty> {
+
+        /// <summary>
+        /// The <see cref="CacheSizeTracker"/> that tracks memory usage.
+        /// </summary>
+        private readonly CacheSizeTracker _sizeTracker;
+
+
+        /// <summary>
+        /// Creates a new <see cref="SizeTrackingSpanByteFunctions"/> instance.
+        /// </summary>
+        /// <param name="sizeTracker">
+        ///   The <see cref="CacheSizeTracker"/> that tracks memory usage.
+        /// </param>
+        public SizeTrackingSpanByteFunctions(CacheSizeTracker sizeTracker) {
+            _sizeTracker = sizeTracker;
+        }
+
+
+        /// <inheritdoc/>
+        public override bool ConcurrentWriter(ref SpanByte key, ref SpanByte input, ref SpanByte src, ref SpanByte dst, ref SpanByteAndMemory output, ref UpsertInfo upsertInfo) {
+            var delta = src.TotalSize - dst.TotalSize;
+            if (base.ConcurrentWriter(ref key, ref input, ref src, ref dst, ref output, ref upsertInfo)) {
+                _sizeTracker.UpdateHeapSize(delta);
+                return true;
+            }
+
+            return false;
+        }
+
+
+        /// <inheritdoc/>
+        public override void PostSingleWriter(ref SpanByte key, ref SpanByte input, ref SpanByte src, ref SpanByte dst, ref SpanByteAndMemory output, ref UpsertInfo upsertInfo, WriteReason reason) {
+            var delta = key.TotalSize + src.TotalSize;
+            base.PostSingleWriter(ref key, ref input, ref src, ref dst, ref output, ref upsertInfo, reason);
+            _sizeTracker.UpdateHeapSize(delta, reason == WriteReason.CopyToReadCache);
+        }
+
+
+        /// <inheritdoc/>
+        public override bool ConcurrentDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo) {
+            var delta = value.TotalSize;
+            if (base.ConcurrentDeleter(ref key, ref value, ref deleteInfo)) {
+                if (deleteInfo.RecordInfo.Invalid) {
+                    delta += key.TotalSize;
+                }
+
+                _sizeTracker.UpdateHeapSize(-delta);
+                return true;
+            }
+
+            return false;
+        }
+
+    }
+
+}

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@ DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreWriteBufferOptions.Enab
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreWriteBufferOptions.Enabled.set -> void
 DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStoreWriteBufferOptions.SqliteKeyValueStoreWriteBufferOptions() -> void
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.AllowRawWrites.get -> bool
+override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ExistsAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<bool>
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadAsync<T>(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<T?>
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.ReadRawAsync(DataCore.Adapter.Services.KVKey key) -> System.Threading.Tasks.ValueTask<byte[]?>
 override DataCore.Adapter.KeyValueStore.Sqlite.SqliteKeyValueStore.WriteAsync<T>(DataCore.Adapter.Services.KVKey key, T value) -> System.Threading.Tasks.ValueTask

--- a/test/DataCore.Adapter.Tests/FasterKeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/FasterKeyValueStoreTests.cs
@@ -18,7 +18,11 @@ namespace DataCore.Adapter.Tests {
     [TestClass]
     public class FasterKeyValueStoreTests : KeyValueStoreTests<FasterKeyValueStore> {
         protected override FasterKeyValueStore CreateStore(CompressionLevel compressionLevel, bool enableRawWrites = false) {
-            return new FasterKeyValueStore(new FasterKeyValueStoreOptions() { CompressionLevel = compressionLevel, EnableRawWrites = enableRawWrites });
+            return new FasterKeyValueStore(new FasterKeyValueStoreOptions() { 
+                Name = TestContext.TestName,
+                CompressionLevel = compressionLevel, 
+                EnableRawWrites = enableRawWrites 
+            });
         }
 
 

--- a/test/DataCore.Adapter.Tests/KeyValueStoreTests.cs
+++ b/test/DataCore.Adapter.Tests/KeyValueStoreTests.cs
@@ -31,7 +31,10 @@ namespace DataCore.Adapter.Tests {
                 await store.WriteAsync(TestContext.TestName, now);
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }
@@ -67,6 +70,26 @@ namespace DataCore.Adapter.Tests {
         }
 
 
+        [TestMethod]
+        public async Task KeyShouldExistInStore() {
+            var now = DateTime.UtcNow;
+
+            var store = CreateStore(CompressionLevel.NoCompression);
+            try {
+                await store.WriteAsync(TestContext.TestName, now);
+                Assert.IsTrue(await store.ExistsAsync(TestContext.TestName));
+            }
+            finally {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
+                    disposable.Dispose();
+                }
+            }
+        }
+
+
         [DataTestMethod]
         [DataRow(CompressionLevel.NoCompression)]
         [DataRow(CompressionLevel.Fastest)]
@@ -85,7 +108,10 @@ namespace DataCore.Adapter.Tests {
                 Assert.AreEqual(now, value);
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }
@@ -116,7 +142,10 @@ namespace DataCore.Adapter.Tests {
                 Assert.AreEqual(default(DateTime), value2);
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }
@@ -147,7 +176,10 @@ namespace DataCore.Adapter.Tests {
                 }
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }
@@ -179,7 +211,10 @@ namespace DataCore.Adapter.Tests {
                 Assert.AreEqual(now, value2);
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }
@@ -206,7 +241,10 @@ namespace DataCore.Adapter.Tests {
                 Assert.IsTrue(keys.Contains(TestContext.TestName));
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }
@@ -246,7 +284,10 @@ namespace DataCore.Adapter.Tests {
                 }
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }
@@ -277,7 +318,10 @@ namespace DataCore.Adapter.Tests {
                 Assert.AreEqual(now, deserialized);
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }
@@ -308,7 +352,10 @@ namespace DataCore.Adapter.Tests {
                 Assert.IsTrue(raw.SequenceEqual(raw2));
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }
@@ -330,7 +377,10 @@ namespace DataCore.Adapter.Tests {
                 await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await rawStore.WriteRawAsync(TestContext.TestName, raw));
             }
             finally {
-                if (store is IDisposable disposable) {
+                if (store is IAsyncDisposable asyncDisposable) {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (store is IDisposable disposable) {
                     disposable.Dispose();
                 }
             }


### PR DESCRIPTION
This PR adds a new `IKeyValueStore.ExistsAsync` method that checks if a given key exists in the store. `BulkCopyToAsync` and `BulkCopyFromAsync` extension methods for `IKeyValueStore` now include an `overwrite` parameter that controls the behaviour when copying if a destination key already exists.

The PR also updates the FASTER key/value store to track the memory footprint of the store (i.e. the index, in-memory log portion and read cache for the underlying FASTER store). This information is made available via metric instruments.