### PR TITLE
Allow customisation of compression/decompression of raw key/value store values

### DIFF
--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -108,4 +108,5 @@ static DataCore.Adapter.Services.KeyValueStoreExtensions.CopyToAsync(this DataCo
 static DataCore.Adapter.Services.KeyValueStoreExtensions.GetKeysAsStringsAsync(this DataCore.Adapter.Services.IKeyValueStore! store) -> System.Collections.Generic.IAsyncEnumerable<string!>!
 static DataCore.Adapter.Services.KeyValueStoreExtensions.GetKeysAsStringsAsync(this DataCore.Adapter.Services.IKeyValueStore! store, DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<string!>!
 static DataCore.Adapter.Services.KVKey.implicit operator string?(DataCore.Adapter.Services.KVKey value) -> string?
+virtual DataCore.Adapter.Services.RawKeyValueStore<TOptions>.CompressRawBytesAsync(byte[]! data, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
 ~static DataCore.Adapter.AbstractionsResources.Error_KeyValueStore_RawWritesDisabled.get -> string

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -68,7 +68,9 @@ DataCore.Adapter.Services.JsonKeyValueStoreSerializer.DeserializeAsync<T>(System
 DataCore.Adapter.Services.JsonKeyValueStoreSerializer.JsonKeyValueStoreSerializer(System.Text.Json.JsonSerializerOptions? jsonOptions) -> void
 DataCore.Adapter.Services.JsonKeyValueStoreSerializer.SerializeAsync<T>(System.IO.Stream! stream, T value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.KeyValueStore.DeserializeFromBytesAsync<T>(byte[]! data) -> System.Threading.Tasks.ValueTask<T?>
+DataCore.Adapter.Services.KeyValueStore.DeserializeFromStreamCoreAsync<T>(System.IO.Stream! stream) -> System.Threading.Tasks.ValueTask<T?>
 DataCore.Adapter.Services.KeyValueStore.SerializeToBytesAsync<T>(T value, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
+DataCore.Adapter.Services.KeyValueStore.SerializeToStreamCoreAsync<T>(System.IO.Stream! stream, T value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.get -> DataCore.Adapter.Services.IKeyValueStoreSerializer?
 DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.set -> void
 DataCore.Adapter.Services.KeyValueStoreWriteBuffer

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -101,6 +101,8 @@ override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetCompression
 override sealed DataCore.Adapter.Services.KeyValueStore<TOptions>.GetSerializer() -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
 static DataCore.Adapter.AdapterExtensions.CreateExtendedAdapterDescriptorBuilder(this DataCore.Adapter.IAdapter! adapter) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
 static DataCore.Adapter.Services.JsonKeyValueStoreSerializer.Default.get -> DataCore.Adapter.Services.IKeyValueStoreSerializer!
+static DataCore.Adapter.Services.KeyValueStore.IsGzipped(System.IO.Stream! stream) -> bool
+static DataCore.Adapter.Services.KeyValueStore.IsGzipped(System.Span<byte> data) -> bool
 static DataCore.Adapter.Services.KeyValueStoreExtensions.BulkCopyFromAsync(this DataCore.Adapter.Services.IRawKeyValueStore! destination, DataCore.Adapter.Services.IRawKeyValueStore! source, DataCore.Adapter.Services.KVKey? keyPrefix = null, bool overwrite = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 static DataCore.Adapter.Services.KeyValueStoreExtensions.BulkCopyToAsync(this DataCore.Adapter.Services.IRawKeyValueStore! source, DataCore.Adapter.Services.IRawKeyValueStore! destination, DataCore.Adapter.Services.KVKey? keyPrefix = null, bool overwrite = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 static DataCore.Adapter.Services.KeyValueStoreExtensions.CopyFromAsync(this DataCore.Adapter.Services.IRawKeyValueStore! destination, DataCore.Adapter.Services.IRawKeyValueStore! source, System.Collections.Generic.IEnumerable<DataCore.Adapter.Services.KVKey>! keys, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
@@ -109,4 +111,5 @@ static DataCore.Adapter.Services.KeyValueStoreExtensions.GetKeysAsStringsAsync(t
 static DataCore.Adapter.Services.KeyValueStoreExtensions.GetKeysAsStringsAsync(this DataCore.Adapter.Services.IKeyValueStore! store, DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<string!>!
 static DataCore.Adapter.Services.KVKey.implicit operator string?(DataCore.Adapter.Services.KVKey value) -> string?
 virtual DataCore.Adapter.Services.RawKeyValueStore<TOptions>.CompressRawBytesAsync(byte[]! data, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
+virtual DataCore.Adapter.Services.RawKeyValueStore<TOptions>.DecompressRawBytesAsync(byte[]! data) -> System.Threading.Tasks.ValueTask<byte[]!>
 ~static DataCore.Adapter.AbstractionsResources.Error_KeyValueStore_RawWritesDisabled.get -> string

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -68,9 +68,7 @@ DataCore.Adapter.Services.JsonKeyValueStoreSerializer.DeserializeAsync<T>(System
 DataCore.Adapter.Services.JsonKeyValueStoreSerializer.JsonKeyValueStoreSerializer(System.Text.Json.JsonSerializerOptions? jsonOptions) -> void
 DataCore.Adapter.Services.JsonKeyValueStoreSerializer.SerializeAsync<T>(System.IO.Stream! stream, T value) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.KeyValueStore.DeserializeFromBytesAsync<T>(byte[]! data) -> System.Threading.Tasks.ValueTask<T?>
-DataCore.Adapter.Services.KeyValueStore.DeserializeFromStreamAsync<T>(System.IO.Stream! stream) -> System.Threading.Tasks.ValueTask<T?>
 DataCore.Adapter.Services.KeyValueStore.SerializeToBytesAsync<T>(T value, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
-DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
 DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.get -> DataCore.Adapter.Services.IKeyValueStoreSerializer?
 DataCore.Adapter.Services.KeyValueStoreOptions.Serializer.set -> void
 DataCore.Adapter.Services.KeyValueStoreWriteBuffer
@@ -110,6 +108,8 @@ static DataCore.Adapter.Services.KeyValueStoreExtensions.CopyToAsync(this DataCo
 static DataCore.Adapter.Services.KeyValueStoreExtensions.GetKeysAsStringsAsync(this DataCore.Adapter.Services.IKeyValueStore! store) -> System.Collections.Generic.IAsyncEnumerable<string!>!
 static DataCore.Adapter.Services.KeyValueStoreExtensions.GetKeysAsStringsAsync(this DataCore.Adapter.Services.IKeyValueStore! store, DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<string!>!
 static DataCore.Adapter.Services.KVKey.implicit operator string?(DataCore.Adapter.Services.KVKey value) -> string?
+virtual DataCore.Adapter.Services.KeyValueStore.DeserializeFromStreamAsync<T>(System.IO.Stream! stream) -> System.Threading.Tasks.ValueTask<T?>
+virtual DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
 virtual DataCore.Adapter.Services.RawKeyValueStore<TOptions>.CompressRawBytesAsync(byte[]! data, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>
 virtual DataCore.Adapter.Services.RawKeyValueStore<TOptions>.DecompressRawBytesAsync(byte[]! data) -> System.Threading.Tasks.ValueTask<byte[]!>
 ~static DataCore.Adapter.AbstractionsResources.Error_KeyValueStore_RawWritesDisabled.get -> string

--- a/src/DataCore.Adapter.Abstractions/Services/KeyValueStore.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/KeyValueStore.cs
@@ -313,13 +313,9 @@ namespace DataCore.Adapter.Services {
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            if (IsGzipped(stream)) {
-                using (var decompressStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true)) {
-                    return await GetSerializer().DeserializeAsync<T?>(decompressStream).ConfigureAwait(false);
-                }
+            using (var decompressStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true)) {
+                return await GetSerializer().DeserializeAsync<T?>(decompressStream).ConfigureAwait(false);
             }
-
-            return await GetSerializer().DeserializeAsync<T?>(stream).ConfigureAwait(false);
         }
 
 

--- a/src/DataCore.Adapter.Abstractions/Services/RawKeyValueStoreT.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/RawKeyValueStoreT.cs
@@ -157,17 +157,5 @@ namespace DataCore.Adapter.Services {
             }
         }
 
-
-        /// <summary>
-        /// Checks if the data is gzipped.
-        /// </summary>
-        /// <param name="data">
-        ///   The data to check.
-        /// </param>
-        /// <returns>
-        ///   <see langword="true"/> if the data is gzipped; otherwise, <see langword="false"/>.
-        /// </returns>
-        private static bool IsGzipped(byte[] data) => data.Length >= 2 && data[0] == 0x1F && data[1] == 0x8B;
-
     }
 }

--- a/src/DataCore.Adapter.Abstractions/Services/RawKeyValueStoreT.cs
+++ b/src/DataCore.Adapter.Abstractions/Services/RawKeyValueStoreT.cs
@@ -105,18 +105,7 @@ namespace DataCore.Adapter.Services {
         /// <returns>
         ///   A byte array containing the compressed raw data.
         /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="data"/> is <see langword="null"/>.
-        /// </exception>
         protected virtual async ValueTask<byte[]> CompressRawBytesAsync(byte[] data, CompressionLevel? compressionLevel = null) {
-            if (data == null) {
-                throw new ArgumentNullException(nameof(data));
-            }
-
-            if (IsGzipped(data)) {
-                return data;
-            }
-
             var level = compressionLevel ?? GetCompressionLevel();
 
             using (var ms = new MemoryStream())
@@ -141,14 +130,6 @@ namespace DataCore.Adapter.Services {
         ///   <paramref name="data"/> is <see langword="null"/>.
         /// </exception>
         protected virtual async ValueTask<byte[]> DecompressRawBytesAsync(byte[] data) {
-            if (data == null) {
-                throw new ArgumentNullException(nameof(data));
-            }
-
-            if (!IsGzipped(data)) {
-                return data;
-            }
-
             using (var ms1 = new MemoryStream(data))
             using (var decompressStream = new GZipStream(ms1, CompressionMode.Decompress, leaveOpen: true))
             using (var ms2 = new MemoryStream()) {

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/CacheSizeTracker.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/CacheSizeTracker.cs
@@ -52,7 +52,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         /// <returns>
         ///   The total in-memory size of the FASTER store, in bytes.
         /// </returns>
-        internal long GetTotalSize() => GetIndexSize() + GetLogSize() + GetReadCacheSize();
+        internal long GetTotalSizeBytes() => GetIndexSizeBytes() + GetLogSizeBytes() + GetReadCacheSizeBytes();
 
         /// <summary>
         /// Gets the size of the FASTER index.
@@ -60,7 +60,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         /// <returns>
         ///   The size of the FASTER index, in bytes.
         /// </returns>
-        internal long GetIndexSize() => (_store.IndexSize * 64) + (_store.OverflowBucketCount * 64);
+        internal long GetIndexSizeBytes() => (_store.IndexSize * 64) + (_store.OverflowBucketCount * 64);
 
         /// <summary>
         /// Gets the size of the in-memory portion of the FASTER log.
@@ -68,7 +68,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         /// <returns>
         ///   The size of the in-memory portion of the FASTER log, in bytes.
         /// </returns>
-        internal long GetLogSize() => _logSizeTracker.TotalMemorySize;
+        internal long GetLogSizeBytes() => _logSizeTracker.TotalMemorySizeBytes;
 
         /// <summary>
         /// Gets the size of the FASTER read cache.
@@ -76,7 +76,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         /// <returns>
         ///   The size of the FASTER read cache, in bytes.
         /// </returns>
-        internal long GetReadCacheSize() => _readCacheSizeTracker?.TotalMemorySize ?? 0;
+        internal long GetReadCacheSizeBytes() => _readCacheSizeTracker?.TotalMemorySizeBytes ?? 0;
 
 
         /// <summary>

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
@@ -315,7 +315,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         ///   A new <see cref="LogSettings"/> object.
         /// </returns>
         private static LogSettings CreateLogSettings(FasterKeyValueStoreOptions options) {
-            IDevice CreateDefaultDevice() {
+            static IDevice CreateDefaultDevice() {
                 return Devices.CreateLogDevice(
                     Path.Combine(Path.GetTempPath(), "FASTER", "hlog.log"),
                     preallocateFile: false,
@@ -522,7 +522,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         ///   A session object that can be used to query or modify the FASTER log.
         /// </returns>
         private ClientSession<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, Empty, SpanByteFunctions<Empty>> GetPooledSession() {
-            if (_sessionPool.TryDequeue(out ClientSession<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, Empty, SpanByteFunctions<Empty>>? result)) {
+            if (_sessionPool.TryDequeue(out var result)) {
                 return result;
             }
 

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
@@ -54,7 +54,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
             "KeyValueStore.FASTER.Size.Total",
             () => {
                 using (s_instancesLock.ReaderLock()) {
-                    return s_instances.Select(x => new Measurement<long>(x._sizeTracker.GetTotalSize(), CreateInstanceIdTag(x))).ToArray();
+                    return s_instances.Select(x => new Measurement<long>(x._sizeTracker.GetTotalSizeBytes(), CreateInstanceIdTag(x))).ToArray();
                 }
             },
             "By",
@@ -68,7 +68,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
             "KeyValueStore.FASTER.Size.Index",
             () => {
                 using (s_instancesLock.ReaderLock()) {
-                    return s_instances.Select(x => new Measurement<long>(x._sizeTracker.GetIndexSize(), CreateInstanceIdTag(x))).ToArray();
+                    return s_instances.Select(x => new Measurement<long>(x._sizeTracker.GetIndexSizeBytes(), CreateInstanceIdTag(x))).ToArray();
                 }
             },
             "By",
@@ -82,7 +82,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
             "KeyValueStore.FASTER.Size.Log",
             () => {
                 using (s_instancesLock.ReaderLock()) {
-                    return s_instances.Select(x => new Measurement<long>(x._sizeTracker.GetLogSize(), CreateInstanceIdTag(x))).ToArray();
+                    return s_instances.Select(x => new Measurement<long>(x._sizeTracker.GetLogSizeBytes(), CreateInstanceIdTag(x))).ToArray();
                 }
             },
             "By",
@@ -96,7 +96,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
             "KeyValueStore.FASTER.Size.ReadCache",
             () => {
                 using (s_instancesLock.ReaderLock()) {
-                    return s_instances.Select(x => new Measurement<long>(x._sizeTracker.GetReadCacheSize(), CreateInstanceIdTag(x))).ToArray();
+                    return s_instances.Select(x => new Measurement<long>(x._sizeTracker.GetReadCacheSizeBytes(), CreateInstanceIdTag(x))).ToArray();
                 }
             },
             "By",

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/LogSizeTracker.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/LogSizeTracker.cs
@@ -31,9 +31,19 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         private int _heapSize;
 
         /// <summary>
-        /// The total size of the <see cref="_log"/> and heap.
+        /// Actual memory used by the log (not including heap objects).
         /// </summary>
-        public long TotalMemorySize => _log.MemorySizeBytes + _heapSize;
+        public long MemorySizeBytes => _log.MemorySizeBytes;
+
+        /// <summary>
+        /// The size of the log's heap objects.
+        /// </summary>
+        public int HeapSizeBytes => _heapSize;
+
+        /// <summary>
+        /// The total size of the log and heap.
+        /// </summary>
+        public long TotalMemorySizeBytes => MemorySizeBytes + HeapSizeBytes;
 
 
         /// <summary>


### PR DESCRIPTION
This PR adds protected virtual methods to `RawKeyValueStore<T>` that are called when compressing/decompressing raw values. It also adds `IsGzipped` methods to `KeyValueStore` that look for the gzip magic bytes (`0x1F`, `0x8B`) at the start of an array or stream. 

The purpose of these changes is to allow for situations where a `RawKeyValueStore<T>` implementation retrieves bytes from an external source that may not be compressed. `RawKeyValueStore<T>` always assumes that raw byte values being read from the store are compressed, since it always compresses bytes when they are written to the store. However, if an implementation received raw bytes from an external service and those raw bytes were not compressed, an exception would previously be thrown when the `RawKeyValueStore<T>` attempted to decompress the raw bytes.

The PR also makes minor changes to the FASTER key/value store size tracking used in metrics.