### PR TITLE
Full gRPC support when running on .NET Framework on Windows 11

### DIFF
--- a/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.cs
@@ -24,5 +24,69 @@ namespace DataCore.Adapter.Grpc.Proxy.Events {
         /// </param>
         public EventMessagePushWithTopicsImpl(GrpcAdapterProxy proxy) : base(proxy) { }
 
+
+        private async IAsyncEnumerable<Adapter.Events.EventMessage> SubscribeCoreAsync(
+            IAdapterCallContext context,
+            CreateEventMessageTopicSubscriptionRequest request,
+            IAsyncEnumerable<EventMessageSubscriptionUpdate> channel,
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            var client = CreateClient<EventsService.EventsServiceClient>();
+
+            var createSubscriptionMessage = new CreateEventTopicPushChannelMessage() {
+                AdapterId = AdapterId,
+                SubscriptionType = request.SubscriptionType == EventMessageSubscriptionType.Active
+                    ? EventSubscriptionType.Active
+                    : EventSubscriptionType.Passive
+            };
+            createSubscriptionMessage.Topics.Add(request.Topics?.Where(x => x != null) ?? Array.Empty<string>());
+            if (request.Properties != null) {
+                foreach (var item in request.Properties) {
+                    createSubscriptionMessage.Properties.Add(item.Key, item.Value ?? string.Empty);
+                }
+            }
+
+            using (var grpcStream = client.CreateEventTopicPushChannel(GetCallOptions(context, cancellationToken))) {
+
+                // Create the subscription.
+                await grpcStream.RequestStream.WriteAsync(new CreateEventTopicPushChannelRequest() {
+                    Create = createSubscriptionMessage
+                }).ConfigureAwait(false);
+
+                // Stream subscription changes.
+                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
+                    await foreach (var update in channel.WithCancellation(ct).ConfigureAwait(false)) {
+                        if (update == null) {
+                            continue;
+                        }
+
+                        var msg = new UpdateEventTopicPushChannelMessage() {
+                            Action = update.Action == Common.SubscriptionUpdateAction.Subscribe
+                                ? SubscriptionUpdateAction.Subscribe
+                                : SubscriptionUpdateAction.Unsubscribe
+                        };
+                        msg.Topics.Add(update.Topics.Where(x => x != null));
+                        if (msg.Topics.Count == 0) {
+                            continue;
+                        }
+
+                        await grpcStream.RequestStream.WriteAsync(new CreateEventTopicPushChannelRequest() {
+                            Update = msg
+                        }).ConfigureAwait(false);
+                    }
+                }, cancellationToken);
+
+                // Stream the results.
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                    if (grpcStream.ResponseStream.Current == null) {
+                        continue;
+                    }
+
+                    yield return grpcStream.ResponseStream.Current.ToAdapterEventMessage();
+                }
+            }
+        }
+
     }
 }

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.netfx.cs
@@ -136,6 +136,16 @@ namespace DataCore.Adapter.Grpc.Proxy.Events {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
+            if (GrpcAdapterProxy.IsGrpcClientFullySupported()) {
+                // Bidirectional streaming is fully supported.
+                await foreach (var item in SubscribeCoreAsync(context, request, channel, cancellationToken).ConfigureAwait(false)) {
+                    yield return item;
+                }
+                yield break;
+            }
+
+            // Bidirectional streaming is not supported.
+
             var client = CreateClient<EventsService.EventsServiceClient>();
 
             using var handler = CreateInnerHandler(context, client, request, cancellationToken);

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.netstandard.cs
@@ -5,78 +5,22 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 
 using DataCore.Adapter.Events;
 
-using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.Grpc.Proxy.Events {
 
     partial class EventMessagePushWithTopicsImpl {
 
         /// <inheritdoc/>
-        public async IAsyncEnumerable<Adapter.Events.EventMessage> Subscribe(
+        public IAsyncEnumerable<Adapter.Events.EventMessage> Subscribe(
             IAdapterCallContext context,
             CreateEventMessageTopicSubscriptionRequest request,
             IAsyncEnumerable<EventMessageSubscriptionUpdate> channel,
-            [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var client = CreateClient<EventsService.EventsServiceClient>();
-
-            var createSubscriptionMessage = new CreateEventTopicPushChannelMessage() {
-                AdapterId = AdapterId,
-                SubscriptionType = request.SubscriptionType == EventMessageSubscriptionType.Active
-                    ? EventSubscriptionType.Active
-                    : EventSubscriptionType.Passive
-            };
-            createSubscriptionMessage.Topics.Add(request.Topics?.Where(x => x != null) ?? Array.Empty<string>());
-            if (request.Properties != null) {
-                foreach (var item in request.Properties) {
-                    createSubscriptionMessage.Properties.Add(item.Key, item.Value ?? string.Empty);
-                }
-            }
-
-            using (var grpcStream = client.CreateEventTopicPushChannel(GetCallOptions(context, cancellationToken))) {
-
-                // Create the subscription.
-                await grpcStream.RequestStream.WriteAsync(new CreateEventTopicPushChannelRequest() {
-                    Create = createSubscriptionMessage
-                }).ConfigureAwait(false);
-
-                // Stream subscription changes.
-                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
-                    await foreach (var update in channel.WithCancellation(ct).ConfigureAwait(false)) {
-                        if (update == null) {
-                            continue;
-                        }
-
-                        var msg = new UpdateEventTopicPushChannelMessage() {
-                            Action = update.Action == Common.SubscriptionUpdateAction.Subscribe
-                                ? SubscriptionUpdateAction.Subscribe
-                                : SubscriptionUpdateAction.Unsubscribe
-                        };
-                        msg.Topics.Add(update.Topics.Where(x => x != null));
-                        if (msg.Topics.Count == 0) {
-                            continue;
-                        }
-
-                        await grpcStream.RequestStream.WriteAsync(new CreateEventTopicPushChannelRequest() {
-                            Update = msg
-                        }).ConfigureAwait(false);
-                    }
-                }, cancellationToken);
-
-                // Stream the results.
-                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
-                    if (grpcStream.ResponseStream.Current == null) {
-                        continue;
-                    }
-
-                    yield return grpcStream.ResponseStream.Current.ToAdapterEventMessage();
-                }
-            }
+            return SubscribeCoreAsync(context, request, channel, cancellationToken);
         }
 
     }

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.cs
@@ -1,4 +1,11 @@
-﻿using DataCore.Adapter.Events;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.Events;
+
+using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
 
@@ -14,6 +21,53 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
         ///   The proxy that owns the instance.
         /// </param>
         public WriteEventMessagesImpl(GrpcAdapterProxy proxy) : base(proxy) { }
+
+
+        private async IAsyncEnumerable<Adapter.Events.WriteEventMessageResult> WriteEventMessagesCoreAsync(
+            IAdapterCallContext context,
+            Adapter.Events.WriteEventMessagesRequest request,
+            IAsyncEnumerable<Adapter.Events.WriteEventMessageItem> channel,
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            var client = CreateClient<EventsService.EventsServiceClient>();
+
+            using (var grpcStream = client.WriteEventMessages(GetCallOptions(context, cancellationToken))) {
+
+                // Create the subscription.
+                var initMessage = new WriteEventMessageInitMessage() {
+                    AdapterId = AdapterId
+                };
+
+                if (request.Properties != null) {
+                    foreach (var prop in request.Properties) {
+                        initMessage.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                    }
+                }
+
+                await grpcStream.RequestStream.WriteAsync(new WriteEventMessageRequest() {
+                    Init = initMessage
+                }).ConfigureAwait(false);
+
+                // Run a background task to stream the values to write.
+                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
+                    try {
+                        await foreach (var item in channel.WithCancellation(ct).ConfigureAwait(false)) {
+                            await grpcStream.RequestStream.WriteAsync(new WriteEventMessageRequest() {
+                                Write = item.ToGrpcWriteEventMessageItem()
+                            }).ConfigureAwait(false);
+                        }
+                    }
+                    finally {
+                        await grpcStream.RequestStream.CompleteAsync().ConfigureAwait(false);
+                    }
+                }, cancellationToken);
+
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                    yield return grpcStream.ResponseStream.Current.ToAdapterWriteEventMessageResult();
+                }
+            }
+        }
 
     }
 }

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.netfx.cs
@@ -17,6 +17,16 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
+            if (GrpcAdapterProxy.IsGrpcClientFullySupported()) {
+                // Bidrectional streaming is fully supported.
+                await foreach (var item in WriteEventMessagesCoreAsync(context, request, channel, cancellationToken).ConfigureAwait(false)) {
+                    yield return item;
+                }
+                yield break;
+            }
+
+            // Bidirectional streaming is not supported.
+
             var client = CreateClient<EventsService.EventsServiceClient>();
 
             var callOptions = GetCallOptions(context, cancellationToken);

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/WriteEventMessagesImpl.netstandard.cs
@@ -10,50 +10,13 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
     partial class WriteEventMessagesImpl {
 
         /// <inheritdoc/>
-        public async IAsyncEnumerable<Adapter.Events.WriteEventMessageResult> WriteEventMessages(
+        public IAsyncEnumerable<Adapter.Events.WriteEventMessageResult> WriteEventMessages(
             IAdapterCallContext context,
             Adapter.Events.WriteEventMessagesRequest request,
             IAsyncEnumerable<Adapter.Events.WriteEventMessageItem> channel,
-            [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var client = CreateClient<EventsService.EventsServiceClient>();
-
-            using (var grpcStream = client.WriteEventMessages(GetCallOptions(context, cancellationToken))) {
-
-                // Create the subscription.
-                var initMessage = new WriteEventMessageInitMessage() {
-                    AdapterId = AdapterId
-                };
-
-                if (request.Properties != null) {
-                    foreach (var prop in request.Properties) {
-                        initMessage.Properties.Add(prop.Key, prop.Value ?? string.Empty);
-                    }
-                }
-
-                await grpcStream.RequestStream.WriteAsync(new WriteEventMessageRequest() {
-                    Init = initMessage
-                }).ConfigureAwait(false);
-
-                // Run a background task to stream the values to write.
-                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
-                    try {
-                        await foreach (var item in channel.WithCancellation(ct).ConfigureAwait(false)) {
-                            await grpcStream.RequestStream.WriteAsync(new WriteEventMessageRequest() {
-                                Write = item.ToGrpcWriteEventMessageItem()
-                            }).ConfigureAwait(false);
-                        }
-                    }
-                    finally {
-                        await grpcStream.RequestStream.CompleteAsync().ConfigureAwait(false);
-                    }
-                }, cancellationToken);
-
-                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
-                    yield return grpcStream.ResponseStream.Current.ToAdapterWriteEventMessageResult();
-                }
-            }
+            return WriteEventMessagesCoreAsync(context, request, channel, cancellationToken);
         }
 
     }

