### PR TITLE
Use MSTest metapackage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,13 +30,11 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
     <PackageVersion Include="Microsoft.FASTER.Core" Version="2.6.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="MiniValidation" Version="0.9.2" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageVersion Include="MSTest" Version="3.8.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="NSwag.AspNetCore" Version="13.20.0" />

--- a/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
+++ b/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="MSTest" />
     <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 

--- a/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
+++ b/test/DataCore.Adapter.Tests/DataCore.Adapter.Tests.csproj
@@ -11,9 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="MSTest.TestAdapter" />
-    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="MSTest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Modifies test-related projects to reference the MSTest metapackage instead of separate packages for the .NET test SDK and the MSTest framework and adapter