### PR TITLE
Fix BOM validation error

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -61,7 +61,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=2.0.1
+#load nuget:?package=Jaahas.Cake.Extensions&version=2.0.2
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);


### PR DESCRIPTION
Updates Cake extensions to fix a bill of materials issue where referenced packages that defined multiple licences (such as CsvHelper) would result in a CycloneDX BOM that failed validation.