--- a/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.netfx.cs
@@ -96,7 +96,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
         /// <summary>
         /// Describes a Windows product type.
         /// </summary>
-        public enum PRODUCT_TYPE {
+        internal enum PRODUCT_TYPE {
             VER_NT_WORKSTATION = 0x0000001,
             VER_NT_DOMAIN_CONTROLLER = 0x0000002,
             VER_NT_SERVER = 0x0000003
@@ -104,7 +104,7 @@ namespace DataCore.Adapter.Grpc.Proxy {
 
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        struct OSVERSIONINFOEXW {
+        internal struct OSVERSIONINFOEXW {
             public int dwOSVersionInfoSize;
             public int dwMajorVersion;
             public int dwMinorVersion;

--- a/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/GrpcAdapterProxy.netfx.cs
@@ -1,0 +1,127 @@
+﻿#if NETFRAMEWORK
+using System;
+using System.Runtime.InteropServices;
+
+namespace DataCore.Adapter.Grpc.Proxy {
+
+    partial class GrpcAdapterProxy {
+
+        /// <summary>
+        /// Specifies if .NET Framework has full support for gRPC clients on the current 
+        /// operating system.
+        /// </summary>
+        private static bool? s_isGrpcClientFullySupported;
+
+
+        /// <summary>
+        /// Determines if .NET Framework has full support for gRPC clients.
+        /// </summary>
+        /// <returns>
+        ///   <see langword="true"/> if .NET Framework has full support for gRPC clients; 
+        ///   otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   .NET Framework has limited support for gRPC clients on some Windows versions.
+        /// </para>
+        /// 
+        /// <para>
+        ///   See <a href="https://learn.microsoft.com/en-us/aspnet/core/grpc/netstandard#net-framework">here</a> 
+        ///   for more information about gRPC support on .NET Framework.
+        /// </para>
+        /// 
+        /// </remarks>
+        internal static bool IsGrpcClientFullySupported() {
+            return s_isGrpcClientFullySupported ??= IsGrpcClientFullySupportedCore();
+        }
+
+
+        /// <summary>
+        /// Determines if .NET Framework has full support for gRPC clients.
+        /// </summary>
+        private static bool IsGrpcClientFullySupportedCore() {
+            var windowsVersion = GetWindowsVersion(out var isServer);
+
+            // Windows 11 is required for full support on workstation versions of Windows.
+            // No Windows Server versions are supported at time of writing (April 2024).
+
+            if (isServer) {
+                return false;
+            }
+
+            // Version number for Windows 11.
+            var minWorkstationVersion = new Version(10, 0, 22000);
+            return windowsVersion >= minWorkstationVersion;
+        }
+
+
+        /// <summary>
+        /// Gets the version of Windows that Data Core is running on.
+        /// </summary>
+        /// <param name="isServer">
+        ///   <see langword="true"/> if the operating system is a server version of Windows (e.g. 
+        ///   Windows Server 2022), or <see langword="false"/> if it is a workstation version of 
+        ///   Windows (e.g. Windows 11).
+        /// </param>
+        /// <returns>
+        ///   The Windows version.
+        /// </returns>
+        /// <exception cref="COMException">
+        ///   An error occurred while retrieving the Windows version.
+        /// </exception>
+        /// <remarks>
+        ///   This method uses P/Invoke to call <c>RtlGetVersion</c> via the Windows API.
+        /// </remarks>
+        /// <seealso href="https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlgetversion"/>
+        private static Version GetWindowsVersion(out bool isServer) {
+            var osvi = default(OSVERSIONINFOEXW);
+            osvi.dwOSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEXW));
+            var result = RtlGetVersion(ref osvi);
+            if (result != 0) {
+                throw new COMException("Error retrieving Windows version.", result);
+            }
+            else {
+                isServer = osvi.wProductType != PRODUCT_TYPE.VER_NT_WORKSTATION;
+                return new Version(osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
+            }
+        }
+
+        #region [ P/Invoke Types and Declarations ]
+
+        [DllImport("ntdll.dll", SetLastError = true)]
+        static extern int RtlGetVersion(ref OSVERSIONINFOEXW versionInfo);
+
+
+        /// <summary>
+        /// Describes a Windows product type.
+        /// </summary>
+        public enum PRODUCT_TYPE {
+            VER_NT_WORKSTATION = 0x0000001,
+            VER_NT_DOMAIN_CONTROLLER = 0x0000002,
+            VER_NT_SERVER = 0x0000003
+        }
+
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        struct OSVERSIONINFOEXW {
+            public int dwOSVersionInfoSize;
+            public int dwMajorVersion;
+            public int dwMinorVersion;
+            public int dwBuildNumber;
+            public int dwPlatformId;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string szCSDVersion;
+            public ushort wServicePackMajor;
+            public ushort wServicePackMinor;
+            public ushort wSuiteMask;
+            public PRODUCT_TYPE wProductType;
+            public byte wReserved;
+        }
+
+        #endregion
+
+    }
+
+}
+#endif

--- a/src/DataCore.Adapter.Grpc.Proxy/README.md
+++ b/src/DataCore.Adapter.Grpc.Proxy/README.md
@@ -30,7 +30,7 @@ var channel = Grpc.Net.Client.GrpcChannel.ForAddress("https://localhost:5001", n
 });
 ```
 
-> Grpc.Net.Client on .NET Framework does not support duplex streaming calls. Adapter operations that normally use duplex streaming such as tag value subscriptions and writes are translated into unary or server streaming invocations by the proxy.
+> Grpc.Net.Client on .NET Framework has limited suuport for bidirectional and client streaming calls on some versions of Windows. Adapter operations that normally use bidirectional streaming such as tag value subscriptions and writes are translated into unary or server streaming invocations by the proxy if the underlying version of Windows does not provide full gRPC client support.
 
 
 # Using the Proxy

--- a/src/DataCore.Adapter.Grpc.Proxy/README.md
+++ b/src/DataCore.Adapter.Grpc.Proxy/README.md
@@ -30,7 +30,7 @@ var channel = Grpc.Net.Client.GrpcChannel.ForAddress("https://localhost:5001", n
 });
 ```
 
-> Grpc.Net.Client on .NET Framework has limited suuport for bidirectional and client streaming calls on some versions of Windows. Adapter operations that normally use bidirectional streaming such as tag value subscriptions and writes are translated into unary or server streaming invocations by the proxy if the underlying version of Windows does not provide full gRPC client support.
+> Grpc.Net.Client on .NET Framework has limited support for bidirectional and client streaming calls on some versions of Windows. Adapter operations that normally use bidirectional streaming such as tag value subscriptions and writes are translated into unary or server streaming invocations by the proxy if the underlying version of Windows does not provide full gRPC client support.
 
 
 # Using the Proxy

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
@@ -24,5 +24,71 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
         /// </param>
         public SnapshotTagValuePushImpl(GrpcAdapterProxy proxy) : base(proxy) { }
 
+
+        private async IAsyncEnumerable<Adapter.RealTimeData.TagValueQueryResult> SubscribeCoreAsync(
+            IAdapterCallContext context,
+            CreateSnapshotTagValueSubscriptionRequest request,
+            IAsyncEnumerable<TagValueSubscriptionUpdate> channel,
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            var client = CreateClient<TagValuesService.TagValuesServiceClient>();
+
+            var createSubscriptionMessage = new CreateSnapshotPushChannelMessage() {
+                AdapterId = AdapterId
+            };
+
+            if (request.PublishInterval > TimeSpan.Zero) {
+                createSubscriptionMessage.PublishInterval = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(request.PublishInterval);
+            }
+
+            createSubscriptionMessage.Tags.Add(request.Tags?.Where(x => x != null) ?? Array.Empty<string>());
+            if (request.Properties != null) {
+                foreach (var item in request.Properties) {
+                    createSubscriptionMessage.Properties.Add(item.Key, item.Value ?? string.Empty);
+                }
+            }
+
+            using (var grpcStream = client.CreateSnapshotPushChannel(GetCallOptions(context, cancellationToken))) {
+
+                // Create the subscription.
+                await grpcStream.RequestStream.WriteAsync(new CreateSnapshotPushChannelRequest() {
+                    Create = createSubscriptionMessage
+                }).ConfigureAwait(false);
+
+                // Stream subscription changes.
+                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
+                    await foreach (var update in channel.WithCancellation(ct).ConfigureAwait(false)) {
+                        if (update == null) {
+                            continue;
+                        }
+
+                        var msg = new UpdateSnapshotPushChannelMessage() {
+                            Action = update.Action == Common.SubscriptionUpdateAction.Subscribe
+                                ? SubscriptionUpdateAction.Subscribe
+                                : SubscriptionUpdateAction.Unsubscribe
+                        };
+                        msg.Tags.Add(update.Tags.Where(x => x != null));
+                        if (msg.Tags.Count == 0) {
+                            continue;
+                        }
+
+                        await grpcStream.RequestStream.WriteAsync(new CreateSnapshotPushChannelRequest() {
+                            Update = msg
+                        }).ConfigureAwait(false);
+                    }
+                }, cancellationToken);
+
+                // Stream the results.
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                    if (grpcStream.ResponseStream.Current == null) {
+                        continue;
+                    }
+
+                    yield return grpcStream.ResponseStream.Current.ToAdapterTagValueQueryResult();
+                }
+            }
+        }
+
     }
 }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netfx.cs
