### PR TITLE
Tooling update

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,8 @@
+{
+    "version": "1.0",
+    "components": [],
+    "extensions": [
+        "https://marketplace.visualstudio.com/items?itemName=MadsKristensen.WorkflowBrowser",
+        "https://marketplace.visualstudio.com/items?itemName=MadsKristensen.MarkdownEditor2"
+    ]
+}

--- a/DataCore.Adapter.sln
+++ b/DataCore.Adapter.sln
@@ -5,18 +5,11 @@ VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "common", "common", "{0DEC6A31-20B5-46C7-A1FD-D4193755119E}"
 	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-		.gitignore = .gitignore
 		build.cake = build.cake
-		build.ps1 = build.ps1
-		build.sh = build.sh
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
-		LICENSE = LICENSE
 		README.md = README.md
-		swagger.json = swagger.json
-		THIRD_PARTY_LICENSES.md = THIRD_PARTY_LICENSES.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{004EC5B0-7D4E-4382-A139-A9BD049D99C4}"
@@ -98,13 +91,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.Json.Newto
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.OpenTelemetry", "src\DataCore.Adapter.OpenTelemetry\DataCore.Adapter.OpenTelemetry.csproj", "{A955719A-1C0A-4CE4-80C4-C09CD404380F}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{C48E4C85-6A13-46D5-9DA2-4AAC739D12FF}"
-	ProjectSection(SolutionItems) = preProject
-		docs\adapter-host-authn-authz.md = docs\adapter-host-authn-authz.md
-		docs\adapter-host-logging.md = docs\adapter-host-logging.md
-		docs\writing-an-adapter.md = docs\writing-an-adapter.md
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Templates", "Templates", "{7701E410-A9F0-4F50-80E4-51576DABB306}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.Templates", "src\DataCore.Adapter.Templates\DataCore.Adapter.Templates.csproj", "{B5692AC0-AA11-4062-8F65-8A120C8846FA}"
@@ -118,13 +104,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.KeyValueStore.FileSystem", "src\DataCore.Adapter.KeyValueStore.FileSystem\DataCore.Adapter.KeyValueStore.FileSystem.csproj", "{8C225A69-794C-4451-B5CE-91EAD5269C87}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinimalApiExample", "examples\MinimalApiExample\MinimalApiExample.csproj", "{144B4A51-9F3E-45BD-B0A3-0732A946D2F4}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "features", "features", "{4AA5F467-4724-42CC-B7B8-DC8D4C7CE7FE}"
-	ProjectSection(SolutionItems) = preProject
-		docs\features\tag-history-polling.md = docs\features\tag-history-polling.md
-		docs\features\tag-search.md = docs\features\tag-search.md
-		docs\features\tag-snapshot-polling-and-subscriptions.md = docs\features\tag-snapshot-polling-and-subscriptions.md
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataCore.Adapter.AspNetCore.MinimalApi", "src\DataCore.Adapter.AspNetCore.MinimalApi\DataCore.Adapter.AspNetCore.MinimalApi.csproj", "{7DAD7F07-BE1A-4A33-A9BF-90FFE15D3478}"
 EndProject
@@ -305,7 +284,6 @@ Global
 		{22DD3CC9-034B-4C43-A143-6240E8E833CC} = {B158078F-D217-46FE-A9B8-7BD1B99922BA}
 		{8C225A69-794C-4451-B5CE-91EAD5269C87} = {B158078F-D217-46FE-A9B8-7BD1B99922BA}
 		{144B4A51-9F3E-45BD-B0A3-0732A946D2F4} = {92FD0A48-0AE7-44A6-86BC-C4E47E014C17}
-		{4AA5F467-4724-42CC-B7B8-DC8D4C7CE7FE} = {C48E4C85-6A13-46D5-9DA2-4AAC739D12FF}
 		{7DAD7F07-BE1A-4A33-A9BF-90FFE15D3478} = {68BD9B3D-78AB-4399-ACC9-CBD11CAB523F}
 		{9B6385F3-BDAE-4E8D-8096-7007C67CCE84} = {B158078F-D217-46FE-A9B8-7BD1B99922BA}
 	EndGlobalSection


### PR DESCRIPTION
This PR adds a `.vsconfig` file to the repository to [automatically prompt Visual Studio to install recommended extensions](https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022#extensions) when the main solution is loaded.

This includes installing the [File Explorer](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.WorkflowBrowser) extension, which allows the entire repository to be browsed and edited from inside Visual Studio. This removes the need for various tooling configuration files (e.g. `.gitignore`, `.editorconfig`) and solution folders to be directly added to the solution file since they can be opened and edited using the File Explorer extension instead.