### PR TITLE
Improved FASTER logging and package updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,41 +10,41 @@
   project. 
   -->
   <PropertyGroup>
-    <PkgVersion_OpenTelemetry>1.6.0</PkgVersion_OpenTelemetry>
-    <PkgVersion_OpenTelemetry_Api>1.6.0</PkgVersion_OpenTelemetry_Api>
-    <PkgVersion_OpenTelemetry_Exporter_Console>1.6.0</PkgVersion_OpenTelemetry_Exporter_Console>
-    <PkgVersion_OpenTelemetry_Exporter_OpenTelemetryProtocol>1.6.0</PkgVersion_OpenTelemetry_Exporter_OpenTelemetryProtocol>
-    <PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>1.6.0-rc.1</PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>
-    <PkgVersion_OpenTelemetry_Extensions_Hosting>1.6.0</PkgVersion_OpenTelemetry_Extensions_Hosting>
-    <PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>1.6.0-beta.3</PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>
+    <PkgVersion_OpenTelemetry>1.7.0</PkgVersion_OpenTelemetry>
+    <PkgVersion_OpenTelemetry_Api>1.7.0</PkgVersion_OpenTelemetry_Api>
+    <PkgVersion_OpenTelemetry_Exporter_Console>1.7.0</PkgVersion_OpenTelemetry_Exporter_Console>
+    <PkgVersion_OpenTelemetry_Exporter_OpenTelemetryProtocol>1.7.0</PkgVersion_OpenTelemetry_Exporter_OpenTelemetryProtocol>
+    <PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>1.7.0-rc.1</PkgVersion_OpenTelemetry_Exporter_Prometheus_AspNetCore>
+    <PkgVersion_OpenTelemetry_Extensions_Hosting>1.7.0</PkgVersion_OpenTelemetry_Extensions_Hosting>
+    <PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>1.7.0</PkgVersion_OpenTelemetry_Instrumentation_AspNetCore>
     <PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>1.6.0-beta.3</PkgVersion_OpenTelemetry_Instrumentation_GrpcNetClient>
-    <PkgVersion_OpenTelemetry_Instrumentation_Http>1.6.0-beta.3</PkgVersion_OpenTelemetry_Instrumentation_Http>
-    <PkgVersion_OpenTelemetry_Instrumentation_Runtime>1.5.1</PkgVersion_OpenTelemetry_Instrumentation_Runtime>
+    <PkgVersion_OpenTelemetry_Instrumentation_Http>1.7.0</PkgVersion_OpenTelemetry_Instrumentation_Http>
+    <PkgVersion_OpenTelemetry_Instrumentation_Runtime>1.7.0</PkgVersion_OpenTelemetry_Instrumentation_Runtime>
     <PkgVersion_OpenTelemetry_Instrumentation_SqlClient>1.6.0-beta.3</PkgVersion_OpenTelemetry_Instrumentation_SqlClient>
     <PkgVersion_Microsoft_Web_LibraryManager_Build>2.1.175</PkgVersion_Microsoft_Web_LibraryManager_Build>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="CsvHelper" Version="30.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.25.1" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.59.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.59.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.59.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.25.2" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.60.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.60.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.60.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="11.0.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="11.0.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="11.0.0" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="2.2.0" />
-    <PackageVersion Include="JsonSchema.Net.Generation" Version="3.4.1" />
+    <PackageVersion Include="JsonSchema.Net.Generation" Version="3.5.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.FASTER.Core" Version="2.6.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
@@ -75,7 +75,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.1" />
     <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStore.cs
@@ -197,13 +197,13 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         /// <param name="options">
         ///   The options for the store.
         /// </param>
-        /// <param name="logger">
-        ///   The <see cref="ILogger"/> for the store.
+        /// <param name="loggerFactory">
+        ///   The <see cref="ILoggerFactory"/> to use when creating loggers for the store.
         /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="options"/> is <see langword="null"/>.
         /// </exception>
-        public FasterKeyValueStore(FasterKeyValueStoreOptions options, ILogger<FasterKeyValueStore>? logger = null) : base(options, logger) {
+        public FasterKeyValueStore(FasterKeyValueStoreOptions options, ILoggerFactory? loggerFactory = null) : base(options, loggerFactory?.CreateLogger<FasterKeyValueStore>()) {
             if (options == null) {
                 throw new ArgumentNullException(nameof(options));
             }
@@ -224,9 +224,10 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
             _fasterKVStore = new FasterKV<SpanByte, SpanByte>(
                 options.IndexBucketCount,
                 logSettings,
-                checkpointManager == null ? null : new CheckpointSettings() { 
+                checkpointManager == null ? null : new CheckpointSettings() {
                     CheckpointManager = checkpointManager
-                }
+                },
+                logger: loggerFactory?.CreateLogger($"{typeof(FasterKV<SpanByte, SpanByte>).Namespace}.FasterKV")
             );
             _sizeTracker = new CacheSizeTracker(_fasterKVStore);
 

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStoreOptions.cs
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/FasterKeyValueStoreOptions.cs
@@ -152,7 +152,7 @@ namespace DataCore.Adapter.KeyValueStore.FASTER {
         ///   a read-only part of the FASTER log. These items remain in FASTER until the log is 
         ///   compacted. Compaction is performed on a periodic basis via the <see cref="CompactionInterval"/> 
         ///   setting. At each compaction interval, the FASTER log will be compacted if it is 
-        ///   created than the current size threshold, in order to remove expired records from the 
+        ///   greater than the current size threshold, in order to remove expired records from the 
         ///   log.
         /// </para>
         /// 

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Shipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.DisposeAsync() -> System.Threading.Tasks.ValueTask
-DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterKeyValueStore(DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions! options, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore!>? logger = null) -> void
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.TakeFullCheckpointAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.CheckpointInterval.get -> System.TimeSpan?

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.FasterKeyValueStore(DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions! options, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null) -> void
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.GetRecordsAsync(DataCore.Adapter.Services.KVKey? prefix = null) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.KeyValueStore.FASTER.FasterRecord>!
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStore.TakeIncrementalCheckpointAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
 DataCore.Adapter.KeyValueStore.FASTER.FasterKeyValueStoreOptions.EnableRawWrites.get -> bool


### PR DESCRIPTION
- `FasterKeyValueStore` now creates a logger for the underlying FASTER KV store.
- Updates various packages to their latest minor releases, including .NET runtime packages to their latest version 8.* versions and OpenTelemetry to 1.7.* versions.