### PR TITLE
Add Count and Size properties to StringCache

### DIFF
--- a/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
@@ -2,9 +2,11 @@
 const DataCore.Adapter.StringCache.UseNativeInternSwitchName = "Switch.DataCore.Adapter.StringCache.UseNativeIntern" -> string!
 DataCore.Adapter.StringCache
 static DataCore.Adapter.StringCache.Clear() -> void
+static DataCore.Adapter.StringCache.Count.get -> int
 static DataCore.Adapter.StringCache.Get(string? str) -> string?
 static DataCore.Adapter.StringCache.Intern(string? str) -> string?
 static DataCore.Adapter.StringCache.NativeInternEnabled.get -> bool
+static DataCore.Adapter.StringCache.Size.get -> long
 static System.DCAStringExtensions.GetFromStringCache(this string! str) -> string!
 static System.DCAStringExtensions.InternToStringCache(this string! str) -> string!
 System.DCAStringExtensions

--- a/src/DataCore.Adapter.Core/StringCache.cs
+++ b/src/DataCore.Adapter.Core/StringCache.cs
@@ -71,7 +71,33 @@ namespace DataCore.Adapter {
 
 
         /// <summary>
-        /// Interns the specified string.
+        /// The number of strings in the cache.
+        /// </summary>
+        /// <remarks>
+        ///   <see cref="Count"/> will always return -1 if native interning is enabled.
+        /// </remarks>
+        public static int Count => NativeInternEnabled
+            ? -1
+            : s_strings.Count;
+
+        /// <summary>
+        /// The total size of all cached strings, in bytes.
+        /// </summary>
+        private static long s_size;
+
+        /// <summary>
+        /// The total size of all cached strings, in bytes.
+        /// </summary>
+        /// <remarks>
+        ///   <see cref="Size"/> will always return -1 if native interning is enabled.
+        /// </remarks>
+        public static long Size => NativeInternEnabled
+            ? -1
+            : s_size;
+
+
+        /// <summary>
+        /// Retrieves the interned reference to the specified string.
         /// </summary>
         /// <param name="str">
         ///   The string to intern.
@@ -86,7 +112,22 @@ namespace DataCore.Adapter {
 
             return NativeInternEnabled
                 ? string.Intern(str)
-                : s_strings.GetOrAdd(str, str);
+                : s_strings.GetOrAdd(str, OnAddToCache);
+        }
+
+
+        /// <summary>
+        /// Updates the recorded size of the cache to include the specified string.
+        /// </summary>
+        /// <param name="str">
+        ///   The string being added to the cache.
+        /// </param>
+        /// <returns>
+        ///   The string being added to the cache.
+        /// </returns>
+        private static string OnAddToCache(string str) {
+            s_size += (str.Length * sizeof(char));
+            return str;
         }
 
 
@@ -125,6 +166,7 @@ namespace DataCore.Adapter {
             }
 
             s_strings.Clear();
+            s_size = 0;
         }
 
     }


### PR DESCRIPTION
This PR adds `Count` and `Size` properties to `StringCache` that report the number of strings in the cache and the total size of all cached strings in bytes respectively.

Both properties return -1 if native interning is enabled as it is not possible to obtain this information from the runtime.