### PR TITLE
Ensure that byte[] is always converted to ByteString

### DIFF
--- a/docs/release-notes/v3.1.0.md
+++ b/docs/release-notes/v3.1.0.md
@@ -7,6 +7,11 @@ Welcome to version 3.1.0 of the adapter toolkit for App Store Connect!
 This release contains the following breaking changes:
 
 
+## `Variant` changes
+
+A new [ByteString](../../src/DataCore.Adapter.Core/Common/ByteString.cs) type has been introduced to represent an immutable byte sequence. The [Variant](../../src/DataCore.Adapter.Core/Common/Variant.cs) type has been extended to provide first-class support for `ByteString` values. As a result of this, `Variant` instances created with `byte[]` values will now automatically convert the value to `ByteString` and set the `Type` property to `VariantType.ByteString`. The `ArrayDimensions` property on a `Variant` created using a `byte[]` is now `null` instead of specifying the dimensions of the original `byte[]`.
+
+
 ## `IKeyValueStore` changes
 
 The [IKeyValueStore](../../src/DataCore.Adapter.Abstractions/Services/IKeyValueStore.cs) service contract has changed: writing and reading values is now performed using generic `WriteAsync<T>(KVKey, T)` and `ReadAsync<T>(KVKey)` methods respectively, instead of writing and reading `byte[]` instances.
@@ -54,6 +59,8 @@ Additionally, the identifier that the adapter host uses in its OpenTelemetry tra
 # Upgrading from v3.0.0 to 3.1.0
 
 To upgrade from v3.0.0 to v3.1.0, you need to update your adapter toolkit package references to version 3.1.0.
+
+If your adapter returns data values constructed with `byte[]` values, note that the `Variant` type will now convert these values to `ByteString` internally.
 
 If you have written a custom `IKeyValueStore` implementation you will need to update your implementation to account for changes in the `IKeyValueStore` interface, and `KeyValueStore` and `KeyValueStore<TOptions>` base classes. Use the new `SerializeToBytesAsync`, `SerializeToStreamAsync`, `DeserializeFromBytesAsync` and `DeserializeFromStreamAsync` methods on `KeyValueStore` if your implementation needs to store and retrieve serialized values. If your implementation is derived from `KeyValueStore<TOptions>`, the default compression level and `JsonSerializerOptions` specified in `KeyValueStoreOptions` will be used in (de)serialization operations if the equivalent parameters in the `SerializeToXXX`/`DeserializeFromXXX` methods are not specified. 
 

--- a/src/DataCore.Adapter.Core/AssemblyAttributes.cs
+++ b/src/DataCore.Adapter.Core/AssemblyAttributes.cs
@@ -7,3 +7,6 @@
 // DataCore.Adapter.Json is allowed to use internals from this assembly so that it can correctly 
 // deserialize Variant instances.
 [assembly: InternalsVisibleTo("DataCore.Adapter.Json")]
+
+// Unit tests are allowed to use internals from this assembly.
+[assembly: InternalsVisibleTo("DataCore.Adapter.Tests")]

