### PR TITLE
Remove unsupported frameworks and update packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
     building via build.ps1 or build.sh. It is defined here to allow Visual Studio to build with 
     the solution with the correct version number.
     -->
-    <Version>5.0.1</Version>
+    <Version>6.0.0-pre</Version>
   </PropertyGroup>
 
   <Choose>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,59 +7,59 @@
   <ItemGroup>
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="CsvHelper" Version="33.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.28.2" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.66.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.67.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.29.3" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.67.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.69.0" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks" Version="12.0.1" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.AspNetCore" Version="12.0.1" />
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="12.0.1" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="2.2.0" />
-    <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="2.1.0" />
-    <PackageVersion Include="JsonSchema.Net" Version="7.2.3" />
-    <PackageVersion Include="JsonSchema.Net.Generation" Version="4.5.1" />
+    <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="2.7.0" />
+    <PackageVersion Include="JsonSchema.Net" Version="7.3.3" />
+    <PackageVersion Include="JsonSchema.Net.Generation" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
     <PackageVersion Include="Microsoft.FASTER.Core" Version="2.6.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
-    <PackageVersion Include="MiniValidation" Version="0.9.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageVersion Include="MiniValidation" Version="0.9.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.8.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.8.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="NSwag.AspNetCore" Version="13.20.0" />
-    <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
-    <PackageVersion Include="Semver" Version="2.3.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.11.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.11.0-beta.1" />
+    <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.2" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Net.Http.Json" Version="8.0.1" />
-    <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.2" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-    <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
+    <PackageVersion Include="System.Net.Http.Json" Version="9.0.2" />
+    <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="9.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.2" />
+    <PackageVersion Include="System.Threading.Channels" Version="9.0.2" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
-  "Major": 5,
+  "Major": 6,
   "Minor": 0,
-  "Patch": 3,
-  "PreRelease": ""
+  "Patch": 0,
+  "PreRelease": "pre"
 }

--- a/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Common/DataCore.Adapter.AspNetCore.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.Common</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/DataCore.Adapter.AspNetCore.Grpc/DataCore.Adapter.AspNetCore.Grpc.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/DataCore.Adapter.AspNetCore.Grpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.Grpc</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>ASP.NET Core types for hosting App Store Connect adapter gRPC services.</Description>

--- a/src/DataCore.Adapter.AspNetCore.HealthChecks/DataCore.Adapter.AspNetCore.HealthChecks.csproj
+++ b/src/DataCore.Adapter.AspNetCore.HealthChecks/DataCore.Adapter.AspNetCore.HealthChecks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.HealthChecks</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/DataCore.Adapter.AspNetCore.MinimalApi/DataCore.Adapter.AspNetCore.MinimalApi.csproj
+++ b/src/DataCore.Adapter.AspNetCore.MinimalApi/DataCore.Adapter.AspNetCore.MinimalApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.MinimalApi</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/DataCore.Adapter.AspNetCore.Mvc/DataCore.Adapter.AspNetCore.Mvc.csproj
+++ b/src/DataCore.Adapter.AspNetCore.Mvc/DataCore.Adapter.AspNetCore.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.Mvc</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/DataCore.Adapter.AspNetCore.SignalR/DataCore.Adapter.AspNetCore.SignalR.csproj
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/DataCore.Adapter.AspNetCore.SignalR.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.AspNetCore</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.AspNetCore.SignalR</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
+++ b/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.Tests</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Tests.Helpers</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -67,8 +67,7 @@
     </Otherwise>
   </Choose>
 
-  <!-- Minimal API project is only supported on >= net7.0 -->
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net48' And '$(TargetFramework)' != 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
     <ProjectReference Include="..\..\src\DataCore.Adapter.AspNetCore.MinimalApi\DataCore.Adapter.AspNetCore.MinimalApi.csproj" />
   </ItemGroup>
   


### PR DESCRIPTION
⚠️ Breaking changes!

This PR removes targets for `net6.0` and `net7.0` since these are now out-of-support. It also bumps all package references to their latest versions.