### PR TITLE
Simplify creation of Variant instances that have JSON values

### DIFF
--- a/src/DataCore.Adapter.Core/Common/Variant.Json.cs
+++ b/src/DataCore.Adapter.Core/Common/Variant.Json.cs
@@ -1,0 +1,58 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace DataCore.Adapter.Common {
+    partial struct Variant {
+
+        /// <summary>
+        /// Serializes a value to a <see cref="JsonElement"/> and creates a new <see cref="Variant"/> 
+        /// containing the serialized value.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The type of value to serialize to JSON.
+        /// </typeparam>
+        /// <param name="value">
+        ///   The value to serialize to JSON.
+        /// </param>
+        /// <param name="options">
+        ///   The JSON serializer options to use when serializing the value.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="Variant"/> containing the serialized JSON value.
+        /// </returns>
+        /// <remarks>
+        ///   Serialization is performed using <see cref="JsonSerializer"/>. If <typeparamref name="T"/> 
+        ///   is <see cref="JsonElement"/> the <paramref name="value"/> will be passed through 
+        ///   as-is.
+        /// </remarks>
+#pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+        public static Variant FromJsonValue<T>(T value, JsonSerializerOptions? options = null) => new Variant(value is JsonElement json ? json : JsonSerializer.SerializeToElement(value, options));
+#pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+
+        /// <summary>
+        /// Serializes a value to a <see cref="JsonElement"/> and creates a new <see cref="Variant"/> 
+        /// containing the serialized value.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The type of value to serialize to JSON.
+        /// </typeparam>
+        /// <param name="value">
+        ///   The value to serialize to JSON.
+        /// </param>
+        /// <param name="jsonTypeInfo">
+        ///   The JSON type information to use when serializing the value.
+        /// </param>
+        /// <returns>
+        ///   A new <see cref="Variant"/> containing the serialized JSON value.
+        /// </returns>
+        /// <remarks>
+        ///   Serialization is performed using <see cref="JsonSerializer"/>. If <typeparamref name="T"/> 
+        ///   is <see cref="JsonElement"/> the <paramref name="value"/> will be passed through 
+        ///   as-is.
+        /// </remarks>
+        public static Variant FromJsonValue<T>(T value, JsonTypeInfo<T> jsonTypeInfo) => new Variant(value is JsonElement json ? json : JsonSerializer.SerializeToElement(value, jsonTypeInfo));
+
+    }
+
+}

--- a/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+static DataCore.Adapter.Common.Variant.FromJsonValue<T>(T value, System.Text.Json.JsonSerializerOptions? options = null) -> DataCore.Adapter.Common.Variant
+static DataCore.Adapter.Common.Variant.FromJsonValue<T>(T value, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo) -> DataCore.Adapter.Common.Variant


### PR DESCRIPTION
This PR adds static methods to `Variant` that serialize a value to a `JsonElement` before wrapping them in a `Variant`. This removes the need to manually serialize values to JSON prior to passing them to the `Variant` constructor.