### PR TITLE
Enforce UTC conversion when serializing DateTime instances

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 4,
-  "Minor": 0,
-  "Patch": 2,
+  "Minor": 1,
+  "Patch": 0,
   "PreRelease": ""
 }

--- a/src/DataCore.Adapter.Core/Events/EventMessageBase.cs
+++ b/src/DataCore.Adapter.Core/Events/EventMessageBase.cs
@@ -88,7 +88,7 @@ namespace DataCore.Adapter.Events {
         protected EventMessageBase(string id, string? topic, DateTime utcEventTime, EventPriority priority, string? category, string? type, string? message, IEnumerable<AdapterProperty>? properties) {
             Id = id ?? throw new ArgumentNullException(nameof(id));
             Topic = topic;
-            UtcEventTime = utcEventTime;
+            UtcEventTime = utcEventTime.ToUniversalTime();
             Priority = priority;
             Category = category;
             Type = type;

--- a/src/DataCore.Adapter.Core/Json/JsonExtensions.cs
+++ b/src/DataCore.Adapter.Core/Json/JsonExtensions.cs
@@ -30,6 +30,10 @@ namespace DataCore.Adapter.Json {
             options.NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals;
             //options.AddContext<AdapterJsonContext>();
 
+            // Ensure that DateTime values are always serialized/deserialized in UTC.
+            options.Converters.Add(new UtcDateTimeConverter());
+            options.Converters.Add(new NullableUtcDateTimeConverter());
+
             return options;
         }
 

--- a/src/DataCore.Adapter.Core/Json/NullableUtcDateTimeConverter.cs
+++ b/src/DataCore.Adapter.Core/Json/NullableUtcDateTimeConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace DataCore.Adapter.Json {
+
+    /// <summary>
+    /// <see cref="JsonConverter{T}"/> that ensures that nullable <see cref="DateTime"/> values are 
+    /// always converted to UTC during serialization and deserializarion operations.
+    /// </summary>
+    public sealed class NullableUtcDateTimeConverter : JsonConverter<DateTime?> {
+
+        /// <inheritdoc/>
+        public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+            if (reader.TokenType == JsonTokenType.Null) {
+                return null;
+            }
+
+            if (!reader.TryGetDateTimeOffset(out var dateTimeOffset)) {
+                throw new JsonException();
+            }
+
+            return dateTimeOffset.UtcDateTime;
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options) {
+            if (value == null) {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStringValue(value.Value.ToUniversalTime());
+        }
+
+    }
+
+}

--- a/src/DataCore.Adapter.Core/Json/UtcDateTimeConverter.cs
+++ b/src/DataCore.Adapter.Core/Json/UtcDateTimeConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DataCore.Adapter.Json {
+
+    /// <summary>
+    /// <see cref="JsonConverter{T}"/> that ensures that <see cref="DateTime"/> values are always 
+    /// converted to UTC during serialization and deserializarion operations.
+    /// </summary>
+    public sealed class UtcDateTimeConverter : JsonConverter<DateTime> {
+
+        /// <inheritdoc/>
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+            if (!reader.TryGetDateTimeOffset(out var dateTimeOffset)) {
+                throw new JsonException();
+            }
+
+            return dateTimeOffset.UtcDateTime;
+        }
+
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options) {
+            writer.WriteStringValue(value.ToUniversalTime());
+        }
+
+    }
+
+}