@@ -138,6 +138,16 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
+            if (GrpcAdapterProxy.IsGrpcClientFullySupported()) {
+                // Bidirectional streaming is fully supported.
+                await foreach (var item in SubscribeCoreAsync(context, request, channel, cancellationToken).ConfigureAwait(false)) {
+                    yield return item;
+                }
+                yield break;
+            }
+
+            // Bidirectional streaming is not supported.
+
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             
             using var handler = CreateInnerHandler(context, client, request, cancellationToken);

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.netstandard.cs
@@ -1,84 +1,22 @@
 ﻿#if NETFRAMEWORK == false
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 
 using DataCore.Adapter.RealTimeData;
-
-using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
     partial class SnapshotTagValuePushImpl {
 
         /// <inheritdoc />
-        public async IAsyncEnumerable<Adapter.RealTimeData.TagValueQueryResult> Subscribe(
+        public IAsyncEnumerable<Adapter.RealTimeData.TagValueQueryResult> Subscribe(
             IAdapterCallContext context,
             CreateSnapshotTagValueSubscriptionRequest request,
             IAsyncEnumerable<TagValueSubscriptionUpdate> channel,
-            [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var client = CreateClient<TagValuesService.TagValuesServiceClient>();
-
-            var createSubscriptionMessage = new CreateSnapshotPushChannelMessage() {
-                AdapterId = AdapterId
-            };
-
-            if (request.PublishInterval > TimeSpan.Zero) {
-                createSubscriptionMessage.PublishInterval = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(request.PublishInterval);
-            }
-
-            createSubscriptionMessage.Tags.Add(request.Tags?.Where(x => x != null) ?? Array.Empty<string>());
-            if (request.Properties != null) {
-                foreach (var item in request.Properties) {
-                    createSubscriptionMessage.Properties.Add(item.Key, item.Value ?? string.Empty);
-                }
-            }
-
-            using (var grpcStream = client.CreateSnapshotPushChannel(GetCallOptions(context, cancellationToken))) {
-
-                // Create the subscription.
-                await grpcStream.RequestStream.WriteAsync(new CreateSnapshotPushChannelRequest() {
-                    Create = createSubscriptionMessage
-                }).ConfigureAwait(false);
-
-                // Stream subscription changes.
-                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
-                    await foreach (var update in channel.WithCancellation(ct).ConfigureAwait(false)) {
-                        if (update == null) {
-                            continue;
-                        }
-
-                        var msg = new UpdateSnapshotPushChannelMessage() {
-                            Action = update.Action == Common.SubscriptionUpdateAction.Subscribe
-                                ? SubscriptionUpdateAction.Subscribe
-                                : SubscriptionUpdateAction.Unsubscribe
-                        };
-                        msg.Tags.Add(update.Tags.Where(x => x != null));
-                        if (msg.Tags.Count == 0) {
-                            continue;
-                        }
-
-                        await grpcStream.RequestStream.WriteAsync(new CreateSnapshotPushChannelRequest() {
-                            Update = msg
-                        }).ConfigureAwait(false);
-                    }
-                }, cancellationToken);
-
-                // Stream the results.
-                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
-                    if (grpcStream.ResponseStream.Current == null) {
-                        continue;
-                    }
-
-                    yield return grpcStream.ResponseStream.Current.ToAdapterTagValueQueryResult();
-                }
-            }
+            return SubscribeCoreAsync(context, request, channel, cancellationToken);
         }
 
     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.cs
