### PR TITLE
Add readme files to all NuGet packages

### DIFF
--- a/src/DataCore.Adapter.Abstractions/DataCore.Adapter.Abstractions.csproj
+++ b/src/DataCore.Adapter.Abstractions/DataCore.Adapter.Abstractions.csproj
@@ -5,6 +5,7 @@
     <LangVersion>9.0</LangVersion>
     <RootNamespace>DataCore.Adapter</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Abstractions</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Base types for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -50,6 +51,10 @@
       <LastGenOutput>AdapterEventSourceResources.Designer.cs</LastGenOutput>
       <Generator>ResXFileCodeGenerator</Generator>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Abstractions/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Abstractions/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Abstractions contains interfaces and base types used when implementing App Store Connect adapters.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.Common</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Common ASP.NET Core types for hosting App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -36,6 +37,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
   
 </Project>

--- a/src/DataCore.Adapter.AspNetCore.Common/PACKAGE_README.md
+++ b/src/DataCore.Adapter.AspNetCore.Common/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.Common defines common types and services used when hosting App Store Connect adapters in an ASP.NET Core application.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.AspNetCore.Grpc/DataCore.Adapter.AspNetCore.Grpc.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/DataCore.Adapter.AspNetCore.Grpc.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.Grpc</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>ASP.NET Core types for hosting App Store Connect adapter gRPC services.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -40,6 +41,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.AspNetCore.Grpc/PACKAGE_README.md
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.Grpc defines gRPC services for querying App Store Connect adapters hosted in an ASP.NET Core application.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.AspNetCore.HealthChecks/DataCore.Adapter.AspNetCore.HealthChecks.csproj
+++ b/src/DataCore.Adapter.AspNetCore.HealthChecks/DataCore.Adapter.AspNetCore.HealthChecks.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.HealthChecks</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>ASP.NET Core health checks for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -26,6 +27,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.AspNetCore.HealthChecks/PACKAGE_README.md
+++ b/src/DataCore.Adapter.AspNetCore.HealthChecks/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.HealthChecks defines health checks for App Store Connect adapters hosted in an ASP.NET Core application.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/DataCore.Adapter.AspNetCore.MinimalApi.csproj
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/DataCore.Adapter.AspNetCore.MinimalApi.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.MinimalApi</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>ASP.NET Core types for hosting App Store Connect adapter APIs.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -35,6 +36,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/PACKAGE_README.md
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.MinimalApi defines Minimal API routes for querying App Store Connect adapters hosted in an ASP.NET Core application.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.AspNetCore.Mvc/DataCore.Adapter.AspNetCore.Mvc.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/DataCore.Adapter.AspNetCore.Mvc.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.Mvc</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>ASP.NET Core types for hosting App Store Connect adapter MVC controllers.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -26,6 +27,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/PACKAGE_README.md
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.Mvc defines MVC API controllers for querying App Store Connect adapters hosted in an ASP.NET Core application.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/DataCore.Adapter.AspNetCore.SignalR.Client.csproj
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/DataCore.Adapter.AspNetCore.SignalR.Client.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net48</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.SignalR.Client</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>ASP.NET Core SignalR for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -35,6 +36,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/PACKAGE_README.md
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.SignalR.Client contains a strongly-typed client for querying hosted App Store Connect adapters using ASP.NET Core SignalR.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/DataCore.Adapter.AspNetCore.SignalR.Proxy.csproj
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/DataCore.Adapter.AspNetCore.SignalR.Proxy.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.SignalR.Proxy</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>App Store Connect adapter proxy using ASP.NET Core SignalR.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -31,6 +32,10 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\VendorInfo.cs" Link="VendorInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/PACKAGE_README.md
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.SignalR.Proxy contains a proxy for querying a hosted App Store Connect adapter using ASP.NET Core SignalR.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.AspNetCore.SignalR/DataCore.Adapter.AspNetCore.SignalR.csproj
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/DataCore.Adapter.AspNetCore.SignalR.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.SignalR</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>ASP.NET Core SignalR hubs for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -26,6 +27,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.AspNetCore.SignalR/PACKAGE_README.md
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.SignalR defines SignalR hubs for querying App Store Connect adapters hosted in an ASP.NET Core application.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Compatibility/DataCore.Adapter.Compatibility.csproj
+++ b/src/DataCore.Adapter.Compatibility/DataCore.Adapter.Compatibility.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
     <RootNamespace>DataCore.Adapter</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Compatibility</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Compatibility shims for $(PackagePrefix).Adapter when running on .NET Framework.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -11,6 +12,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Threading.Channels" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Compatibility/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Compatibility/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Compatibility provides compatibility shims for [IntelligentPlant.AppStoreConnect.Adapter](https://www.nuget.org/packages/IntelligentPlant.AppStoreConnect.Adapter) when running on .NET Framework.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