--- a/src/DataCore.Adapter.Core/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Shipped.txt
@@ -1038,3 +1038,11 @@ static DataCore.Adapter.RealTimeData.TagValueExtensions.TryGetSteppedFlag(this D
 ~static DataCore.Adapter.SharedResources.Error_TooManyEntries.get -> string
 ~static DataCore.Adapter.SharedResources.Error_UnitIsTooLong.get -> string
 ~static DataCore.Adapter.SharedResources.Error_ValueIsTooLong.get -> string
+DataCore.Adapter.Json.NullableUtcDateTimeConverter
+DataCore.Adapter.Json.NullableUtcDateTimeConverter.NullableUtcDateTimeConverter() -> void
+DataCore.Adapter.Json.UtcDateTimeConverter
+DataCore.Adapter.Json.UtcDateTimeConverter.UtcDateTimeConverter() -> void
+override DataCore.Adapter.Json.NullableUtcDateTimeConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> System.DateTime?
+override DataCore.Adapter.Json.NullableUtcDateTimeConverter.Write(System.Text.Json.Utf8JsonWriter! writer, System.DateTime? value, System.Text.Json.JsonSerializerOptions! options) -> void
+override DataCore.Adapter.Json.UtcDateTimeConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> System.DateTime
+override DataCore.Adapter.Json.UtcDateTimeConverter.Write(System.Text.Json.Utf8JsonWriter! writer, System.DateTime value, System.Text.Json.JsonSerializerOptions! options) -> void

--- a/src/DataCore.Adapter.Core/RealTimeData/TagValue.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/TagValue.cs
@@ -50,7 +50,7 @@ namespace DataCore.Adapter.RealTimeData {
         /// </param>
         [JsonConstructor]
         public TagValue(DateTime utcSampleTime, Variant value, TagValueStatus status, string? units) {
-            UtcSampleTime = utcSampleTime;
+            UtcSampleTime = utcSampleTime.ToUniversalTime();
             Value = value;
             Status = status;
             Units = units;

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
@@ -30,8 +30,8 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
             var client = CreateClient<EventsService.EventsServiceClient>();
             var grpcRequest = new GetEventMessagesForTimeRangeRequest() {
                 AdapterId = AdapterId,
-                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime),
-                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime),
+                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime.ToUniversalTime()),
+                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime.ToUniversalTime()),
                 Direction = request.Direction.ToGrpcEventReadDirection(),
                 PageSize = request.PageSize,
                 Page = request.Page

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -30,8 +30,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadPlotTagValuesRequest() {
                 AdapterId = AdapterId,
-                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime),
-                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime),
+                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime.ToUniversalTime()),
+                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime.ToUniversalTime()),
                 Intervals = request.Intervals
             };
             grpcRequest.Tags.AddRange(request.Tags);

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -58,8 +58,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadProcessedTagValuesRequest() {
                 AdapterId = AdapterId,
-                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime),
-                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime),
+                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime.ToUniversalTime()),
+                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime.ToUniversalTime()),
                 SampleInterval = Google.Protobuf.WellKnownTypes.Duration.FromTimeSpan(request.SampleInterval)
             };
             grpcRequest.Tags.AddRange(request.Tags);

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -30,8 +30,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             var client = CreateClient<TagValuesService.TagValuesServiceClient>();
             var grpcRequest = new ReadRawTagValuesRequest() {
                 AdapterId = AdapterId,
-                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime),
-                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime),
+                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime.ToUniversalTime()),
+                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime.ToUniversalTime()),
                 SampleCount = request.SampleCount,
                 BoundaryType = request.BoundaryType.ToGrpcRawDataBoundaryType()
             };

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
@@ -31,8 +31,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             var client = CreateClient<TagValueAnnotationsService.TagValueAnnotationsServiceClient>();
             var grpcRequest = new ReadAnnotationsRequest() {
                 AdapterId = AdapterId,
-                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime),
-                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime),
+                UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime.ToUniversalTime()),
+                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime.ToUniversalTime()),
                 MaxAnnotationCount = request.AnnotationCount
             };
             grpcRequest.Tags.AddRange(request.Tags);

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -33,7 +33,7 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 AdapterId = AdapterId
             };
             grpcRequest.Tags.AddRange(request.Tags);
