### PR TITLE
Filter tags using labels

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 5,
   "Minor": 0,
-  "Patch": 2,
+  "Patch": 3,
   "PreRelease": ""
 }

--- a/src/DataCore.Adapter/Tags/TagDefinitionExtensions.cs
+++ b/src/DataCore.Adapter/Tags/TagDefinitionExtensions.cs
@@ -52,6 +52,12 @@ namespace DataCore.Adapter.Tags {
                 }
             }
 
+            if (!string.IsNullOrWhiteSpace(filter.Label)) {
+                if (!tag.Labels.Any(x => x.Like(filter.Label!))) {
+                    return false;
+                }
+            }
+
             if (filter.Other != null) {
                 foreach (var item in filter.Other) {
                     if (string.IsNullOrWhiteSpace(item.Value)) {

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DataCore.Adapter.Tests/TagManagerTests.cs
+++ b/test/DataCore.Adapter.Tests/TagManagerTests.cs
@@ -79,7 +79,7 @@ namespace DataCore.Adapter.Tests {
 
 
         [TestMethod]
-        public async Task ShouldFindTags() {
+        public async Task ShouldFindTagsByName() {
             var tmpPath = new DirectoryInfo(Path.Combine(Path.GetTempPath(), nameof(SnapshotTagValueManagerTests), Guid.NewGuid().ToString()));
             try {
                 var tag1 = new TagDefinitionBuilder().WithId(Guid.NewGuid().ToString()).WithName(TestContext.TestName + "-1").Build();
@@ -106,6 +106,128 @@ namespace DataCore.Adapter.Tests {
                     var tagActual2 = tags.Last();
                     Assert.AreEqual(tag2.Id, tagActual2.Id);
                     Assert.AreEqual(tag2.Name, tagActual2.Name);
+                }
+            }
+            finally {
+                tmpPath.Delete();
+            }
+        }
+
+
+        [TestMethod]
+        public async Task ShouldFindTagsByDescription() {
+            var tmpPath = new DirectoryInfo(Path.Combine(Path.GetTempPath(), nameof(SnapshotTagValueManagerTests), Guid.NewGuid().ToString()));
+            try {
+                var tag1 = new TagDefinitionBuilder()
+                    .WithId(Guid.NewGuid().ToString())
+                    .WithName(TestContext.TestName + "-1")
+                    .WithDescription("ABCD")
+                    .Build();
+
+                var tag2 = new TagDefinitionBuilder()
+                    .WithId(Guid.NewGuid().ToString())
+                    .WithName(TestContext.TestName + "-2")
+                    .WithDescription("EFGH")
+                    .Build();
+
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                    CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
+                }))
+                using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
+                    await tm.InitAsync();
+                    await tm.AddOrUpdateTagAsync(tag1);
+                    await tm.AddOrUpdateTagAsync(tag2);
+
+                    var tags = await tm.FindTags(new DefaultAdapterCallContext(), new FindTagsRequest() {
+                        Description = "*FG*"
+                    }, default).ToEnumerable();
+
+                    Assert.AreEqual(1, tags.Count());
+
+                    var tagActual = tags.First();
+                    Assert.AreEqual(tag2.Id, tagActual.Id);
+                    Assert.AreEqual(tag2.Name, tagActual.Name);
+                }
+            }
+            finally {
+                tmpPath.Delete();
+            }
+        }
+
+
+        [TestMethod]
+        public async Task ShouldFindTagsByUnit() {
+            var tmpPath = new DirectoryInfo(Path.Combine(Path.GetTempPath(), nameof(SnapshotTagValueManagerTests), Guid.NewGuid().ToString()));
+            try {
+                var tag1 = new TagDefinitionBuilder()
+                    .WithId(Guid.NewGuid().ToString())
+                    .WithName(TestContext.TestName + "-1")
+                    .WithUnits("deg C")
+                    .Build();
+
+                var tag2 = new TagDefinitionBuilder()
+                    .WithId(Guid.NewGuid().ToString())
+                    .WithName(TestContext.TestName + "-2")
+                    .WithUnits("hPa")
+                    .Build();
+
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                    CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
+                }))
+                using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
+                    await tm.InitAsync();
+                    await tm.AddOrUpdateTagAsync(tag1);
+                    await tm.AddOrUpdateTagAsync(tag2);
+
+                    var tags = await tm.FindTags(new DefaultAdapterCallContext(), new FindTagsRequest() {
+                        Units = "hPa"
+                    }, default).ToEnumerable();
+
+                    Assert.AreEqual(1, tags.Count());
+
+                    var tagActual = tags.First();
+                    Assert.AreEqual(tag2.Id, tagActual.Id);
+                    Assert.AreEqual(tag2.Name, tagActual.Name);
+                }
+            }
+            finally {
+                tmpPath.Delete();
+            }
+        }
+
+
+        [TestMethod]
+        public async Task ShouldFindTagsByLabel() {
+            var tmpPath = new DirectoryInfo(Path.Combine(Path.GetTempPath(), nameof(SnapshotTagValueManagerTests), Guid.NewGuid().ToString()));
+            try {
+                var tag1 = new TagDefinitionBuilder()
+                    .WithId(Guid.NewGuid().ToString())
+                    .WithName(TestContext.TestName + "-1")
+                    .Build();
+
+                var tag2 = new TagDefinitionBuilder()
+                    .WithId(Guid.NewGuid().ToString())
+                    .WithName(TestContext.TestName + "-2")
+                    .WithLabels(TestContext.TestName)
+                    .Build();
+
+                await using (var store = new FasterKeyValueStore(new FasterKeyValueStoreOptions() {
+                    CheckpointManagerFactory = () => FasterKeyValueStore.CreateLocalStorageCheckpointManager(tmpPath.FullName)
+                }))
+                using (var tm = ActivatorUtilities.CreateInstance<TagManager>(AssemblyInitializer.ApplicationServices, (IEnumerable<AdapterProperty>) Array.Empty<AdapterProperty>())) {
+                    await tm.InitAsync();
+                    await tm.AddOrUpdateTagAsync(tag1);
+                    await tm.AddOrUpdateTagAsync(tag2);
+
+                    var tags = await tm.FindTags(new DefaultAdapterCallContext(), new FindTagsRequest() {
+                        Label = TestContext.TestName
+                    }, default).ToEnumerable();
+
+                    Assert.AreEqual(1, tags.Count());
+
+                    var tagActual = tags.First();
+                    Assert.AreEqual(tag2.Id, tagActual.Id);
+                    Assert.AreEqual(tag2.Name, tagActual.Name);
                 }
             }
             finally {

--- a/test/DataCore.Adapter.Tests/WebHostConfiguration.cs
+++ b/test/DataCore.Adapter.Tests/WebHostConfiguration.cs
@@ -6,15 +6,13 @@ using GrpcNet = Grpc.Net;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace DataCore.Adapter.Tests {
     internal static class WebHostConfiguration {
 
         public const string DefaultHostName = "localhost";
 
-        public const int DefaultPortNumber = 31415;
+        public static int DefaultPortNumber { get; } = Random.Shared.Next(31415, 31500);
 
         public static string DefaultUrl { get; } = string.Concat("https://", DefaultHostName, ":", DefaultPortNumber);
 


### PR DESCRIPTION
This PR modifies the `TagDefinitionExtensions.MatchesFilter` in `DataCore.Adapter` so that it correctly applies a label filter if one is provided.

This ensures that the `TagManager` class can correctly process label-based search requests.