+++ b/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
@@ -5,6 +5,7 @@
     <LangVersion>9.0</LangVersion>
     <RootNamespace>DataCore.Adapter</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Core</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Base types for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -33,6 +34,10 @@
       <LastGenOutput>SharedResources.Designer.cs</LastGenOutput>
       <CustomToolNamespace>DataCore.Adapter</CustomToolNamespace>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Core/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Core/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Core contains DTOs used in App Store Connect adapters.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Csv/DataCore.Adapter.Csv.csproj
+++ b/src/DataCore.Adapter.Csv/DataCore.Adapter.Csv.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.Csv</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>App Store Connect adapter that serves data from CSV files.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -33,6 +34,10 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\VendorInfo.cs" Link="VendorInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Csv/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Csv/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Csv contains an App Store Connect adapter that loads time series data from a CSV file.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.DependencyInjection/DataCore.Adapter.DependencyInjection.csproj
+++ b/src/DataCore.Adapter.DependencyInjection/DataCore.Adapter.DependencyInjection.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.DependencyInjection</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>App Store Connect types for use with Microsoft.Extensions.DependencyInjection.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -14,6 +15,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DataCore.Adapter\DataCore.Adapter.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
   
 </Project>

--- a/src/DataCore.Adapter.DependencyInjection/PACKAGE_README.md
+++ b/src/DataCore.Adapter.DependencyInjection/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.DependencyInjection contains extensions for Microsoft.Extensions.DependencyInjection to register common services used in App Store Connect adapters.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Grpc.Client/DataCore.Adapter.Grpc.Client.csproj
+++ b/src/DataCore.Adapter.Grpc.Client/DataCore.Adapter.Grpc.Client.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.Grpc.Client</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>gRPC client for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -29,6 +30,10 @@
 
   <ItemGroup>
     <Compile Include="..\DataCore.Adapter.AspNetCore.Grpc\GrpcExtensions.cs" Link="GrpcExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
   
 </Project>

--- a/src/DataCore.Adapter.Grpc.Client/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Grpc.Client/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Grpc.Client contains a strongly-typed client for querying hosted App Store Connect adapters using gRPC. Note that .NET Framework compatibility is subject to Microsoft's constraints as described [here](https://learn.microsoft.com/en-us/aspnet/core/grpc/netstandard#net-framework).
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Grpc.Proxy/DataCore.Adapter.Grpc.Proxy.csproj
+++ b/src/DataCore.Adapter.Grpc.Proxy/DataCore.Adapter.Grpc.Proxy.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.Grpc.Proxy</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>App Store Connect adapter proxy using gRPC.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -31,6 +32,10 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\VendorInfo.cs" Link="VendorInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Grpc.Proxy/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Grpc.Proxy/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Grpc.Proxy contains a proxy for querying a hosted App Store Connect adapter using gRPC. Note that .NET Framework compatibility is subject to Microsoft's constraints as described [here](https://learn.microsoft.com/en-us/aspnet/core/grpc/netstandard#net-framework).
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Http.Client/DataCore.Adapter.Http.Client.csproj
+++ b/src/DataCore.Adapter.Http.Client/DataCore.Adapter.Http.Client.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net48</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.Http.Client</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>HTTP client for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -34,6 +35,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
   
 </Project>

