### PR TITLE
IAdapterFeature no longer inherits from IBackgroundTaskServiceProvider

### DIFF
--- a/examples/DataCore.Adapter.ExampleAdapter/ExampleAdapter.cs
+++ b/examples/DataCore.Adapter.ExampleAdapter/ExampleAdapter.cs
@@ -54,7 +54,7 @@ namespace DataCore.Adapter.Example {
             loggerFactory
         ) {
             // Register additional features!
-            _assetModelBrowser = new AssetModelManager(new InMemoryKeyValueStore(), BackgroundTaskService);
+            _assetModelBrowser = new AssetModelManager(new InMemoryKeyValueStore());
 
             AddFeatures(_assetModelBrowser);
             AddFeatures(new InMemoryEventMessageStore(new InMemoryEventMessageStoreOptions() { Capacity = 500 }, backgroundTaskService, LoggerFactory));

--- a/examples/ExampleHostedAdapter/MyAdapter.cs
+++ b/examples/ExampleHostedAdapter/MyAdapter.cs
@@ -82,9 +82,6 @@ namespace ExampleHostedAdapter {
                 // If we are not interested in persisting tag definitions, we can pass null
                 // here instead.
                 keyValueStore.CreateScopedStore(id),
-                // TagManager uses an IBackgroundTaskService instance to run background tasks
-                // that have a lifetime matching the adapter and/or the TagManager.
-                BackgroundTaskService,
                 // We need to tell TagManager about the types of bespoke properties that our tags
                 // will define.
                 new[] { s_tagCreatedAtPropertyDefinition },
@@ -121,8 +118,7 @@ namespace ExampleHostedAdapter {
             // The CustomFunctions class implements the ICustomFunctions feature, which allows us
             // to define vendor-specific custom functions that callers can invoke.
             _customFunctions = new CustomFunctions(
-                TypeDescriptor.Id, 
-                BackgroundTaskService, 
+                TypeDescriptor.Id,
                 jsonOptions.Value.SerializerOptions, 
                 LoggerFactory.CreateLogger<CustomFunctions>()
             );

--- a/src/DataCore.Adapter.Abstractions/AdapterFeatureWrapper.cs
+++ b/src/DataCore.Adapter.Abstractions/AdapterFeatureWrapper.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using IntelligentPlant.BackgroundTasks;
-
 namespace DataCore.Adapter {
 
     /// <summary>
@@ -22,9 +20,6 @@ namespace DataCore.Adapter {
         /// The feature that is wrapped by the <see cref="AdapterFeatureWrapper"/>.
         /// </summary>
         internal IAdapterFeature InnerFeature { get; }
-
-        /// <inheritdoc/>
-        IBackgroundTaskService IBackgroundTaskServiceProvider.BackgroundTaskService { get { return InnerFeature.BackgroundTaskService; } }
 
 
         /// <summary>

--- a/src/DataCore.Adapter.Abstractions/IAdapterFeature.cs
+++ b/src/DataCore.Adapter.Abstractions/IAdapterFeature.cs
@@ -4,6 +4,6 @@
     /// Interface that all standard adapter features must implement.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "Need to identify adapter feature types")]
-    public interface IAdapterFeature : IBackgroundTaskServiceProvider { }
+    public interface IAdapterFeature { }
 
 }

--- a/src/DataCore.Adapter/AssetModel/AssetModelManager.cs
+++ b/src/DataCore.Adapter/AssetModel/AssetModelManager.cs
@@ -70,9 +70,6 @@ namespace DataCore.Adapter.AssetModel {
         /// </summary>
         private readonly IComparer<string> _nodeNameComparer;
 
-        /// <inheritdoc/>
-        public IBackgroundTaskService BackgroundTaskService { get; }
-
 
         /// <summary>
         /// Creates a new <see cref="AssetModelManager"/> object.
@@ -80,9 +77,6 @@ namespace DataCore.Adapter.AssetModel {
         /// <param name="keyValueStore">
         ///   The <see cref="IKeyValueStore"/> where the nodes will be persisted to. Specify 
         ///   <see langword="null"/> if persistence is not required.
-        /// </param>
-        /// <param name="backgroundTaskService">
-        ///   The <see cref="IBackgroundTaskService"/> for the asset model manager.
         /// </param>
         /// <param name="onConfigurationChange">
         ///   An optional callback that will be invoked when a node is added, updated, or deleted.
@@ -92,11 +86,9 @@ namespace DataCore.Adapter.AssetModel {
         /// </param>
         public AssetModelManager(
             IKeyValueStore? keyValueStore = null,
-            IBackgroundTaskService? backgroundTaskService = null,
             Func<ConfigurationChange, CancellationToken, ValueTask>? onConfigurationChange = null,
             IComparer<string>? nodeNameComparer = null
         ) {
-            BackgroundTaskService = backgroundTaskService ?? IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default;
             _onConfigurationChange = onConfigurationChange;
             _nodeNameComparer = nodeNameComparer ?? StringComparer.OrdinalIgnoreCase;
             _keyValueStore = keyValueStore?.CreateScopedStore("asset-model-manager:");

--- a/src/DataCore.Adapter/Diagnostics/HealthCheckManager.cs
+++ b/src/DataCore.Adapter/Diagnostics/HealthCheckManager.cs
@@ -16,7 +16,7 @@ namespace DataCore.Adapter.Diagnostics {
     /// <summary>
     /// Default <see cref="IHealthCheck"/> implementation.
     /// </summary>
-    internal partial class HealthCheckManager<TAdapterOptions> : IBackgroundTaskServiceProvider, IHealthCheck, IDisposable where TAdapterOptions : AdapterOptions, new() {
+    internal partial class HealthCheckManager<TAdapterOptions> : IHealthCheck, IDisposable where TAdapterOptions : AdapterOptions, new() {
 
         /// <summary>
         /// Indicates if the object has been disposed.
@@ -64,8 +64,6 @@ namespace DataCore.Adapter.Diagnostics {
             FullMode = BoundedChannelFullMode.DropWrite
         });
 
-        /// <inheritdoc/>
-        public IBackgroundTaskService BackgroundTaskService => _adapter.BackgroundTaskService;
 
 
         /// <summary>

--- a/src/DataCore.Adapter/Extensions/CustomFunctions.cs
+++ b/src/DataCore.Adapter/Extensions/CustomFunctions.cs
@@ -5,8 +5,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-using IntelligentPlant.BackgroundTasks;
-
 using JsonSchema = Json.Schema;
 
 using Microsoft.Extensions.Logging;
@@ -45,9 +43,6 @@ namespace DataCore.Adapter.Extensions {
         /// </summary>
         private readonly Nito.AsyncEx.AsyncReaderWriterLock _functionsLock = new Nito.AsyncEx.AsyncReaderWriterLock();
 
-        /// <inheritdoc/>
-        public IBackgroundTaskService BackgroundTaskService { get; }
-
 
         /// <summary>
         /// Creates a new <see cref="CustomFunctions"/> instance.
@@ -56,9 +51,6 @@ namespace DataCore.Adapter.Extensions {
         ///   The base URI for custom functions registered with a relative URI. This would usually 
         ///   be the type URI for the adapter associated with the <see cref="CustomFunctions"/> 
         ///   instance.
-        /// </param>
-        /// <param name="backgroundTaskService">
-        ///   The <see cref="IBackgroundTaskService"/> to use.
         /// </param>
         /// <param name="jsonOptions">
         ///   The <see cref="JsonSerializerOptions"/> to use.
@@ -72,7 +64,7 @@ namespace DataCore.Adapter.Extensions {
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="baseUri"/> is not an absolute URI.
         /// </exception>
-        public CustomFunctions(Uri baseUri, IBackgroundTaskService? backgroundTaskService = null, JsonSerializerOptions? jsonOptions = null, ILogger<CustomFunctions>? logger = null) {
+        public CustomFunctions(Uri baseUri, JsonSerializerOptions? jsonOptions = null, ILogger<CustomFunctions>? logger = null) {
             if (baseUri == null) {
                 throw new ArgumentNullException(nameof(baseUri));
             }
@@ -80,7 +72,6 @@ namespace DataCore.Adapter.Extensions {
                 throw new ArgumentOutOfRangeException(nameof(baseUri), SharedResources.Error_AbsoluteUriRequired);
             }
             BaseUri = new Uri(baseUri.EnsurePathHasTrailingSlash(), "custom-functions/");
-            BackgroundTaskService = backgroundTaskService ?? IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default;
             _jsonOptions = jsonOptions;
             _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<CustomFunctions>.Instance;
         }

--- a/src/DataCore.Adapter/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter/PublicAPI.Shipped.txt
@@ -65,8 +65,6 @@ DataCore.Adapter.AdapterRequestExtensions
 DataCore.Adapter.AdapterTaskExtensions
 DataCore.Adapter.AssetModel.AssetModelManager
 DataCore.Adapter.AssetModel.AssetModelManager.AddOrUpdateNodeAsync(DataCore.Adapter.AssetModel.AssetModelNode! node, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
-DataCore.Adapter.AssetModel.AssetModelManager.AssetModelManager(DataCore.Adapter.Services.IKeyValueStore? keyValueStore = null, IntelligentPlant.BackgroundTasks.IBackgroundTaskService? backgroundTaskService = null, System.Func<DataCore.Adapter.Diagnostics.ConfigurationChange!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onConfigurationChange = null, System.Collections.Generic.IComparer<string!>? nodeNameComparer = null) -> void
-DataCore.Adapter.AssetModel.AssetModelManager.BackgroundTaskService.get -> IntelligentPlant.BackgroundTasks.IBackgroundTaskService!
 DataCore.Adapter.AssetModel.AssetModelManager.BrowseAssetModelNodes(DataCore.Adapter.IAdapterCallContext! context, DataCore.Adapter.AssetModel.BrowseAssetModelNodesRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<DataCore.Adapter.AssetModel.AssetModelNode!>!
 DataCore.Adapter.AssetModel.AssetModelManager.DeleteNodeAsync(string! nodeId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
 DataCore.Adapter.AssetModel.AssetModelManager.Dispose() -> void
@@ -228,7 +226,6 @@ DataCore.Adapter.Extensions.CustomFunctionHandler
 DataCore.Adapter.Extensions.CustomFunctionHandler<TRequest, TResponse>
 DataCore.Adapter.Extensions.CustomFunctionHandler<TResponse>
 DataCore.Adapter.Extensions.CustomFunctions
-DataCore.Adapter.Extensions.CustomFunctions.BackgroundTaskService.get -> IntelligentPlant.BackgroundTasks.IBackgroundTaskService!
 DataCore.Adapter.Extensions.CustomFunctions.BaseUri.get -> System.Uri!
 DataCore.Adapter.Extensions.CustomFunctions.CreateJsonSchema<T>() -> System.Text.Json.JsonElement
 DataCore.Adapter.Extensions.CustomFunctions.RegisterFunctionAsync(DataCore.Adapter.Extensions.CustomFunctionDescriptorExtended! descriptor, DataCore.Adapter.Extensions.CustomFunctionHandler! handler, DataCore.Adapter.Extensions.CustomFunctionAuthorizeHandler? authorizeHandler = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
@@ -469,7 +466,6 @@ DataCore.Adapter.Tags.TagDefinitionBuilder.WithUnits(string? units) -> DataCore.
 DataCore.Adapter.Tags.TagDefinitionExtensions
 DataCore.Adapter.Tags.TagManager
 DataCore.Adapter.Tags.TagManager.AddOrUpdateTagAsync(DataCore.Adapter.Tags.TagDefinition! tag, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
-DataCore.Adapter.Tags.TagManager.BackgroundTaskService.get -> IntelligentPlant.BackgroundTasks.IBackgroundTaskService!
 DataCore.Adapter.Tags.TagManager.Count.get -> int
 DataCore.Adapter.Tags.TagManager.DeleteTagAsync(string! tagNameOrId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
 DataCore.Adapter.Tags.TagManager.Dispose() -> void
@@ -732,7 +728,6 @@ DataCore.Adapter.Events.EventMessageBuilder.WithType(string? type) -> DataCore.A
 DataCore.Adapter.Events.EventMessagePush.EventMessagePush(DataCore.Adapter.Events.EventMessagePushOptions? options, IntelligentPlant.BackgroundTasks.IBackgroundTaskService? backgroundTaskService, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.Events.EventMessagePush!>? logger) -> void
 DataCore.Adapter.Events.EventMessagePushWithTopics.EventMessagePushWithTopics(DataCore.Adapter.Events.EventMessagePushWithTopicsOptions? options, IntelligentPlant.BackgroundTasks.IBackgroundTaskService? backgroundTaskService, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.Events.EventMessagePushWithTopics!>? logger) -> void
 DataCore.Adapter.Events.InMemoryEventMessageStore.InMemoryEventMessageStore(DataCore.Adapter.Events.InMemoryEventMessageStoreOptions? options = null, IntelligentPlant.BackgroundTasks.IBackgroundTaskService? backgroundTaskService = null, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null) -> void
-DataCore.Adapter.Extensions.CustomFunctions.CustomFunctions(System.Uri! baseUri, IntelligentPlant.BackgroundTasks.IBackgroundTaskService? backgroundTaskService = null, System.Text.Json.JsonSerializerOptions? jsonOptions = null, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.Extensions.CustomFunctions!>? logger = null) -> void
 DataCore.Adapter.RealTimeData.DefaultDataFunctions
 DataCore.Adapter.RealTimeData.DefaultDataFunctions.Constants
 DataCore.Adapter.RealTimeData.PollingSnapshotTagValuePush.PollingSnapshotTagValuePush(DataCore.Adapter.RealTimeData.IReadSnapshotTagValues! readSnapshotFeature, DataCore.Adapter.RealTimeData.PollingSnapshotTagValuePushOptions? options, IntelligentPlant.BackgroundTasks.IBackgroundTaskService? backgroundTaskService, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.RealTimeData.PollingSnapshotTagValuePush!>? logger) -> void
@@ -757,7 +752,6 @@ DataCore.Adapter.RealTimeData.Utilities.TagValueBucket.BeforeEndBoundary.get -> 
 DataCore.Adapter.RealTimeData.Utilities.TagValueBucket.BeforeStartBoundary.get -> DataCore.Adapter.RealTimeData.Utilities.PreBoundaryInfo!
 DataCore.Adapter.SubscriptionManager<TOptions, TTopic, TValue, TSubscription>.BeginLoggerScope() -> System.IDisposable?
 DataCore.Adapter.SubscriptionManager<TOptions, TTopic, TValue, TSubscription>.SubscriptionManager(TOptions? options, IntelligentPlant.BackgroundTasks.IBackgroundTaskService? backgroundTaskService, Microsoft.Extensions.Logging.ILogger? logger) -> void
-DataCore.Adapter.Tags.TagManager.TagManager(DataCore.Adapter.Services.IKeyValueStore? keyValueStore = null, IntelligentPlant.BackgroundTasks.IBackgroundTaskService? backgroundTaskService = null, System.Collections.Generic.IEnumerable<DataCore.Adapter.Common.AdapterProperty!>? tagPropertyDefinitions = null, System.Func<DataCore.Adapter.Diagnostics.ConfigurationChange!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onConfigurationChange = null, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.Tags.TagManager!>? logger = null) -> void
 static DataCore.Adapter.AdapterAccessorExtensions.GetAdapterDescriptorAsync(this DataCore.Adapter.IAdapterAccessor! adapterAccessor, DataCore.Adapter.IAdapterCallContext! context, string! adapterId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<DataCore.Adapter.Common.AdapterDescriptorExtended?>!
 static DataCore.Adapter.ChannelExtensions.ToEnumerable<T>(this System.Collections.Generic.IAsyncEnumerable<T>! enumerable, int maxItems, int expectedItems, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<T>!>!
 static DataCore.Adapter.RealTimeData.DefaultDataFunctions.Average.get -> DataCore.Adapter.RealTimeData.DataFunctionDescriptor!

--- a/src/DataCore.Adapter/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter/PublicAPI.Unshipped.txt
@@ -1,7 +1,10 @@
 ﻿#nullable enable
+DataCore.Adapter.AssetModel.AssetModelManager.AssetModelManager(DataCore.Adapter.Services.IKeyValueStore? keyValueStore = null, System.Func<DataCore.Adapter.Diagnostics.ConfigurationChange!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onConfigurationChange = null, System.Collections.Generic.IComparer<string!>? nodeNameComparer = null) -> void
+DataCore.Adapter.Extensions.CustomFunctions.CustomFunctions(System.Uri! baseUri, System.Text.Json.JsonSerializerOptions? jsonOptions = null, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.Extensions.CustomFunctions!>? logger = null) -> void
 DataCore.Adapter.FeatureBase
 DataCore.Adapter.FeatureBase.CheckFeatureHealthAsync(DataCore.Adapter.IAdapterCallContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<DataCore.Adapter.Diagnostics.HealthCheckResult>!
 DataCore.Adapter.FeatureBase.FeatureBase() -> void
+DataCore.Adapter.Tags.TagManager.TagManager(DataCore.Adapter.Services.IKeyValueStore? keyValueStore = null, System.Collections.Generic.IEnumerable<DataCore.Adapter.Common.AdapterProperty!>? tagPropertyDefinitions = null, System.Func<DataCore.Adapter.Diagnostics.ConfigurationChange!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onConfigurationChange = null, Microsoft.Extensions.Logging.ILogger<DataCore.Adapter.Tags.TagManager!>? logger = null) -> void
 override DataCore.Adapter.AssetModel.AssetModelManager.GetFeatureHealthCheckData(DataCore.Adapter.IAdapterCallContext! context) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string!>>!
 override DataCore.Adapter.Events.EventMessagePush.GetFeatureHealthCheckData(DataCore.Adapter.IAdapterCallContext! context) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string!>>!
 override DataCore.Adapter.Events.EventMessagePushWithTopics.GetFeatureHealthCheckData(DataCore.Adapter.IAdapterCallContext! context) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string!>>!

--- a/src/DataCore.Adapter/SubscriptionManager.cs
+++ b/src/DataCore.Adapter/SubscriptionManager.cs
@@ -28,14 +28,14 @@ namespace DataCore.Adapter {
     ///   The subscription type.
     /// </typeparam>
     public abstract partial class SubscriptionManager<TOptions, TTopic, TValue, TSubscription> 
-        : FeatureBase, IBackgroundTaskServiceProvider, IDisposable 
+        : FeatureBase, IDisposable 
         where TOptions : SubscriptionManagerOptions, new() 
         where TSubscription : SubscriptionChannel<TTopic, TValue> {
 
         /// <summary>
         /// The <see cref="IBackgroundTaskService"/> to use when running background tasks.
         /// </summary>
-        public IBackgroundTaskService BackgroundTaskService { get; }
+        protected IBackgroundTaskService BackgroundTaskService { get; }
 
         /// <summary>
         /// The ID of the subscription manager.

--- a/src/DataCore.Adapter/Tags/TagManager.cs
+++ b/src/DataCore.Adapter/Tags/TagManager.cs
@@ -76,9 +76,6 @@ namespace DataCore.Adapter.Tags {
         /// </summary>
         private readonly Func<ConfigurationChange, CancellationToken, ValueTask>? _onConfigurationChange;
 
-        /// <inheritdoc/>
-        public IBackgroundTaskService BackgroundTaskService { get; }
-
         /// <summary>
         /// The number of tag definitions held by the <see cref="TagManager"/>.
         /// </summary>
@@ -92,9 +89,6 @@ namespace DataCore.Adapter.Tags {
         ///   The <see cref="IKeyValueStore"/> where the tag definitions will be persisted to. 
         ///   Specify <see langword="null"/> if persistence of tag definitions is not required.
         /// </param>
-        /// <param name="backgroundTaskService">
-        ///   The <see cref="IBackgroundTaskService"/> for the tag manager.
-        /// </param>
         /// <param name="tagPropertyDefinitions">
         ///   The definitions for the properties that can be defined on tags managed by the 
         ///   <see cref="TagManager"/>.
@@ -106,14 +100,12 @@ namespace DataCore.Adapter.Tags {
         ///   The logger for the tag manager.
         /// </param>
         public TagManager(
-            IKeyValueStore? keyValueStore = null, 
-            IBackgroundTaskService? backgroundTaskService = null, 
+            IKeyValueStore? keyValueStore = null,
             IEnumerable<AdapterProperty>? tagPropertyDefinitions = null,
             Func<ConfigurationChange, CancellationToken, ValueTask>? onConfigurationChange = null,
             ILogger<TagManager>? logger = null
         ) {
             _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<TagManager>.Instance;
-            BackgroundTaskService = backgroundTaskService ?? IntelligentPlant.BackgroundTasks.BackgroundTaskService.Default;
             _onConfigurationChange = onConfigurationChange;
             _keyValueStore = keyValueStore?.CreateScopedStore("tag-manager:");
 

--- a/test/DataCore.Adapter.Tests/AdapterCallContextTests.cs
+++ b/test/DataCore.Adapter.Tests/AdapterCallContextTests.cs
@@ -87,9 +87,6 @@ namespace DataCore.Adapter.Tests {
 
         private class TestFeature : ITestFeature {
 
-            IBackgroundTaskService IBackgroundTaskServiceProvider.BackgroundTaskService { get; }
-
-
             public Task<bool> IsValid(IAdapterCallContext context, TestFeatureRequest request, CancellationToken cancellationToken) {
                 if (request == null) {
                     return Task.FromResult(false);

--- a/test/DataCore.Adapter.Tests/ExampleAdapter.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapter.cs
@@ -36,7 +36,7 @@ namespace DataCore.Adapter.Tests {
             _eventSubscriptionManager = new EventSubscriptionManager();
             _eventTopicSubscriptionManager = new EventTopicSubscriptionManager();
             _assetModelManager = new AssetModelManager(new InMemoryKeyValueStore());
-            _customFunctions = new CustomFunctions(TypeDescriptor.Id, BackgroundTaskService);
+            _customFunctions = new CustomFunctions(TypeDescriptor.Id);
 
             AddFeatures(this);
             AddFeatures(_snapshotSubscriptionManager);


### PR DESCRIPTION
## ⚠️ Breaking Changes

This PR modifies `IAdapterFeature` so that it no longer inherits from `IBackgroundTaskServiceProvider`. The following types have also have related breaking changes:

* `AdapterFeatureWrapper` no longer implements `IBackgroundTaskServiceProvider`
* `AssetModelManager` no longer implements `IBackgroundTaskServiceProvider` and no longer accepts an `IBackgroundTaskService` constructor parameter.
* `HealthCheckManager` no longer implements `IBackgroundTaskServiceProvider`.
* `CustomFunctions` no longer implements `IBackgroundTaskServiceProvider` and no longer accepts an `IBackgroundTaskService` constructor parameter.
* `SubscriptionManager` no longer implements `IBackgroundTaskServiceProvider` but its constructor is unchanged. Its `BackgroundTaskService` property has changed from `public` to `protected`.
* `TagManager` no longer implements `IBackgroundTaskServiceProvider` and no longer accepts an `IBackgroundTaskService` constructor parameter.