### PR TITLE
Backport CVE-2024-30105 mitigation to 4.x

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,7 +59,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 4,
   "Minor": 1,
-  "Patch": 0,
+  "Patch": 1,
   "PreRelease": ""
 }


### PR DESCRIPTION
This PR adds mitigation for https://github.com/advisories/GHSA-hh2w-p6rv-4g7w