--- a/src/DataCore.Adapter.Http.Client/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Http.Client/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Http.Client contains a strongly-typed client for querying hosted App Store Connect adapters using HTTP.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Http.Proxy/DataCore.Adapter.Http.Proxy.csproj
+++ b/src/DataCore.Adapter.Http.Proxy/DataCore.Adapter.Http.Proxy.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.Http.Proxy</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>App Store Connect adapter proxy using HTTP.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -32,6 +33,10 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\VendorInfo.cs" Link="VendorInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Http.Proxy/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Http.Proxy/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Http.Proxy contains a proxy for querying a hosted App Store Connect adapter using HTTP.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Json.Newtonsoft/DataCore.Adapter.Json.Newtonsoft.csproj
+++ b/src/DataCore.Adapter.Json.Newtonsoft/DataCore.Adapter.Json.Newtonsoft.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.NewtonsoftJson</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Json.Newtonsoft</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Newtonsoft.Json extensions for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -14,6 +15,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DataCore.Adapter.Core\DataCore.Adapter.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Json.Newtonsoft/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Json.Newtonsoft/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Json.Newtonsoft contains JSON converters for Newtonsoft.Json for DTOs used in App Store Connect adapters.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/DataCore.Adapter.KeyValueStore.FASTER.csproj
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/DataCore.Adapter.KeyValueStore.FASTER.csproj
@@ -5,6 +5,7 @@
     <LangVersion>9.0</LangVersion>
     <RootNamespace>DataCore.Adapter.KeyValueStore.FASTER</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.KeyValueStore.FASTER</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Key-value store for App Store Connect adapters using Microsoft FASTER.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -31,6 +32,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.KeyValueStore.FASTER/PACKAGE_README.md
