### PR TITLE
Refactor adapter string cache to use Jaahas.StringCache

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="IntelligentPlant.BackgroundTasks.DependencyInjection" Version="12.0.1" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="3.0.1" />
     <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="3.0.0" />
+    <PackageVersion Include="Jaahas.StringCache" Version="1.0.0-pre.3" />
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
     <PackageVersion Include="JsonSchema.Net.Generation" Version="5.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />

--- a/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
+++ b/src/DataCore.Adapter.Core/DataCore.Adapter.Core.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Jaahas.StringCache" />
     <PackageReference Include="Microsoft.Bcl.HashCode" />
     <PackageReference Include="Semver" />
     <PackageReference Include="System.ComponentModel.Annotations" />

--- a/src/DataCore.Adapter.Core/PublicAPI.Shipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Shipped.txt
@@ -1053,7 +1053,6 @@ static DataCore.Adapter.StringCache.Count.get -> int
 static DataCore.Adapter.StringCache.Get(string? str) -> string?
 static DataCore.Adapter.StringCache.Intern(string? str) -> string?
 static DataCore.Adapter.StringCache.NativeInternEnabled.get -> bool
-static DataCore.Adapter.StringCache.Size.get -> long
 static System.DCAStringExtensions.GetFromStringCache(this string! str) -> string!
 static System.DCAStringExtensions.InternToStringCache(this string! str) -> string!
 System.DCAStringExtensions

--- a/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
+++ b/src/DataCore.Adapter.Core/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 ﻿#nullable enable
 static DataCore.Adapter.Common.Variant.FromJsonValue<T>(T value, System.Text.Json.JsonSerializerOptions? options = null) -> DataCore.Adapter.Common.Variant
 static DataCore.Adapter.Common.Variant.FromJsonValue<T>(T value, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo) -> DataCore.Adapter.Common.Variant
+static DataCore.Adapter.StringCache.CalculateSize() -> long


### PR DESCRIPTION
## ⚠️ Breaking Changes

Adapter string cache now uses Jaahas.StringCache under the hood. The size of the cache is no longer available as a property but can be computed on demand.