### PR TITLE
Cache and re-use ScopedLogger instances

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AdapterCore.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterCore.cs
@@ -195,7 +195,7 @@ namespace DataCore.Adapter {
             
             LoggerFactory = new WrapperLoggerFactory(new ScopedLogger(logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance, new Dictionary<string, object?>() {
                 ["AdapterId"] = Descriptor.Id
-            }));
+            }, null));
 
             _logger = LoggerFactory.CreateLogger<AdapterCore>();
 

--- a/src/DataCore.Adapter.Abstractions/Logging/ScopedLogger.cs
+++ b/src/DataCore.Adapter.Abstractions/Logging/ScopedLogger.cs
@@ -24,6 +24,11 @@ namespace DataCore.Adapter.Logging {
         /// </summary>
         private readonly IDisposable? _scope;
 
+        /// <summary>
+        /// Invoked when the logger is disposed.
+        /// </summary>
+        private readonly Action _onDisposed;
+
 
         /// <summary>
         /// Creates a new <see cref="ScopedLogger"/> instance.
@@ -34,9 +39,13 @@ namespace DataCore.Adapter.Logging {
         /// <param name="scope">
         ///   The scope data to add to each log message.
         /// </param>
-        internal ScopedLogger(ILogger logger, object scope) {
+        /// <param name="onDisposed">
+        ///   Invoked when the logger is disposed.
+        /// </param>
+        internal ScopedLogger(ILogger logger, object scope, Action onDisposed) {
             _logger = logger;
             _scope = _logger.BeginScope(scope);
+            _onDisposed = onDisposed;
         }
 
 
@@ -65,6 +74,8 @@ namespace DataCore.Adapter.Logging {
             }
 
             _scope?.Dispose();
+            _onDisposed.Invoke();
+
             _disposed = true;
         }
 

--- a/src/DataCore.Adapter.Abstractions/Logging/ScopedLogger.cs
+++ b/src/DataCore.Adapter.Abstractions/Logging/ScopedLogger.cs
@@ -27,7 +27,7 @@ namespace DataCore.Adapter.Logging {
         /// <summary>
         /// Invoked when the logger is disposed.
         /// </summary>
-        private readonly Action _onDisposed;
+        private readonly Action? _onDisposed;
 
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace DataCore.Adapter.Logging {
         /// <param name="onDisposed">
         ///   Invoked when the logger is disposed.
         /// </param>
-        internal ScopedLogger(ILogger logger, object scope, Action onDisposed) {
+        internal ScopedLogger(ILogger logger, object scope, Action? onDisposed) {
             _logger = logger;
             _scope = _logger.BeginScope(scope);
             _onDisposed = onDisposed;
@@ -74,7 +74,7 @@ namespace DataCore.Adapter.Logging {
             }
 
             _scope?.Dispose();
-            _onDisposed.Invoke();
+            _onDisposed?.Invoke();
 
             _disposed = true;
         }

--- a/src/DataCore.Adapter.Abstractions/Logging/ScopedLoggerFactory.cs
+++ b/src/DataCore.Adapter.Abstractions/Logging/ScopedLoggerFactory.cs
@@ -91,6 +91,7 @@ namespace DataCore.Adapter.Logging {
             }
 
             _loggers.Clear();
+            _disposed = true;
         }
 
     }


### PR DESCRIPTION
This PR caches `ScopedLogger` instances created by `ScopedLoggerFactory` by category name and re-uses an existing instance when `ILoggerFactory.CreateLogger` is called.