+++ b/src/DataCore.Adapter.KeyValueStore.FASTER/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.KeyValueStore.FASTER provides a key-value store based on [Microsoft FASTER](https://github.com/microsoft/FASTER) for use in App Store Connect adapters.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/DataCore.Adapter.KeyValueStore.FileSystem.csproj
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/DataCore.Adapter.KeyValueStore.FileSystem.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.KeyValueStore.FileSystem</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.KeyValueStore.FileSystem</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>File system-based key-value store for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -30,6 +31,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.KeyValueStore.FileSystem/PACKAGE_README.md
+++ b/src/DataCore.Adapter.KeyValueStore.FileSystem/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.KeyValueStore.FileSystem provides a file system-based key-value store for use in App Store Connect adapters.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/DataCore.Adapter.KeyValueStore.Sqlite.csproj
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/DataCore.Adapter.KeyValueStore.Sqlite.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.KeyValueStore.Sqlite</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.KeyValueStore.Sqlite</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Sqlite key-value store for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -29,6 +30,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.KeyValueStore.Sqlite/PACKAGE_README.md
+++ b/src/DataCore.Adapter.KeyValueStore.Sqlite/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.KeyValueStore.Sqlite provides a key-value store based on [Microsoft.Data.Sqlite](https://learn.microsoft.com/en-us/dotnet/standard/data/sqlite) for use in App Store Connect adapters.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.OpenTelemetry/DataCore.Adapter.OpenTelemetry.csproj
+++ b/src/DataCore.Adapter.OpenTelemetry/DataCore.Adapter.OpenTelemetry.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.Diagnostics</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.OpenTelemetry</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Helper classes for enabling OpenTelemetry instrumentation in App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -14,6 +15,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DataCore.Adapter.Abstractions\DataCore.Adapter.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.OpenTelemetry/PACKAGE_README.md
+++ b/src/DataCore.Adapter.OpenTelemetry/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.OpenTelemetry defines extension methods for registering App Store Connect adapter services, trace sources and metrics with OpenTelemetry builders.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Proxy/DataCore.Adapter.Proxy.csproj
+++ b/src/DataCore.Adapter.Proxy/DataCore.Adapter.Proxy.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.Proxy</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>App Store Connect adapter proxy support library.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -14,6 +15,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DataCore.Adapter\DataCore.Adapter.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Proxy/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Proxy/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Proxy contains supporting types for implementing App Store Connect adapter proxies. Note that this package will be deprecated in a future release.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Templates/DataCore.Adapter.Templates.csproj
+++ b/src/DataCore.Adapter.Templates/DataCore.Adapter.Templates.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>$(PackagePrefix).Adapter.Templates</PackageId>
     <PackageType>Template</PackageType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <DefaultNetCoreTargetFramework>net6.0</DefaultNetCoreTargetFramework>
     <Title>App Store Connect Adapter Templates</Title>
     <Description>Templates to use when creating an adapter for Intelligent Plant App Store Connect.</Description>
@@ -64,5 +65,9 @@
     <!-- Ensure that the example hosted adapter project specifies the package versions defined by Central Package Management. -->
     <Exec Command="$(_PowerShellExe) -NoLogo -NonInteractive $(_ExecutionPolicy) -File &quot;$(_PowerShellScriptPath)&quot; -ProjectFile &quot;$(_ProjectFilePath)&quot; -PackageVersionsFile &quot;$(_PackageVersionsFile)&quot; -DefaultPackageVersion &quot;$(_DefaultPackageVersion)&quot;" />
   </Target>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
+  </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.Templates/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Templates/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Templates contains templates for `dotnet new` and Visual Studio for creating App Store Connect adapter projects.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
+++ b/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.Tests</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Tests.Helpers</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Base MSTest test classes for testing App Store Connect adapters.</Description>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -40,6 +41,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
   
 </Project>

--- a/src/DataCore.Adapter.Tests.Helpers/PACKAGE_README.md
+++ b/src/DataCore.Adapter.Tests.Helpers/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Tests.Helpers provides a base set of MSTest unit tests to use when writing an App Store Connect adapter.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter.WaveGenerator/DataCore.Adapter.WaveGenerator.csproj
+++ b/src/DataCore.Adapter.WaveGenerator/DataCore.Adapter.WaveGenerator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.WaveGenerator</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>App Store Connect adapter that generates simulated wave data.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -29,6 +30,10 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter.WaveGenerator/PACKAGE_README.md
+++ b/src/DataCore.Adapter.WaveGenerator/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter.Csv contains an App Store Connect adapter that generates time series data using sinusoid, sawtooth, square and triangle wave functions.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).

--- a/src/DataCore.Adapter/DataCore.Adapter.csproj
+++ b/src/DataCore.Adapter/DataCore.Adapter.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.1;netstandard2.0;net48</TargetFrameworks>
     <RootNamespace>DataCore.Adapter</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Base implementations and utility classes for App Store Connect adapters.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -46,6 +47,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PACKAGE_README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/DataCore.Adapter/PACKAGE_README.md
+++ b/src/DataCore.Adapter/PACKAGE_README.md
@@ -1,0 +1,7 @@
+﻿# About
+
+IntelligentPlant.AppStoreConnect.Adapter contains base implementations and utility classes to simplify the implementiion of App Store Connect adapters.
+
+App Store Connect adapters allow you to easily connect your own custom data sources to the Intelligent Plant [Industrial App Store](https://appstore.intelligentplant.com/) platform.
+
+For more information about writing custom adapters, [visit the GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters/).


### PR DESCRIPTION
Closes #309

The added READMEs are very lightweight for now and for the most part give a brief overview and a link to the GitHub repository; can consider adding more details to them at a later date.