@@ -1,4 +1,11 @@
-﻿using DataCore.Adapter.RealTimeData;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.RealTimeData;
+
+using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
@@ -14,6 +21,52 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
         ///   The proxy that owns the instance.
         /// </param>
         public WriteHistoricalTagValuesImpl(GrpcAdapterProxy proxy) : base(proxy) { }
+
+
+        private async IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueResult> WriteHistoricalTagValuesCoreAsync(
+            IAdapterCallContext context,
+            Adapter.RealTimeData.WriteTagValuesRequest request,
+            IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueItem> channel,
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            var client = CreateClient<TagValuesService.TagValuesServiceClient>();
+
+            using (var grpcStream = client.WriteHistoricalTagValues(GetCallOptions(context, cancellationToken))) {
+                // Create the subscription.
+                var initMessage = new WriteTagValueInitMessage() {
+                    AdapterId = Proxy.RemoteDescriptor.Id
+                };
+
+                if (request.Properties != null) {
+                    foreach (var prop in request.Properties) {
+                        initMessage.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                    }
+                }
+
+                await grpcStream.RequestStream.WriteAsync(new WriteTagValueRequest() {
+                    Init = initMessage
+                }).ConfigureAwait(false);
+
+                // Run a background task to stream the values to write.
+                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
+                    try {
+                        await foreach (var item in channel.WithCancellation(ct).ConfigureAwait(false)) {
+                            await grpcStream.RequestStream.WriteAsync(new WriteTagValueRequest() {
+                                Write = item.ToGrpcWriteTagValueItem()
+                            }).ConfigureAwait(false);
+                        }
+                    }
+                    finally {
+                        await grpcStream.RequestStream.CompleteAsync().ConfigureAwait(false);
+                    }
+                }, cancellationToken);
+
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                    yield return grpcStream.ResponseStream.Current.ToAdapterWriteTagValueResult();
+                }
+            }
+        }
 
     }
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.netfx.cs
@@ -17,6 +17,16 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
+            if (GrpcAdapterProxy.IsGrpcClientFullySupported()) {
+                // Bidirectional streaming is fully supported.
+                await foreach (var item in WriteHistoricalTagValuesCoreAsync(context, request, channel, cancellationToken).ConfigureAwait(false)) {
+                    yield return item;
+                }
+                yield break;
+            }
+
+            // Bidirectional streaming is not supported.
+
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
 
             var callOptions = GetCallOptions(context, cancellationToken);

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteHistoricalTagValuesImpl.netstandard.cs
@@ -1,60 +1,20 @@
 ﻿#if NETFRAMEWORK == false
 
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
-
-using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
     partial class WriteHistoricalTagValuesImpl {
 
         /// <inheritdoc />
-        public async IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueResult> WriteHistoricalTagValues(
+        public IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueResult> WriteHistoricalTagValues(
             IAdapterCallContext context,
             Adapter.RealTimeData.WriteTagValuesRequest request,
             IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueItem> channel,
-            [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var client = CreateClient<TagValuesService.TagValuesServiceClient>();
-
-            using (var grpcStream = client.WriteHistoricalTagValues(GetCallOptions(context, cancellationToken))) {
-                // Create the subscription.
-                var initMessage = new WriteTagValueInitMessage() {
-                    AdapterId = Proxy.RemoteDescriptor.Id
-                };
-
-                if (request.Properties != null) {
-                    foreach (var prop in request.Properties) {
-                        initMessage.Properties.Add(prop.Key, prop.Value ?? string.Empty);
-                    }
-                }
-
-                await grpcStream.RequestStream.WriteAsync(new WriteTagValueRequest() {
-                    Init = initMessage
-                }).ConfigureAwait(false);
-
-                // Run a background task to stream the values to write.
-                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
-                    try {
-                        await foreach (var item in channel.WithCancellation(ct).ConfigureAwait(false)) {
-                            await grpcStream.RequestStream.WriteAsync(new WriteTagValueRequest() {
-                                Write = item.ToGrpcWriteTagValueItem()
-                            }).ConfigureAwait(false);
-                        }
-                    }
-                    finally {
-                        await grpcStream.RequestStream.CompleteAsync().ConfigureAwait(false);
-                    }
-                }, cancellationToken);
-
-                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
-                    yield return grpcStream.ResponseStream.Current.ToAdapterWriteTagValueResult();
-                }
-            }
+            return WriteHistoricalTagValuesCoreAsync(context, request, channel, cancellationToken);
         }
 
     }

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.cs
@@ -1,4 +1,11 @@
-﻿using DataCore.Adapter.RealTimeData;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.RealTimeData;
+
+using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
@@ -14,6 +21,52 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
         ///   The proxy that owns the instance.
         /// </param>
         public WriteSnapshotTagValuesImpl(GrpcAdapterProxy proxy) : base(proxy) { }
