### PR TITLE
Simplify registration of adapter descriptor features by URI

### DIFF
--- a/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+DataCore.Adapter.Common.AdapterDescriptorBuilder.WithFeature(string! feature) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!
+DataCore.Adapter.Common.AdapterDescriptorBuilder.WithFeature(System.Uri! feature) -> DataCore.Adapter.Common.AdapterDescriptorBuilder!


### PR DESCRIPTION
Adds new `WithFeature` overloads to `AdapterDescriptorBuilder` to simplify addition of feature URIs.