-            grpcRequest.UtcSampleTimes.AddRange(request.UtcSampleTimes.Select(x => Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(x)));
+            grpcRequest.UtcSampleTimes.AddRange(request.UtcSampleTimes.Select(x => Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(x.ToUniversalTime())));
             if (request.Properties != null) {
                 foreach (var prop in request.Properties) {
                     grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);

--- a/src/DataCore.Adapter.Json.Newtonsoft/JsonSerializerSettingsExtensions.cs
+++ b/src/DataCore.Adapter.Json.Newtonsoft/JsonSerializerSettingsExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace DataCore.Adapter.NewtonsoftJson {
 
@@ -11,34 +12,43 @@ namespace DataCore.Adapter.NewtonsoftJson {
     public static class JsonSerializerSettingsExtensions {
 
         /// <summary>
-        /// Registers adapter-related converters.
+        /// Registers adapter-related converters and default serialization behaviours.
         /// </summary>
         /// <param name="settings">
         ///   The JSON serialization settings.
         /// </param>
-        public static void AddDataCoreAdapterConverters(this JsonSerializerSettings settings) {
+        public static void UseDataCoreAdapterDefaults(this JsonSerializerSettings settings) => settings.UseDataCoreAdapterDefaults(null);
+
+
+        /// <summary>
+        /// Registers adapter-related converters and default serialization behaviours.
+        /// </summary>
+        /// <param name="settings">
+        ///   The JSON serialization settings.
+        /// </param>
+        /// <param name="jsonElementConverterOptions">
+        ///   The <see cref="System.Text.Json.JsonSerializerOptions"/> to use with the <see cref="JsonElementConverter"/> 
+        ///   registered by this method.
+        /// </param>
+        public static void UseDataCoreAdapterDefaults(this JsonSerializerSettings settings, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) {
             if (settings == null) {
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            settings.AddDataCoreAdapterConverters(null);
-
+            // Ensure that DateTime values are always serialized as UTC
+            settings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
+            settings.Converters.AddDataCoreAdapterConverters(jsonElementConverterOptions);
         }
 
 
         /// <summary>
         /// Registers adapter-related converters.
         /// </summary>
-        /// <param name="converters">
-        ///   The JSON converter collection to add new converters to.
+        /// <param name="settings">
+        ///   The JSON serialization settings.
         /// </param>
-        public static void AddDataCoreAdapterConverters(this ICollection<JsonConverter> converters) {
-            if (converters == null) {
-                throw new ArgumentNullException(nameof(converters));
-            }
-
-            converters.AddDataCoreAdapterConverters(null);
-        }
+        [Obsolete("This method will be removed in a future version. Call UseDataCoreAdapterDefaults instead.", false)]
+        public static void AddDataCoreAdapterConverters(this JsonSerializerSettings settings) => settings.UseDataCoreAdapterDefaults();
 
 
         /// <summary>
@@ -51,14 +61,17 @@ namespace DataCore.Adapter.NewtonsoftJson {
         ///   The <see cref="System.Text.Json.JsonSerializerOptions"/> to use with the <see cref="JsonElementConverter"/> 
         ///   registered by this method.
         /// </param>
-        public static void AddDataCoreAdapterConverters(this JsonSerializerSettings settings, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) {
-            if (settings == null) {
-                throw new ArgumentNullException(nameof(settings));
-            }
+        [Obsolete("This method will be removed in a future version. Call UseDataCoreAdapterDefaults instead.", false)]
+        public static void AddDataCoreAdapterConverters(this JsonSerializerSettings settings, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) => settings.UseDataCoreAdapterDefaults(jsonElementConverterOptions);
 
-            settings.Converters.AddDataCoreAdapterConverters(jsonElementConverterOptions);
 
-        }
+        /// <summary>
+        /// Registers adapter-related converters.
+        /// </summary>
+        /// <param name="converters">
+        ///   The JSON converter collection to add new converters to.
+        /// </param>
+        public static void AddDataCoreAdapterConverters(this ICollection<JsonConverter> converters) => converters.AddDataCoreAdapterConverters(null);
 
 
         /// <summary>
@@ -80,6 +93,9 @@ namespace DataCore.Adapter.NewtonsoftJson {
             converters.Add(new NullableJsonElementConverter(jsonElementConverterOptions));
             converters.Add(new VariantConverter());
             converters.Add(new ByteStringConverter());
+            converters.Add(new IsoDateTimeConverter() { 
+                DateTimeStyles = System.Globalization.DateTimeStyles.AdjustToUniversal
+            });
         }
 
     }

--- a/src/DataCore.Adapter.Json.Newtonsoft/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.Json.Newtonsoft/PublicAPI.Shipped.txt
@@ -22,3 +22,5 @@ static DataCore.Adapter.NewtonsoftJson.JsonSerializerSettingsExtensions.AddDataC
 static DataCore.Adapter.NewtonsoftJson.JsonSerializerSettingsExtensions.AddDataCoreAdapterConverters(this System.Collections.Generic.ICollection<Newtonsoft.Json.JsonConverter!>! converters) -> void
 static DataCore.Adapter.NewtonsoftJson.JsonSerializerSettingsExtensions.AddDataCoreAdapterConverters(this Newtonsoft.Json.JsonSerializerSettings! settings, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) -> void
 static DataCore.Adapter.NewtonsoftJson.JsonSerializerSettingsExtensions.AddDataCoreAdapterConverters(this System.Collections.Generic.ICollection<Newtonsoft.Json.JsonConverter!>! converters, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) -> void
+static DataCore.Adapter.NewtonsoftJson.JsonSerializerSettingsExtensions.UseDataCoreAdapterDefaults(this Newtonsoft.Json.JsonSerializerSettings! settings) -> void
+static DataCore.Adapter.NewtonsoftJson.JsonSerializerSettingsExtensions.UseDataCoreAdapterDefaults(this Newtonsoft.Json.JsonSerializerSettings! settings, System.Text.Json.JsonSerializerOptions? jsonElementConverterOptions) -> void

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\..\src\DataCore.Adapter.KeyValueStore.FASTER\DataCore.Adapter.KeyValueStore.FASTER.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.KeyValueStore.FileSystem\DataCore.Adapter.KeyValueStore.FileSystem.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.KeyValueStore.Sqlite\DataCore.Adapter.KeyValueStore.Sqlite.csproj" />
+    <ProjectReference Include="..\..\src\DataCore.Adapter.Json.Newtonsoft\DataCore.Adapter.Json.Newtonsoft.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.Tests.Helpers\DataCore.Adapter.Tests.Helpers.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter.WaveGenerator\DataCore.Adapter.WaveGenerator.csproj" />
     <ProjectReference Include="..\..\src\DataCore.Adapter\DataCore.Adapter.csproj" />

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -11,7 +11,6 @@ using DataCore.Adapter.Json;
 using DataCore.Adapter.RealTimeData;
 using DataCore.Adapter.Tags;
 
-using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DataCore.Adapter.Tests {
@@ -1451,6 +1450,37 @@ namespace DataCore.Adapter.Tests {
                 Assert.AreEqual(expectedValue.Name, actualValue.Name);
                 Assert.AreEqual(expectedValue.Value, actualValue.Value);
             }
+        }
+
+
+        [DataTestMethod]
+        [DataRow(@"""2024-05-18T06:00:00.0000000Z""", "2024-05-18T06:00:00.0000000Z")]
+        [DataRow(@"""2024-05-18T06:00:00.1234567+05:30""", "2024-05-18T00:30:00.1234567Z")]
+        [DataRow(@"""2024-05-18T19:45:27.7654321-09:00""", "2024-05-19T04:45:27.7654321Z")]
+        public void DateTimeShouldBeConvertedToUtcOnDeserialize(string json, string expectedUtcDate) {
+            var options = GetOptions();
+
+            var actual = JsonSerializer.Deserialize<DateTime>(json, options);
+            var expected = DateTimeOffset.Parse(expectedUtcDate).UtcDateTime;
+
+            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(DateTimeKind.Utc, expected.Kind);
+            Assert.AreEqual(DateTimeKind.Utc, actual.Kind);
+        }
+
+
+        [DataTestMethod]
+        [DataRow("2024-05-18T19:45:27.1234567", DateTimeKind.Utc)]
+        [DataRow("2024-05-18T19:45:27.1234567", DateTimeKind.Local)]
+        [DataRow("2024-05-18T19:45:27.1234567", DateTimeKind.Unspecified)]
+        public void DateTimeShouldBeConvertedToUtcOnSerialize(string dateString, DateTimeKind kind) {
+            var options = GetOptions();
+
+            var date = DateTime.SpecifyKind(DateTime.Parse(dateString), kind);
+            var expectedJson = $@"""{date.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ")}""";
+
+            var actual = JsonSerializer.Serialize(date, options);
+            Assert.AreEqual(expectedJson, actual);
         }
 
 

--- a/test/DataCore.Adapter.Tests/NewtonsoftJsonTests.cs
+++ b/test/DataCore.Adapter.Tests/NewtonsoftJsonTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+using DataCore.Adapter.NewtonsoftJson;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json;
+
+namespace DataCore.Adapter.Tests {
+
+    [TestClass]
+    public class NewtonsoftJsonTests : TestsBase {
+
+        private JsonSerializerSettings GetOptions() {
+            var options = new JsonSerializerSettings();
+            options.UseDataCoreAdapterDefaults();
+            return options;
+        }
+
+
+
+        [DataTestMethod]
+        [DataRow(@"""2024-05-18T06:00:00.0000000Z""", "2024-05-18T06:00:00.0000000Z")]
+        [DataRow(@"""2024-05-18T06:00:00.1234567+05:30""", "2024-05-18T00:30:00.1234567Z")]
+        [DataRow(@"""2024-05-18T19:45:27.7654321-09:00""", "2024-05-19T04:45:27.7654321Z")]
+        public void DateTimeShouldBeConvertedToUtcOnDeserialize(string json, string expectedUtcDate) {
+            var options = GetOptions();
+
+            var actual = JsonConvert.DeserializeObject<DateTime>(json, options);
+            var expected = DateTimeOffset.Parse(expectedUtcDate).UtcDateTime;
+
+            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(DateTimeKind.Utc, expected.Kind);
+            Assert.AreEqual(DateTimeKind.Utc, actual.Kind);
+        }
+
+
+        [DataTestMethod]
+        [DataRow("2024-05-18T19:45:27.1234567", DateTimeKind.Utc)]
+        [DataRow("2024-05-18T19:45:27.1234567", DateTimeKind.Local)]
+        [DataRow("2024-05-18T19:45:27.1234567", DateTimeKind.Unspecified)]
+        public void DateTimeShouldBeConvertedToUtcOnSerialize(string dateString, DateTimeKind kind) {
+            var options = GetOptions();
+
+            var date = DateTime.SpecifyKind(DateTime.Parse(dateString), kind);
+            var expectedJson = $@"""{date.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ")}""";
+
+            var actual = JsonConvert.SerializeObject(date, options);
+            Assert.AreEqual(expectedJson, actual);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR ensures that DateTime instances are always converted to UTC during JSON serialization/deserialization when using either System.Text.Json or Newtonsoft. It also ensures that the gRPC adapter proxy always converts DateTime instances in query objects to UTC when creating equivalent protobuf request types.

`TagValue`, `EventMessageBase` and `TagValueAnnotation` all ensure that DateTime objects passed to their constructors are converted to UTC.