+
+
+        private async IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueResult> WriteSnapshotTagValuesCoreAsync(
+            IAdapterCallContext context,
+            Adapter.RealTimeData.WriteTagValuesRequest request,
+            IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueItem> channel,
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            var client = CreateClient<TagValuesService.TagValuesServiceClient>();
+
+            using (var grpcStream = client.WriteSnapshotTagValues(GetCallOptions(context, cancellationToken))) {
+                // Create the subscription.
+                var initMessage = new WriteTagValueInitMessage() {
+                    AdapterId = Proxy.RemoteDescriptor.Id
+                };
+
+                if (request.Properties != null) {
+                    foreach (var prop in request.Properties) {
+                        initMessage.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                    }
+                }
+
+                await grpcStream.RequestStream.WriteAsync(new WriteTagValueRequest() {
+                    Init = initMessage
+                }).ConfigureAwait(false);
+
+                // Run a background task to stream the values to write.
+                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
+                    try {
+                        await foreach (var item in channel.WithCancellation(ct).ConfigureAwait(false)) {
+                            await grpcStream.RequestStream.WriteAsync(new WriteTagValueRequest() {
+                                Write = item.ToGrpcWriteTagValueItem()
+                            }).ConfigureAwait(false);
+                        }
+                    }
+                    finally {
+                        await grpcStream.RequestStream.CompleteAsync().ConfigureAwait(false);
+                    }
+                }, cancellationToken);
+
+                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                    yield return grpcStream.ResponseStream.Current.ToAdapterWriteTagValueResult();
+                }
+            }
+        }
 
     }
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.netfx.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.netfx.cs
@@ -17,6 +17,16 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
+            if (GrpcAdapterProxy.IsGrpcClientFullySupported()) {
+                // Bidirectional streaming is fully supported.
+                await foreach (var item in WriteSnapshotTagValuesCoreAsync(context, request, channel, cancellationToken).ConfigureAwait(false)) {
+                    yield return item;
+                }
+                yield break;
+            }
+
+            // Bidirectional streaming is not supported.
+
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
 
             var callOptions = GetCallOptions(context, cancellationToken);

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.netstandard.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteSnapshotTagValuesImpl.netstandard.cs
@@ -1,60 +1,20 @@
 ﻿#if NETFRAMEWORK == false
 
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
-
-using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
     partial class WriteSnapshotTagValuesImpl {
 
         /// <inheritdoc />
-        public async IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueResult> WriteSnapshotTagValues(
+        public IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueResult> WriteSnapshotTagValues(
             IAdapterCallContext context,
             Adapter.RealTimeData.WriteTagValuesRequest request,
             IAsyncEnumerable<Adapter.RealTimeData.WriteTagValueItem> channel,
-            [EnumeratorCancellation]
             CancellationToken cancellationToken
         ) {
-            var client = CreateClient<TagValuesService.TagValuesServiceClient>();
-
-            using (var grpcStream = client.WriteSnapshotTagValues(GetCallOptions(context, cancellationToken))) {
-                // Create the subscription.
-                var initMessage = new WriteTagValueInitMessage() {
-                    AdapterId = Proxy.RemoteDescriptor.Id
-                };
-
-                if (request.Properties != null) {
-                    foreach (var prop in request.Properties) {
-                        initMessage.Properties.Add(prop.Key, prop.Value ?? string.Empty);
-                    }
-                }
-
-                await grpcStream.RequestStream.WriteAsync(new WriteTagValueRequest() {
-                    Init = initMessage
-                }).ConfigureAwait(false);
-
-                // Run a background task to stream the values to write.
-                Proxy.BackgroundTaskService.QueueBackgroundWorkItem(async ct => {
-                    try {
-                        await foreach (var item in channel.WithCancellation(ct).ConfigureAwait(false)) {
-                            await grpcStream.RequestStream.WriteAsync(new WriteTagValueRequest() {
-                                Write = item.ToGrpcWriteTagValueItem()
-                            }).ConfigureAwait(false);
-                        }
-                    }
-                    finally {
-                        await grpcStream.RequestStream.CompleteAsync().ConfigureAwait(false);
-                    }
-                }, cancellationToken);
-
-                while (await grpcStream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
-                    yield return grpcStream.ResponseStream.Current.ToAdapterWriteTagValueResult();
-                }
-            }
+            return WriteSnapshotTagValuesCoreAsync(context, request, channel, cancellationToken);
         }
 
     }


### PR DESCRIPTION
Closes #385.

This PR backports the functionality of various adapter features that use bidirectional streaming from the netstandard2.1 target to net48. The net48 target will continue to use the existing implementation when it detects that the host operating system does not fully support gRPC over HTTP/2.