### PR TITLE
Allow custom AdapterTypeDescriptor creation

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AdapterCore.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterCore.cs
@@ -91,7 +91,17 @@ namespace DataCore.Adapter {
         public AdapterDescriptor Descriptor { get; private set; }
 
         /// <inheritdoc/>
-        public AdapterTypeDescriptor TypeDescriptor { get; }
+        public AdapterTypeDescriptor TypeDescriptor => GetAdapterTypeDescriptor() ?? DefaultTypeDescriptor;
+
+        /// <summary>
+        /// The default adapter type descriptor generated from the adapter type.
+        /// </summary>
+        private AdapterTypeDescriptor DefaultTypeDescriptor => _defaultTypeDescriptor ??= GetType().CreateAdapterTypeDescriptor()!;
+
+        /// <summary>
+        /// The default adapter type descriptor generated from the adapter type.
+        /// </summary>
+        private AdapterTypeDescriptor? _defaultTypeDescriptor;
 
         /// <inheritdoc/>
         public IAdapterFeaturesCollection Features => this;
@@ -152,7 +162,6 @@ namespace DataCore.Adapter {
         /// </exception>
         protected AdapterCore(AdapterDescriptor descriptor, IBackgroundTaskService? backgroundTaskService, ILoggerFactory? loggerFactory) {
             Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
-            TypeDescriptor = GetType().CreateAdapterTypeDescriptor()!;
             _disposedToken = _disposedTokenSource.Token;
             BackgroundTaskService = new BackgroundTaskServiceWrapper(backgroundTaskService ?? IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default, _disposedToken);
 
@@ -192,7 +201,6 @@ namespace DataCore.Adapter {
         [Obsolete("Use an overload that accepts an ILoggerFactory instead.")]
         protected AdapterCore(AdapterDescriptor descriptor, IBackgroundTaskService? backgroundTaskService = null, ILogger? logger = null) {
             Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
-            TypeDescriptor = GetType().CreateAdapterTypeDescriptor()!;
             _disposedToken = _disposedTokenSource.Token;
             BackgroundTaskService = new BackgroundTaskServiceWrapper(backgroundTaskService ?? IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default, _disposedToken);
 
@@ -207,6 +215,18 @@ namespace DataCore.Adapter {
             Enable();
         }
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+
+        /// <summary>
+        /// Gets the type descriptor for the adapter.
+        /// </summary>
+        /// <returns>
+        ///   The type descriptor for the adapter, or <see langword="null"/> if a type descriptor 
+        ///   should be inferred from the adapter type.
+        /// </returns>
+        protected virtual AdapterTypeDescriptor? GetAdapterTypeDescriptor() {
+            return null;
+        }
 
 
         /// <summary>

--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -114,6 +114,7 @@ static DataCore.Adapter.Services.KeyValueStoreExtensions.CopyToAsync(this DataCo
 static DataCore.Adapter.Services.KeyValueStoreExtensions.GetKeysAsStringsAsync(this DataCore.Adapter.Services.IKeyValueStore! store) -> System.Collections.Generic.IAsyncEnumerable<string!>!
 static DataCore.Adapter.Services.KeyValueStoreExtensions.GetKeysAsStringsAsync(this DataCore.Adapter.Services.IKeyValueStore! store, DataCore.Adapter.Services.KVKey? prefix) -> System.Collections.Generic.IAsyncEnumerable<string!>!
 static DataCore.Adapter.Services.KVKey.implicit operator string?(DataCore.Adapter.Services.KVKey value) -> string?
+virtual DataCore.Adapter.AdapterCore.GetAdapterTypeDescriptor() -> DataCore.Adapter.Common.AdapterTypeDescriptor?
 virtual DataCore.Adapter.Services.KeyValueStore.DeserializeFromStreamAsync<T>(System.IO.Stream! stream) -> System.Threading.Tasks.ValueTask<T?>
 virtual DataCore.Adapter.Services.KeyValueStore.SerializeToStreamAsync<T>(System.IO.Stream! stream, T value, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask
 virtual DataCore.Adapter.Services.RawKeyValueStore<TOptions>.CompressRawBytesAsync(byte[]! data, System.IO.Compression.CompressionLevel? compressionLevel = null) -> System.Threading.Tasks.ValueTask<byte[]!>


### PR DESCRIPTION
Adds a virtual `GetAdapterTypeDescriptor` method to `AdapterCore` to allow an adapter to supply its own type descriptor instead of generating one automatically from the adapter type.

This may be useful in some proxy/wrapper scenarios.