### PR TITLE
Fix feature health checks not being called by AdapterBase<TOptions>

### DIFF
--- a/src/DataCore.Adapter.Abstractions/AdapterFeatureExtensions.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterFeatureExtensions.cs
@@ -42,8 +42,8 @@ namespace DataCore.Adapter {
                 return default;
             }
 
-            if (feature is AdapterFeatureWrapper<TFeature> wrapper) {
-                return wrapper.InnerFeature;
+            if (feature is AdapterFeatureWrapper wrapper && wrapper.InnerFeature is TFeature inner) {
+                return inner;
             }
 
             return feature;

--- a/src/DataCore.Adapter/AdapterBaseT.cs
+++ b/src/DataCore.Adapter/AdapterBaseT.cs
@@ -625,7 +625,7 @@ namespace DataCore.Adapter {
 
                 var feature = Features[key];
 
-                if (feature == null || feature == this || !processedFeatures.Add(feature) || !(feature is IFeatureHealthCheck healthCheck)) {
+                if (feature == null || feature == this || !processedFeatures.Add(feature) || !(feature.Unwrap() is IFeatureHealthCheck healthCheck)) {
                     continue;
                 }
 


### PR DESCRIPTION
This PR fixes an issue where `AdapterBase<TOptions>` is unable to successfully detect if a feature provided by an external class implements `IFeatureHealthCheck` or not.

The issue occurred because all features registered with an `AdapterCore` instance are wrapped in a wrapper class that provides telemetry and event sourcing functionality, and `AdapterBase<TOptions>` was not correctly unwrapping the wrapper before checking for `IFeatureHealthCheck`.

The PR also improves the implementation of `AdapterFeatureExtensions.Unwrap<TFeature>` so that it correctly unwraps inner features when `TFeature` is `IAdapterFeature` instead of a more-derived feature interface type such as `ITagSearch`.