--- a/src/DataCore.Adapter.Core/Common/ByteString.cs
+++ b/src/DataCore.Adapter.Core/Common/ByteString.cs
@@ -49,14 +49,71 @@ namespace DataCore.Adapter.Common {
         /// <param name="bytes">
         ///   The byte sequence.
         /// </param>
-        public ByteString(byte[] bytes) {
+        public ByteString(byte[]? bytes) {
             Bytes = bytes ?? Array.Empty<byte>();
         }
 
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Creates a new <see cref="ByteString"/> instance.
+        /// </summary>
+        /// <param name="base64">
+        ///   The base64-encoded byte sequence.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="base64"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   <paramref name="base64"/> is not a valid base64-encoded string.
+        /// </exception>
+        public ByteString(string base64) {
+            if (base64 == null) {
+                throw new ArgumentNullException(nameof(base64));
+            }
+            Bytes = Convert.FromBase64String(base64);
+        }
+
+
+        /// <summary>
+        /// Tried to parse a base64-encoded string into a <see cref="ByteString"/> instance.
+        /// </summary>
+        /// <param name="base64">
+        ///   The base64-encoded byte sequence.
+        /// </param>
+        /// <param name="result">
+        ///   The parsed <see cref="ByteString"/> instance.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if parsing was successful; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool TryParse(string? base64, out ByteString result) {
+            if (string.IsNullOrWhiteSpace(base64)) {
+                result = default;
+                return false;
+            }
+
+            try {
+                result = new ByteString(base64);
+                return true;
+            }
+            catch (FormatException) {
+                result = default;
+                return false;
+            }
+        }
+
+
+        /// <summary>
+        /// Converts the <see cref="ByteString"/> to a base64-encoded string.
+        /// </summary>
+        /// <returns>
+        ///   The base64-encoded string.
+        /// </returns>
+        /// <remarks>
+        ///   If <see cref="IsEmpty"/> is <see langword="true"/>, an empty string is returned.
+        /// </remarks>
         public override string ToString() { 
-            if (Bytes.IsEmpty) {
+            if (IsEmpty) {
                 return string.Empty;
             }
 
@@ -104,13 +161,19 @@ namespace DataCore.Adapter.Common {
         public static implicit operator ByteString(ReadOnlyMemory<byte> bytes) => new ByteString(bytes);
 
         /// <inheritdoc/>
-        public static implicit operator ByteString(byte[] bytes) => new ByteString(bytes);
+        public static implicit operator ByteString(byte[]? bytes) => new ByteString(bytes);
 
         /// <inheritdoc/>
         public static implicit operator ReadOnlyMemory<byte>(ByteString bytes) => bytes.Bytes;
 
         /// <inheritdoc/>
         public static implicit operator byte[](ByteString bytes) => bytes.Bytes.ToArray();
+
+        /// <inheritdoc/>
+        public static bool operator ==(ByteString left, ByteString right) => left.Equals(right);
+
+        /// <inheritdoc/>
+        public static bool operator !=(ByteString left, ByteString right) => !left.Equals(right);
 
     }
 

--- a/src/DataCore.Adapter.Core/Common/ByteString.cs
+++ b/src/DataCore.Adapter.Core/Common/ByteString.cs
@@ -93,7 +93,7 @@ namespace DataCore.Adapter.Common {
             }
 
             try {
-                result = new ByteString(base64);
+                result = new ByteString(base64!);
                 return true;
             }
             catch (FormatException) {

--- a/src/DataCore.Adapter.Core/Common/Variant.Operators.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.Operators.cs
@@ -53,7 +53,11 @@ namespace DataCore.Adapter.Common {
         public static implicit operator Variant(byte[]? val) => new Variant(val);
 
         /// <inheritdoc/>
-        public static explicit operator byte[]?(Variant val) => (byte[]?) val.Value;
+        public static explicit operator byte[]?(Variant val) => val.Value is ByteString byteString 
+            ? byteString 
+            : val.Value is byte[] bytes 
+                ? bytes 
+                : null;
 
 
         /// <inheritdoc/>

--- a/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
@@ -15,7 +15,8 @@ DataCore.Adapter.AssetModel.FindAssetModelNodesRequest.PageSize.set -> void
 DataCore.Adapter.Common.ByteString
 DataCore.Adapter.Common.ByteString.Bytes.get -> System.ReadOnlyMemory<byte>
 DataCore.Adapter.Common.ByteString.ByteString() -> void
-DataCore.Adapter.Common.ByteString.ByteString(byte[]! bytes) -> void
+DataCore.Adapter.Common.ByteString.ByteString(byte[]? bytes) -> void
+DataCore.Adapter.Common.ByteString.ByteString(string! base64) -> void
 DataCore.Adapter.Common.ByteString.ByteString(System.ReadOnlyMemory<byte> bytes) -> void
 DataCore.Adapter.Common.ByteString.Equals(DataCore.Adapter.Common.ByteString other) -> bool
 DataCore.Adapter.Common.ByteString.IsEmpty.get -> bool
@@ -51,9 +52,12 @@ override DataCore.Adapter.Common.FindAdaptersRequest.Validate(System.ComponentMo
 override DataCore.Adapter.DataValidation.MaxUriLengthAttribute.FormatErrorMessage(string! name) -> string!
 static DataCore.Adapter.Common.ByteString.Empty.get -> DataCore.Adapter.Common.ByteString
 static DataCore.Adapter.Common.ByteString.implicit operator byte[]!(DataCore.Adapter.Common.ByteString bytes) -> byte[]!
-static DataCore.Adapter.Common.ByteString.implicit operator DataCore.Adapter.Common.ByteString(byte[]! bytes) -> DataCore.Adapter.Common.ByteString
+static DataCore.Adapter.Common.ByteString.implicit operator DataCore.Adapter.Common.ByteString(byte[]? bytes) -> DataCore.Adapter.Common.ByteString
 static DataCore.Adapter.Common.ByteString.implicit operator DataCore.Adapter.Common.ByteString(System.ReadOnlyMemory<byte> bytes) -> DataCore.Adapter.Common.ByteString
 static DataCore.Adapter.Common.ByteString.implicit operator System.ReadOnlyMemory<byte>(DataCore.Adapter.Common.ByteString bytes) -> System.ReadOnlyMemory<byte>
+static DataCore.Adapter.Common.ByteString.operator !=(DataCore.Adapter.Common.ByteString left, DataCore.Adapter.Common.ByteString right) -> bool
+static DataCore.Adapter.Common.ByteString.operator ==(DataCore.Adapter.Common.ByteString left, DataCore.Adapter.Common.ByteString right) -> bool
+static DataCore.Adapter.Common.ByteString.TryParse(string? base64, out DataCore.Adapter.Common.ByteString result) -> bool
 static DataCore.Adapter.Common.Variant.explicit operator DataCore.Adapter.Common.ByteString(DataCore.Adapter.Common.Variant val) -> DataCore.Adapter.Common.ByteString
 static DataCore.Adapter.Common.Variant.explicit operator DataCore.Adapter.Common.ByteString[]?(DataCore.Adapter.Common.Variant val) -> DataCore.Adapter.Common.ByteString[]?
 static DataCore.Adapter.Common.Variant.implicit operator DataCore.Adapter.Common.Variant(DataCore.Adapter.Common.ByteString val) -> DataCore.Adapter.Common.Variant

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -11,6 +11,7 @@ using DataCore.Adapter.Json;
 using DataCore.Adapter.RealTimeData;
 using DataCore.Adapter.Tags;
 
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DataCore.Adapter.Tests {
@@ -41,7 +42,7 @@ namespace DataCore.Adapter.Tests {
         private void VariantRoundTripTest<T>(T value, JsonSerializerOptions options) {
             var variant = Variant.FromValue(value);
             var json = JsonSerializer.Serialize(variant, options);
-            
+
             var deserialized = JsonSerializer.Deserialize<Variant>(json, options);
             Assert.AreEqual(variant.Type, deserialized.Type);
 
@@ -217,7 +218,7 @@ namespace DataCore.Adapter.Tests {
             var options = GetOptions();
             JsonElement ToJsonElement(string json) => JsonSerializer.Deserialize<JsonElement>(json, options);
 
-            
+
             if (values.Length == 1) {
                 VariantRoundTripTest(ToJsonElement(values[0]), options);
             }
@@ -331,27 +332,41 @@ namespace DataCore.Adapter.Tests {
 
         [TestMethod]
         public void Variant_MultidimensionalArrayShouldRoundTrip() {
-            var arr3d = new int[,,] { 
-                { 
-                    { 1, 2, 3 }, 
-                    { 4, 5, 6 } 
-                }, 
-                { 
-                    { 7, 8, 9 }, 
-                    { 10, 11, 12 } 
-                }, 
-                { 
-                    { 13, 14, 15 }, 
-                    { 16, 17, 18 } 
-                }, 
-                { 
-                    { 19, 20, 21 }, 
-                    { 22, 23, 24 } 
-                } 
+            var arr3d = new int[,,] {
+                {
+                    { 1, 2, 3 },
+                    { 4, 5, 6 }
+                },
+                {
+                    { 7, 8, 9 },
+                    { 10, 11, 12 }
+                },
+                {
+                    { 13, 14, 15 },
+                    { 16, 17, 18 }
+                },
+                {
+                    { 19, 20, 21 },
+                    { 22, 23, 24 }
+                }
             };
 
             VariantRoundTripTest(arr3d, GetOptions());
 
+        }
+
+
+        [TestMethod]
+        public void Variant_LegacyByteArrayShouldDeserializeAsByteString() {
+            var variant = new Variant(new byte[] { 0, 127, 136, 254 }, VariantType.Byte, new[] { 4 });
+            var options = GetOptions();
+
+            var json = JsonSerializer.Serialize(variant, options);
+
+            var deserialized = JsonSerializer.Deserialize<Variant>(json, options);
+
+            Assert.AreEqual(VariantType.ByteString, deserialized.Type);
+            Assert.AreEqual(new ByteString((byte[]) variant.Value), (ByteString) deserialized.Value);
         }
 
 


### PR DESCRIPTION
This PR ensures that `byte[]` is always converted to `ByteString` internally when constructing new `Variant` instances.

`Variant` instances containing 1-dimensional `byte[]` instances serialized by older versions of the toolkit will have these values converted to `ByteString` on deserialization.