### PR TITLE
Update iteration of FASTER records in LogSizeTracker

### DIFF
--- a/src/DataCore.Adapter.KeyValueStore.FASTER/LogSizeTracker.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/LogSizeTracker.cs
@@ -77,8 +77,8 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
 
             var size = 0;
 
-            while (iterator.GetNext(out var recordInfo, out var key, out var value)) {
-                size += key.TotalSize;
+            while (iterator.GetNext(out var recordInfo)) {
+                size += iterator.GetKey().TotalSize;
 
                 // If the record has not been deleted (i.e. it has been replaced by an upsert
                 // operation), we need to account for the size of the value that was replaced in
@@ -89,7 +89,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
                 // deduct the size of the evicted key here.
 
                 if (!recordInfo.Tombstone) {
-                    size += value.TotalSize;
+                    size += iterator.GetValue().TotalSize;
                 }
             }
 


### PR DESCRIPTION
Calling `IFasterScanIterator<Key, Value>.GetNext(out RecordInfo, out Key, out Value)` throws a `NotImplementedException` when the `FASTER.core.VariableLengthBlittableScanIterator` implementation is used.

To work around this, we now call `IFasterScanIterator<Key, Value>.GetNext(out RecordInfo)` and then explicitly call the `GetKey()` and `GetValue()` methods on the iterator.