### PR TITLE
Re-add MSTest.TestFramework reference to tests helpers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
     <PackageVersion Include="MiniValidation" Version="0.9.2" />
     <PackageVersion Include="MSTest" Version="3.8.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.8.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="NSwag.AspNetCore" Version="13.20.0" />

--- a/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
+++ b/src/DataCore.Adapter.Tests.Helpers/DataCore.Adapter.Tests.Helpers.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" />
+    <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 


### PR DESCRIPTION
Replaces the MSTest package reference added to DataCore.Adapter.Tests.Helpers in #427 with MSTest.TestFramework.

Referencing the former seems to set the IsPackable build property to false, meaning that the package for this project was not being correctly built.